### PR TITLE
BackendConnectionManager: connection pools per CPU

### DIFF
--- a/src/backend/BackendConnectionInterface.h
+++ b/src/backend/BackendConnectionInterface.h
@@ -20,8 +20,9 @@
 #include "Namespace.h"
 #include "ObjectInfo.h"
 
-#include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/intrusive/slist.hpp>
 #include <boost/optional.hpp>
 
 #include <youtils/Assert.h>
@@ -42,6 +43,7 @@ using byte = unsigned char;
 using buffer = byte*;
 
 class BackendConnectionInterface
+    : public boost::intrusive::slist_base_hook<>
 {
 protected:
     boost::posix_time::time_duration timeout_;

--- a/src/backend/BackendConnectionManager.h
+++ b/src/backend/BackendConnectionManager.h
@@ -20,13 +20,12 @@
 #include "Namespace.h"
 
 #include <boost/chrono.hpp>
-#include <boost/ptr_container/ptr_list.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
 
 #include <youtils/BooleanEnum.h>
 #include <youtils/ConfigurationReport.h>
 #include <youtils/IOException.h>
+#include <youtils/SpinLock.h>
 #include <youtils/StrongTypedString.h>
 #include <youtils/VolumeDriverComponent.h>
 
@@ -88,6 +87,15 @@ class BackendConnectionManager
     : public youtils::VolumeDriverComponent
     , public std::enable_shared_from_this<BackendConnectionManager>
 {
+private:
+    // Uses boost::intrusive to avoid (de)allocations when modifying the container.
+    // (which has to happen under the spinlock).
+    struct ConnectionPool
+    {
+        mutable fungi::SpinLock lock_;
+        boost::intrusive::slist<BackendConnectionInterface> connections_;
+    };
+
 public:
     // enfore usage via BackendConnectionManagerPtr
     // rationale: BackendConnPtrs hold a reference (via BackendConnectionManagerPtr),
@@ -108,31 +116,31 @@ public:
     BackendConnectionManager&
     operator=(const BackendConnectionManager&) = delete;
 
-#define LOCK_CONNS()                            \
-    ::boost::lock_guard<lock_type> g__(lock_);
-
     inline BackendConnectionInterfacePtr
     getConnection(ForceNewConnection force_new = ForceNewConnection::F)
     {
-        LOCK_CONNS();
-
+        ConnectionPool& pool = get_connection_pool_();
         BackendConnectionDeleter d(shared_from_this());
+        BackendConnectionInterfacePtr conn(nullptr, d);
 
-        if (force_new == ForceNewConnection::T or connections_.empty())
         {
-            BackendConnectionInterfacePtr conn(newConnection_(),
-                                std::move(d));
-            LOG_TRACE("handing out newly created connection handle " << conn.get());
-            return conn;
+            boost::lock_guard<decltype(pool.lock_)> g(pool.lock_);
+            if (force_new != ForceNewConnection::T and not pool.connections_.empty())
+            {
+                conn = BackendConnectionInterfacePtr(&pool.connections_.front(),
+                                                     d);
+                pool.connections_.pop_front();
+            }
         }
-        else
+
+        if (not conn)
         {
-            BackendConnectionInterfacePtr conn(connections_.pop_front().release(),
-                                std::move(d));
-            conn->timeout(default_timeout_);
-            LOG_TRACE("handing out existing connection handle " << conn.get());
-            return conn;
+            conn = BackendConnectionInterfacePtr(newConnection_(),
+                                                 d);
         }
+
+        conn->timeout(default_timeout_);
+        return conn;
     }
 
     BackendInterfacePtr
@@ -213,17 +221,15 @@ public:
 private:
     DECLARE_LOGGER("BackendConnectionManager");
 
+    // one per (logical) CPU.
+    std::vector<ConnectionPool> connection_pools_;
+
     DECLARE_PARAMETER(backend_connection_pool_capacity);
     DECLARE_PARAMETER(backend_interface_retries_on_error);
     DECLARE_PARAMETER(backend_interface_retry_interval_secs);
     DECLARE_PARAMETER(backend_interface_retry_backoff_multiplier);
 
     std::unique_ptr<BackendConfig> config_;
-
-    typedef boost::mutex lock_type;
-    mutable lock_type lock_;
-
-    boost::ptr_list<BackendConnectionInterface> connections_;
 
     // Create through
     // static BackendConnectionManagerPtr
@@ -238,9 +244,38 @@ private:
     boost::posix_time::time_duration default_timeout_;
 
     void
-    releaseConnection(BackendConnectionInterface* conn);
+    releaseConnection(BackendConnectionInterface* conn)
+    {
+        ASSERT(conn != nullptr);
+        if (conn->healthy())
+        {
+            ConnectionPool& pool = get_connection_pool_();
+            boost::lock_guard<decltype(pool.lock_)> g(pool.lock_);
+            if (pool.connections_.size() < backend_connection_pool_capacity.value() / connection_pools_.size())
+            {
+                pool.connections_.push_front(*conn);
+                return;
+            }
+        }
 
-#undef LOCK_CONNS
+        delete conn;
+    }
+
+    ConnectionPool&
+    get_connection_pool_()
+    {
+        int cpu = sched_getcpu();
+        if (cpu < 0)
+        {
+            cpu = 0;
+        }
+
+        ASSERT(not connection_pools_.empty());
+        const auto n = static_cast<unsigned>(cpu);
+        ASSERT(n < connection_pools_.size());
+
+        return connection_pools_[n % connection_pools_.size()];
+    }
 
     friend class BackendConnectionDeleter;
     friend class toolcut::BackendToolCut;

--- a/src/backend/test/ConnectionManagerTest.cpp
+++ b/src/backend/test/ConnectionManagerTest.cpp
@@ -14,6 +14,12 @@
 
 #include "BackendTestBase.h"
 
+#include <future>
+
+#include <boost/thread/thread.hpp>
+
+#include <youtils/UpdateReport.h>
+
 namespace backendtest
 {
 
@@ -30,63 +36,87 @@ public:
     ConnectionManagerTest()
         : be::BackendTestBase("ConnectionManagerTest")
     {}
+
+    void
+    pin_to_cpu_0()
+    {
+        cpu_set_t cpu_set;
+
+        CPU_ZERO(&cpu_set);
+        CPU_SET(0, &cpu_set);
+
+        ASSERT_EQ(0, pthread_setaffinity_np(pthread_self(),
+                                            sizeof(cpu_set),
+                                            &cpu_set));
+    }
 };
 
 TEST_F(ConnectionManagerTest, limited_pool)
 {
-    const size_t cap = cm_->capacity();
-    ASSERT_LT(0U, cap);
+    std::async(std::launch::async,
+               [&]
+               {
+                   pin_to_cpu_0();
 
-    ASSERT_EQ(0U,
-              cm_->size());
+                   const size_t cap = cm_->capacity();
+                   ASSERT_LT(0U, cap);
 
-    for (size_t i = 0; i < cap; ++i)
-    {
-        cm_->getConnection(ForceNewConnection::T);
-    }
+                   ASSERT_EQ(0U,
+                             cm_->size());
 
-    ASSERT_EQ(cap,
-              cm_->size());
+                   for (size_t i = 0; i < cap; ++i)
+                   {
+                                   cm_->getConnection(ForceNewConnection::T);
+                   }
 
-    cm_->getConnection(ForceNewConnection::T);
+                   ASSERT_EQ(cap / boost::thread::hardware_concurrency(),
+                             cm_->size());
 
-    ASSERT_EQ(cap,
-              cm_->size());
+                   cm_->getConnection(ForceNewConnection::T);
+
+                   ASSERT_EQ(cap / boost::thread::hardware_concurrency(),
+                             cm_->size());
+               }).wait();
 }
 
 // OVS-2204: for some reason the count of open fds goes up after an error, but
 //  valgrind does not report a leak. Try to figure our what's going on here.
 TEST_F(ConnectionManagerTest, limited_pool_on_errors)
 {
-    const std::string oname("some-object");
-    const fs::path opath(path_ / oname);
+    std::async(std::launch::async,
+               [&]
+               {
+                   pin_to_cpu_0();
+                   const std::string oname("some-object");
+                   const fs::path opath(path_ / oname);
 
-    const yt::CheckSum cs(createTestFile(opath,
-                                         4096,
-                                         "some pattern"));
+                   const yt::CheckSum cs(createTestFile(opath,
+                                                        4096,
+                                                        "some pattern"));
 
-    yt::CheckSum wrong_cs(1);
+                   yt::CheckSum wrong_cs(1);
 
-    ASSERT_NE(wrong_cs,
-              cs);
+                   ASSERT_NE(wrong_cs,
+                             cs);
 
-    std::unique_ptr<be::BackendTestSetup::WithRandomNamespace>
-        nspace(make_random_namespace());
+                   std::unique_ptr<be::BackendTestSetup::WithRandomNamespace>
+                       nspace(make_random_namespace());
 
-    be::BackendInterfacePtr bi(bi_(nspace->ns()));
-    const size_t count = 2 * cm_->capacity();
+                   be::BackendInterfacePtr bi(bi_(nspace->ns()));
+                   const size_t count = 2 * cm_->capacity();
 
-    for (size_t i = 0; i < count; ++i)
-    {
-        ASSERT_THROW(bi->write(opath,
-                               oname,
-                               OverwriteObject::F,
-                               &wrong_cs),
-                     be::BackendInputException);
-    }
+                   for (size_t i = 0; i < count; ++i)
+                   {
+                       ASSERT_THROW(bi->write(opath,
+                                              oname,
+                                              OverwriteObject::F,
+                                              &wrong_cs),
+                                    be::BackendInputException);
+                   }
 
-    ASSERT_EQ(cm_->capacity(),
-              cm_->size());
+                   ASSERT_EQ(cm_->capacity() / boost::thread::hardware_concurrency(),
+                             cm_->size());
+               }).wait();
 }
 
 TEST_F(ConnectionManagerTest, no_pool)
@@ -127,7 +157,6 @@ TEST_F(ConnectionManagerTest, no_pool)
 
     ASSERT_EQ(0U,
               cm_->size());
-
 }
 
 }


### PR DESCRIPTION
Get rid of the global mutex in the BackendConnectionManager protecting a global, shared pool of BackendConnectionInterfaces in favour of a pool per (logical) CPU.