### PR TITLE
Feature/mds improvements

### DIFF
--- a/src/volumedriver/BackendRestartAccumulator.cpp
+++ b/src/volumedriver/BackendRestartAccumulator.cpp
@@ -52,26 +52,55 @@ BackendRestartAccumulator::operator()(const SnapshotPersistor& sp,
 
     OrderedTLogIds tlogs;
 
+    auto walk_tlogs([&](const OrderedTLogIds& tlog_ids)
+                    {
+                        VERIFY(not end_seen_);
+
+                        for (const auto& tlog_id : tlog_ids)
+                        {
+                            if (start_cork_ != boost::none and
+                                TLogId(*start_cork_) == tlog_id)
+                            {
+                                VERIFY(not start_seen_);
+                                start_seen_ = true;
+                            }
+                            else if (start_seen_)
+                            {
+                                tlogs.push_back(tlog_id);
+                            }
+
+                            if (end_cork_ != boost::none and
+                                TLogId(*end_cork_) == tlog_id)
+                            {
+                                end_seen_ = true;
+                                break;
+                            }
+                        }
+                    });
+
     if (not end_seen_)
     {
         for (const auto& snap : sp.getSnapshots())
         {
-            if (start_cork_ != boost::none and
-                snap.getCork() == *start_cork_)
+            walk_tlogs(snap.getOrderedTLogIds());
+
+            // check the cork IDs of empty snapshots:
+            if (not start_seen_ and
+                start_cork_ != boost::none and
+                *start_cork_ == snap.getCork())
             {
-                VERIFY(not start_seen_);
                 start_seen_ = true;
             }
 
-            if (start_seen_)
-            {
-                snap.getOrderedTLogIds(tlogs);
-            }
-
-            if (end_cork_ != boost::none and
-                snap.getCork() == *end_cork_)
+            if (not end_seen_ and
+                end_cork_ != boost::none and
+                *end_cork_ == snap.getCork())
             {
                 end_seen_ = true;
+            }
+
+            if (end_seen_)
+            {
                 break;
             }
         }
@@ -81,27 +110,7 @@ BackendRestartAccumulator::operator()(const SnapshotPersistor& sp,
     {
         if (not end_seen_)
         {
-            for (const auto& tlog : sp.getCurrentTLogsWrittenToBackend())
-            {
-                if (start_cork_ != boost::none and
-                    tlog == TLogId(*start_cork_))
-                {
-                    VERIFY(not start_seen_);
-                    start_seen_ = true;
-                }
-
-                if (start_seen_)
-                {
-                    tlogs.push_back(tlog);
-                }
-
-                if (end_cork_ != boost::none and
-                    tlog == TLogId(*end_cork_))
-                {
-                    end_seen_ = true;
-                    break;
-                }
-            }
+            walk_tlogs(sp.getCurrentTLogsWrittenToBackend());
         }
     }
     else

--- a/src/volumedriver/MetaDataStoreBuilder.cpp
+++ b/src/volumedriver/MetaDataStoreBuilder.cpp
@@ -56,7 +56,8 @@ MetaDataStoreBuilder::operator()(const boost::optional<yt::UUID>& end_cork,
         return update_metadata_store_(start_cork,
                                       end_cork,
                                       check_scrub_id,
-                                      dry_run);
+                                      dry_run,
+                                      false);
     }
     catch (CorkNotFoundException& e)
     {
@@ -69,19 +70,21 @@ MetaDataStoreBuilder::operator()(const boost::optional<yt::UUID>& end_cork,
     return update_metadata_store_(boost::none,
                                   end_cork,
                                   check_scrub_id,
-                                  dry_run);
+                                  dry_run,
+                                  true);
 }
 
 MetaDataStoreBuilder::Result
 MetaDataStoreBuilder::update_metadata_store_(const boost::optional<yt::UUID>& from,
                                              const boost::optional<yt::UUID>& to,
                                              CheckScrubId check_scrub_id,
-                                             DryRun dry_run)
+                                             DryRun dry_run,
+                                             bool full_rebuild)
 {
     LOG_INFO(bi_->getNS() <<
              ": bringing MetaDataStore in sync with backend, requested interval (" <<
              from << ", " << to << "], check scrub ID: " << check_scrub_id <<
-             ", dry run:" << dry_run);
+             ", dry run:" << dry_run << ", full rebuild: " << full_rebuild);
 
     // This has a lot in common with the mdstore rebuilding code in
     // volumedriver::VolumeFactory - see if this can be unified.
@@ -95,6 +98,8 @@ MetaDataStoreBuilder::update_metadata_store_(const boost::optional<yt::UUID>& fr
     const MaybeScrubId md_scrub_id(mdstore_.scrub_id());
 
     Result res;
+    res.full_rebuild = full_rebuild;
+
     boost::optional<yt::UUID> start_cork(from);
 
     if (check_scrub_id == CheckScrubId::T)

--- a/src/volumedriver/MetaDataStoreBuilder.h
+++ b/src/volumedriver/MetaDataStoreBuilder.h
@@ -47,6 +47,7 @@ public:
     {
         NSIDMap nsid_map;
         size_t num_tlogs = 0;
+        bool full_rebuild = false;
     };
 
     // DryRun: don't apply to mdstore
@@ -66,7 +67,8 @@ private:
     update_metadata_store_(const boost::optional<youtils::UUID>& from,
                            const boost::optional<youtils::UUID>& to,
                            CheckScrubId check_scrub_id,
-                           DryRun dry_run);
+                           DryRun dry_run,
+                           bool full_rebuild);
 };
 
 }

--- a/src/volumedriver/SnapshotManagement.h
+++ b/src/volumedriver/SnapshotManagement.h
@@ -259,7 +259,8 @@ public:
     void
     scheduleWriteSnapshotToBackend();
 
-    void trimToDss();
+    void
+    trimToBackend();
 
     ClusterLocation
     getLastSCOInBackend();

--- a/src/volumedriver/SnapshotPersistor.cpp
+++ b/src/volumedriver/SnapshotPersistor.cpp
@@ -656,7 +656,7 @@ SnapshotPersistor::trimToBackend()
         LOG_TRACE(i->getName() << ": in backend: " << i->inBackend());
         if (not i->inBackend())
         {
-            current = i->tlogsOnDss();
+            current = i->tlogsOnBackend();
             snapshots.erase(i, snapshots.end());
             ready = true;
             break;
@@ -665,7 +665,7 @@ SnapshotPersistor::trimToBackend()
 
     if (not ready)
     {
-        current = current.tlogsOnDss();
+        current = current.tlogsOnBackend();
         ready = true;
     }
 

--- a/src/volumedriver/SnapshotPersistor.cpp
+++ b/src/volumedriver/SnapshotPersistor.cpp
@@ -353,7 +353,7 @@ SnapshotPersistor::getTLogsInSnapshot(const SnapshotNum num,
 void
 SnapshotPersistor::getCurrentTLogs(OrderedTLogIds& outTLogs) const
 {
-    current.getTLogIds(outTLogs);
+    current.getOrderedTLogIds(outTLogs);
 }
 
 TLogId
@@ -458,7 +458,7 @@ SnapshotPersistor::getTLogsAfterSnapshot(SnapshotNum num,
 {
     snapshots.getTLogsAfterSnapshot(num,
                                     out);
-    current.getTLogIds(out);
+    current.getOrderedTLogIds(out);
 }
 
 void

--- a/src/volumedriver/TLog.cpp
+++ b/src/volumedriver/TLog.cpp
@@ -227,15 +227,6 @@ TLogs::writtenToBackend() const
     return true;
 }
 
-void
-TLogs::getTLogIds(OrderedTLogIds& out) const
-{
-    for(const_iterator it = begin(); it != end(); ++it)
-    {
-        out.push_back(it->id());
-    }
-}
-
 boost::optional<TLogId>
 TLogs::checkAndGetAllTLogsWrittenToBackendAndRemoveLaterOnes(OrderedTLogIds& vec)
 {

--- a/src/volumedriver/TLog.cpp
+++ b/src/volumedriver/TLog.cpp
@@ -58,7 +58,7 @@ TLog::writtenToBackend() const
 }
 
 TLogs
-TLogs::tlogsOnDss()
+TLogs::tlogsOnBackend()
 {
     TLogs ret;
 

--- a/src/volumedriver/TLog.h
+++ b/src/volumedriver/TLog.h
@@ -175,7 +175,7 @@ public:
     writtenToBackend() const;
 
     TLogs
-    tlogsOnDss();
+    tlogsOnBackend();
 
     boost::optional<TLogId>
     checkAndGetAllTLogsWrittenToBackendAndRemoveLaterOnes(OrderedTLogIds&);

--- a/src/volumedriver/TLog.h
+++ b/src/volumedriver/TLog.h
@@ -150,6 +150,14 @@ public:
     void
     getOrderedTLogIds(OrderedTLogIds& out) const;
 
+    OrderedTLogIds
+    getOrderedTLogIds() const
+    {
+        OrderedTLogIds tlog_ids;
+        getOrderedTLogIds(tlog_ids);
+        return tlog_ids;
+    }
+
     void
     getReverseOrderedTLogIds(OrderedTLogIds& out) const;
 

--- a/src/volumedriver/TLog.h
+++ b/src/volumedriver/TLog.h
@@ -166,10 +166,8 @@ public:
     bool
     writtenToBackend() const;
 
-    TLogs tlogsOnDss();
-
-    void
-    getTLogIds(OrderedTLogIds& outTLogs) const;
+    TLogs
+    tlogsOnDss();
 
     boost::optional<TLogId>
     checkAndGetAllTLogsWrittenToBackendAndRemoveLaterOnes(OrderedTLogIds&);

--- a/src/volumedriver/Types.h
+++ b/src/volumedriver/Types.h
@@ -95,6 +95,7 @@ BOOLEAN_ENUM(IgnoreFOCIfUnreachable);
 BOOLEAN_ENUM(FallBackToBackendRestart);
 BOOLEAN_ENUM(CreateNamespace);
 BOOLEAN_ENUM(DryRun);
+BOOLEAN_ENUM(Reset);
 
 // AR: these have to go
 #if 1

--- a/src/volumedriver/metadata-server/ClientNG.cpp
+++ b/src/volumedriver/metadata-server/ClientNG.cpp
@@ -252,6 +252,31 @@ struct TableHandle
         return nspace_;
     }
 
+    virtual TableCounters
+    get_counters(vd::Reset reset) override final
+    {
+        auto b([&](mdsproto::Methods::GetTableCountersParams::Builder& builder)
+               {
+                   // LOG_TRACE(nspace_ << ": building CatchUp request");
+                   builder.setNspace(nspace_);
+                   builder.setReset(reset == vd::Reset::T);
+               });
+
+        TableCounters counters;
+
+        auto r([&](mdsproto::Methods::GetTableCountersResults::Reader& reader)
+               {
+                   const auto c = reader.getCounters();
+                   counters.total_tlogs_read = c.getTotalTLogsRead();
+                   counters.incremental_updates = c.getIncrementalUpdates();
+                   counters.full_rebuilds = c.getFullRebuilds();
+               });
+
+        client_->interact_<mdsproto::RequestHeader::Type::GetTableCounters>(std::move(b),
+                                                                            std::move(r));
+        return counters;
+    }
+
     const std::string nspace_;
     ClientNG::Ptr client_;
 };

--- a/src/volumedriver/metadata-server/Interface.cpp
+++ b/src/volumedriver/metadata-server/Interface.cpp
@@ -13,3 +13,21 @@
 // limitations under the License.
 
 #include "Interface.h"
+
+#include <iostream>
+
+namespace metadata_server
+{
+
+std::ostream&
+operator<<(std::ostream& os,
+           const TableCounters& c)
+{
+    return os <<
+        "TableCounters{total_tlogs_read=" << c.total_tlogs_read <<
+        ",incremental_updates=" << c.incremental_updates <<
+        ",full_rebuilds=" << c.full_rebuilds <<
+        "}";
+}
+
+}

--- a/src/volumedriver/metadata-server/Interface.h
+++ b/src/volumedriver/metadata-server/Interface.h
@@ -150,6 +150,32 @@ struct Record
     const Value val;
 };
 
+struct TableCounters
+{
+    uint64_t total_tlogs_read = 0;
+    uint64_t incremental_updates = 0;
+    uint64_t full_rebuilds = 0;
+
+    bool
+    operator==(const TableCounters& other) const
+    {
+        return
+            total_tlogs_read == other.total_tlogs_read and
+            incremental_updates == other.incremental_updates and
+            full_rebuilds == other.full_rebuilds;
+    }
+
+    bool
+    operator!=(const TableCounters& other) const
+    {
+        return not operator==(other);
+    }
+};
+
+std::ostream&
+operator<<(std::ostream&,
+           const TableCounters&);
+
 enum class Role
 {
     Master,
@@ -213,7 +239,10 @@ public:
     // XXX: return an actual list of TLogs (actually pairs of clone ID or namespace and
     // tlog names)?
     virtual size_t
-    catch_up(volumedriver::DryRun dry_run) = 0;
+    catch_up(volumedriver::DryRun) = 0;
+
+    virtual TableCounters
+    get_counters(volumedriver::Reset) = 0;
 
 private:
     Role role_ = Role::Slave;

--- a/src/volumedriver/metadata-server/Protocol.capnp
+++ b/src/volumedriver/metadata-server/Protocol.capnp
@@ -21,9 +21,17 @@ struct Error
 }
 
 # Arrr matey, ye olde scumbag Cap'n P. insists on camelCase.
-#
+
+struct TableCounters
+{
+    totalTLogsRead @0 : UInt64;
+    incrementalUpdates @1 : UInt64;
+    fullRebuilds @2 : UInt64;
+}
+
 # We might want to avoid sending the `nspace' string but introduce another layer of
 # indirection to avoid string comparisons and lookups - profile!
+
 interface Methods
 {
     drop @0 (nspace : Text) -> ();
@@ -52,4 +60,6 @@ interface Methods
 			     logs : List(Text)) -> ();
 
     catchUp @ 10 (nspace : Text, dryRun : Bool) -> (numTLogs : UInt32);
+
+    getTableCounters @ 11 (nspace : Text, reset : Bool) -> (counters : TableCounters);
 }

--- a/src/volumedriver/metadata-server/Protocol.cpp
+++ b/src/volumedriver/metadata-server/Protocol.cpp
@@ -50,6 +50,7 @@ req_hdr_reminder(RequestHeader::Type t)
         C(Ping);
         C(ApplyRelocationLogs);
         C(CatchUp);
+        C(GetTableCounters);
         // If the compiler yells at you that you've forgotten dealing with an enum
         // value chances are that it's also missing from the translations map below.
         // If so add it RIGHT NOW.
@@ -104,6 +105,7 @@ operator<<(std::ostream& os,
         P(Ping),
         P(ApplyRelocationLogs),
         P(CatchUp),
+        P(GetTableCounters),
     };
 
 #undef P

--- a/src/volumedriver/metadata-server/Protocol.h
+++ b/src/volumedriver/metadata-server/Protocol.h
@@ -68,6 +68,7 @@ struct RequestHeader
         Ping = 8,
         ApplyRelocationLogs = 9,
         CatchUp = 10,
+        GetTableCounters = 11,
     };
 
     RequestHeader() = default;
@@ -187,6 +188,7 @@ MAKE_REQUEST(Open);
 MAKE_REQUEST(Ping);
 MAKE_REQUEST(ApplyRelocationLogs);
 MAKE_REQUEST(CatchUp);
+MAKE_REQUEST(GetTableCounters);
 
 #undef MAKE_REQUEST
 

--- a/src/volumedriver/metadata-server/PythonClient.cpp
+++ b/src/volumedriver/metadata-server/PythonClient.cpp
@@ -164,4 +164,13 @@ PythonClient::catch_up(const std::string& nspace,
                                         vd::DryRun::F);
 }
 
+TableCounters
+PythonClient::get_table_counters(const std::string& nspace,
+                                 bool reset) const
+{
+    return get_table_(nspace)->get_counters(reset ?
+                                            vd::Reset::T :
+                                            vd::Reset::F);
+}
+
 }

--- a/src/volumedriver/metadata-server/PythonClient.h
+++ b/src/volumedriver/metadata-server/PythonClient.h
@@ -69,6 +69,10 @@ public:
     catch_up(const std::string& nspace,
              bool dry_run) const;
 
+    TableCounters
+    get_table_counters(const std::string& nspace,
+                       bool reset) const;
+
 private:
     DECLARE_LOGGER("MDSPythonClient");
 

--- a/src/volumedriver/metadata-server/RocksTable.cpp
+++ b/src/volumedriver/metadata-server/RocksTable.cpp
@@ -195,10 +195,18 @@ RocksTable::clear()
     column_family_.reset(h);
 }
 
+
+// XXX: these two could suggest that RocksTable implementing TableInterface might not be a good idea after all?
 size_t
 RocksTable::catch_up(vd::DryRun)
 {
     VERIFY(0 == "RocksTable::catch_up shouldn't be invoked");
+}
+
+TableCounters
+RocksTable::get_counters(vd::Reset)
+{
+    VERIFY(0 == "RocksTable::get_table_counters shouldn't be invoked");
 }
 
 }

--- a/src/volumedriver/metadata-server/RocksTable.h
+++ b/src/volumedriver/metadata-server/RocksTable.h
@@ -37,9 +37,9 @@ class RocksTable
 {
 public:
     RocksTable(const std::string& nspace,
-               std::shared_ptr<rocksdb::DB>& db,
-               std::unique_ptr<rocksdb::ColumnFamilyHandle> column_family,
-               const RocksConfig& rocks_config);
+               std::shared_ptr<rocksdb::DB>&,
+               std::unique_ptr<rocksdb::ColumnFamilyHandle>,
+               const RocksConfig&);
 
     virtual ~RocksTable() = default;
 
@@ -53,10 +53,10 @@ public:
 
     virtual void
     multiset(const TableInterface::Records& sets,
-             Barrier barrier) override final;
+             Barrier) override final;
 
     virtual TableInterface::MaybeStrings
-    multiget(const TableInterface::Keys& keys) override final;
+    multiget(const TableInterface::Keys&) override final;
 
     virtual const std::string&
     nspace() const override final
@@ -65,16 +65,18 @@ public:
     }
 
     virtual void
-    apply_relocations(const volumedriver::ScrubId& scrub_id,
-                      const volumedriver::SCOCloneID cid,
-                      const TableInterface::RelocationLogs& relocs) override final;
+    apply_relocations(const volumedriver::ScrubId&,
+                      const volumedriver::SCOCloneID,
+                      const TableInterface::RelocationLogs&) override final;
 
     virtual void
     clear() override final;
 
     virtual size_t
-    catch_up(volumedriver::DryRun dry_run) override final;
+    catch_up(volumedriver::DryRun) override final;
 
+    virtual TableCounters
+    get_counters(volumedriver::Reset) override final;
 private:
     DECLARE_LOGGER("MetaDataServerRocksTable");
 

--- a/src/volumedriver/metadata-server/ServerNG.cpp
+++ b/src/volumedriver/metadata-server/ServerNG.cpp
@@ -214,6 +214,7 @@ ServerNG::dispatch_(C& conn,
         CASE(Ping, ping_);
         CASE(ApplyRelocationLogs, apply_relocation_logs_);
         CASE(CatchUp, catch_up_);
+        CASE(GetTableCounters, get_table_counters_);
     }
 
 #undef CASE
@@ -714,6 +715,24 @@ ServerNG::catch_up_(mdsproto::Methods::CatchUpParams::Reader& reader,
     const size_t num_tlogs = db_->open(nspace)->catch_up(dry_run);
 
     builder.setNumTLogs(num_tlogs);
+}
+
+void
+ServerNG::get_table_counters_(mdsproto::Methods::GetTableCountersParams::Reader& reader,
+                              mdsproto::Methods::GetTableCountersResults::Builder& builder)
+{
+    const std::string nspace(reader.getNspace().begin(),
+                             reader.getNspace().size());
+    const vd::Reset reset(reader.getReset() ?
+                          vd::Reset::T :
+                          vd::Reset::F);
+
+    const TableCounters table_counters = db_->open(nspace)->get_counters(reset);
+
+    mdsproto::TableCounters::Builder cbuilder = builder.initCounters();
+    cbuilder.setTotalTLogsRead(table_counters.total_tlogs_read);
+    cbuilder.setIncrementalUpdates(table_counters.incremental_updates);
+    cbuilder.setFullRebuilds(table_counters.full_rebuilds);
 }
 
 }

--- a/src/volumedriver/metadata-server/ServerNG.h
+++ b/src/volumedriver/metadata-server/ServerNG.h
@@ -33,7 +33,7 @@ namespace metadata_server
 class ServerNG
 {
 public:
-    ServerNG(DataBaseInterfacePtr db,
+    ServerNG(DataBaseInterfacePtr,
              const std::string& addr,
              const uint16_t port,
              const boost::optional<std::chrono::seconds>& timeout = boost::none,
@@ -62,139 +62,143 @@ private:
     DataBaseInterfacePtr db_;
     youtils::LocORemServer server_;
 
-    template<typename C>
+    template<typename Connection>
     void
-    recv_header_(C& conn,
-                 ConnectionStatePtr state);
+    recv_header_(Connection&,
+                 ConnectionStatePtr);
 
-    template<typename C>
+    template<typename Connection>
     void
-    get_data_(C& conn,
-              ConnectionStatePtr state,
-              std::shared_ptr<metadata_server_protocol::RequestHeader> hdr);
+    get_data_(Connection&,
+              ConnectionStatePtr,
+              std::shared_ptr<metadata_server_protocol::RequestHeader>);
 
-    template<typename C>
+    template<typename Connection>
     void
-    recv_data_(C& conn,
-               ConnectionStatePtr state,
-               std::shared_ptr<metadata_server_protocol::RequestHeader> hdr);
+    recv_data_(Connection&,
+               ConnectionStatePtr,
+               std::shared_ptr<metadata_server_protocol::RequestHeader>);
 
-    template<typename C>
+    template<typename Connection>
     void
-    dispatch_(C& conn,
-              ConnectionStatePtr state,
-              const metadata_server_protocol::RequestHeader& hdr,
-              capnp::MessageReader& reader);
+    dispatch_(Connection&,
+              ConnectionStatePtr,
+              const metadata_server_protocol::RequestHeader&,
+              capnp::MessageReader&);
 
-    template<typename C>
+    template<typename Connection>
     void
-    send_response_(C& conn,
-                   ConnectionStatePtr state,
-                   metadata_server_protocol::ResponseHeader::Type rsp,
-                   metadata_server_protocol::Tag tag,
-                   capnp::MessageBuilder& builder);
+    send_response_(Connection&,
+                   ConnectionStatePtr,
+                   metadata_server_protocol::ResponseHeader::Type,
+                   metadata_server_protocol::Tag,
+                   capnp::MessageBuilder&);
 
-    template<typename C>
+    template<typename Connection>
     void
-    send_response_inband_(C& conn,
-                          ConnectionStatePtr state,
-                          metadata_server_protocol::ResponseHeader::Type rsp,
-                          metadata_server_protocol::Tag tag,
-                          capnp::MessageBuilder& builder);
+    send_response_inband_(Connection&,
+                          ConnectionStatePtr,
+                          metadata_server_protocol::ResponseHeader::Type,
+                          metadata_server_protocol::Tag,
+                          capnp::MessageBuilder&);
 
-    template<typename C>
+    template<typename Connection>
     void
-    send_response_shmem_(C& conn,
-                         ConnectionStatePtr state,
-                         metadata_server_protocol::ResponseHeader::Type rsp,
-                         metadata_server_protocol::Tag tag,
-                         capnp::FlatMessageBuilder& builder);
+    send_response_shmem_(Connection&,
+                         ConnectionStatePtr,
+                         metadata_server_protocol::ResponseHeader::Type,
+                         metadata_server_protocol::Tag,
+                         capnp::FlatMessageBuilder&);
 
-    template<typename C>
+    template<typename Connection>
     void
-    error_(C& conn,
-           ConnectionStatePtr state,
-           const metadata_server_protocol::ResponseHeader::Type rsp,
-           const metadata_server_protocol::Tag tag,
-           const std::string& msg);
+    error_(Connection&,
+           ConnectionStatePtr,
+           const metadata_server_protocol::ResponseHeader::Type,
+           const metadata_server_protocol::Tag,
+           const std::string&);
 
     template<enum metadata_server_protocol::RequestHeader::Type r,
-             typename C,
+             typename Connection,
              typename Traits = metadata_server_protocol::RequestTraits<r>>
     void
-    handle_(C& conn,
-            ConnectionStatePtr state,
-            const metadata_server_protocol::RequestHeader& hdr,
-            capnp::MessageReader& reader,
+    handle_(Connection&,
+            ConnectionStatePtr,
+            const metadata_server_protocol::RequestHeader&,
+            capnp::MessageReader&,
             void (ServerNG::*mem_fn)(typename Traits::Params::Reader&,
                                      typename Traits::Results::Builder&));
 
     template<enum metadata_server_protocol::RequestHeader::Type r,
-             typename C,
+             typename Connection,
              typename Traits = metadata_server_protocol::RequestTraits<r>>
     void
-    handle_shmem_(C& conn,
-                  ConnectionStatePtr state,
-                  const metadata_server_protocol::RequestHeader& hdr,
-                  capnp::MessageReader& reader,
+    handle_shmem_(Connection&,
+                  ConnectionStatePtr,
+                  const metadata_server_protocol::RequestHeader&,
+                  capnp::MessageReader&,
                   void (ServerNG::*mem_fn)(typename Traits::Params::Reader&,
                                            typename Traits::Results::Builder&));
 
     template<enum metadata_server_protocol::RequestHeader::Type r,
-             typename C,
+             typename Connection,
              typename Traits = metadata_server_protocol::RequestTraits<r>>
     void
-    do_handle_(C& conn,
-               ConnectionStatePtr state,
-               const metadata_server_protocol::RequestHeader& hdr,
-               capnp::MessageBuilder& builder,
-               capnp::MessageReader& reader,
+    do_handle_(Connection&,
+               ConnectionStatePtr,
+               const metadata_server_protocol::RequestHeader&,
+               capnp::MessageBuilder&,
+               capnp::MessageReader&,
                void (ServerNG::*mem_fn)(typename Traits::Params::Reader&,
                                         typename Traits::Results::Builder&));
 
     void
-    open_(metadata_server_protocol::Methods::OpenParams::Reader& reader,
-          metadata_server_protocol::Methods::OpenResults::Builder& builder);
+    open_(metadata_server_protocol::Methods::OpenParams::Reader&,
+          metadata_server_protocol::Methods::OpenResults::Builder&);
 
     void
-    drop_(metadata_server_protocol::Methods::DropParams::Reader& reader,
-          metadata_server_protocol::Methods::DropResults::Builder& builder);
+    drop_(metadata_server_protocol::Methods::DropParams::Reader&,
+          metadata_server_protocol::Methods::DropResults::Builder&);
 
     void
-    clear_(metadata_server_protocol::Methods::ClearParams::Reader& reader,
-           metadata_server_protocol::Methods::ClearResults::Builder& builder);
+    clear_(metadata_server_protocol::Methods::ClearParams::Reader&,
+           metadata_server_protocol::Methods::ClearResults::Builder&);
 
     void
-    multiget_(metadata_server_protocol::Methods::MultiGetParams::Reader& reader,
-              metadata_server_protocol::Methods::MultiGetResults::Builder& builder);
+    multiget_(metadata_server_protocol::Methods::MultiGetParams::Reader&,
+              metadata_server_protocol::Methods::MultiGetResults::Builder&);
 
     void
-    multiset_(metadata_server_protocol::Methods::MultiSetParams::Reader& reader,
-              metadata_server_protocol::Methods::MultiSetResults::Builder& builder);
+    multiset_(metadata_server_protocol::Methods::MultiSetParams::Reader&,
+              metadata_server_protocol::Methods::MultiSetResults::Builder&);
 
     void
-    set_role_(metadata_server_protocol::Methods::SetRoleParams::Reader& reader,
-              metadata_server_protocol::Methods::SetRoleResults::Builder& builder);
+    set_role_(metadata_server_protocol::Methods::SetRoleParams::Reader&,
+              metadata_server_protocol::Methods::SetRoleResults::Builder&);
 
     void
-    get_role_(metadata_server_protocol::Methods::GetRoleParams::Reader& reader,
-              metadata_server_protocol::Methods::GetRoleResults::Builder& builder);
+    get_role_(metadata_server_protocol::Methods::GetRoleParams::Reader&,
+              metadata_server_protocol::Methods::GetRoleResults::Builder&);
 
     void
-    list_namespaces_(metadata_server_protocol::Methods::ListParams::Reader& reader,
-                     metadata_server_protocol::Methods::ListResults::Builder& builder);
+    list_namespaces_(metadata_server_protocol::Methods::ListParams::Reader&,
+                     metadata_server_protocol::Methods::ListResults::Builder&);
 
     void
-    ping_(metadata_server_protocol::Methods::PingParams::Reader& reader,
-          metadata_server_protocol::Methods::PingResults::Builder& builder);
+    ping_(metadata_server_protocol::Methods::PingParams::Reader&,
+          metadata_server_protocol::Methods::PingResults::Builder&);
 
     void
-    apply_relocation_logs_(metadata_server_protocol::Methods::ApplyRelocationLogsParams::Reader& reader,
-                           metadata_server_protocol::Methods::ApplyRelocationLogsResults::Builder& builder);
+    apply_relocation_logs_(metadata_server_protocol::Methods::ApplyRelocationLogsParams::Reader&,
+                           metadata_server_protocol::Methods::ApplyRelocationLogsResults::Builder&);
 
     void
-    catch_up_(metadata_server_protocol::Methods::CatchUpParams::Reader& reader,
-              metadata_server_protocol::Methods::CatchUpResults::Builder& builder);
+    catch_up_(metadata_server_protocol::Methods::CatchUpParams::Reader&,
+              metadata_server_protocol::Methods::CatchUpResults::Builder&);
+
+    void
+    get_table_counters_(metadata_server_protocol::Methods::GetTableCountersParams::Reader&,
+                        metadata_server_protocol::Methods::GetTableCountersResults::Builder&);
 
 };
 

--- a/src/volumedriver/metadata-server/Table.cpp
+++ b/src/volumedriver/metadata-server/Table.cpp
@@ -38,6 +38,9 @@ namespace yt = youtils;
 #define LOCKW()                                                 \
     boost::unique_lock<decltype(rwlock_)> wlg__(rwlock_)
 
+#define LOCK_COUNTERS()                                         \
+    boost::lock_guard<decltype(counters_lock_)> clg__(counters_lock_)
+
 Table::Table(DataBaseInterfacePtr db,
              be::BackendInterfacePtr bi,
              yt::PeriodicActionPool::Ptr act_pool,
@@ -199,6 +202,7 @@ Table::apply_relocations(const vd::ScrubId& scrub_id,
                                                            vd::CheckScrubId::T));
 
         update_nsid_map_(res.nsid_map);
+        update_counters_(res);
 
         if (mdstore->scrub_id() == scrub_id)
         {
@@ -293,6 +297,7 @@ Table::work_()
             boost::upgrade_to_unique_lock<decltype(rwlock_)> u(ulg);
 
             update_nsid_map_(res.nsid_map);
+            update_counters_(res);
         }
         catch (be::BackendNamespaceDoesNotExistException& e)
         {
@@ -349,9 +354,47 @@ Table::catch_up(vd::DryRun dry_run)
         if (dry_run == vd::DryRun::F)
         {
             update_nsid_map_(res.nsid_map);
+            update_counters_(res);
         }
 
         return res.num_tlogs;
+    }
+}
+
+TableCounters
+Table::get_counters(vd::Reset reset)
+{
+    LOCKR();
+    LOCK_COUNTERS();
+
+    if (reset == vd::Reset::T)
+    {
+        TableCounters c;
+        std::swap(c, counters_);
+        return c;
+    }
+    else
+    {
+        return counters_;
+    }
+}
+
+void
+Table::update_counters_(const vd::MetaDataStoreBuilder::Result& res)
+{
+    LOCK_COUNTERS();
+
+    if (res.num_tlogs)
+    {
+        counters_.total_tlogs_read += res.num_tlogs;
+        if (res.full_rebuild)
+        {
+            counters_.full_rebuilds += 1;
+        }
+        else
+        {
+            counters_.incremental_updates += 1;
+        }
     }
 }
 

--- a/src/volumedriver/metadata-server/Table.h
+++ b/src/volumedriver/metadata-server/Table.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include <boost/chrono.hpp>
+#include <boost/thread/mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
 #include <youtils/IOException.h>
@@ -58,6 +59,8 @@ namespace metadata_server
 //   * when being forced to catch up
 //   .
 //   All other calls use it in shared mode.
+//
+//   The counters are protected by a plain mutex which needs to be grabbed *after* the shared one.
 class Table
     : public TableInterface
 {
@@ -88,10 +91,10 @@ public:
 
     virtual void
     multiset(const TableInterface::Records& records,
-             Barrier barrier) override final;
+             Barrier) override final;
 
     virtual TableInterface::MaybeStrings
-    multiget(const TableInterface::Keys& keys) override final;
+    multiget(const TableInterface::Keys&) override final;
 
     virtual Role
     get_role() const override final;
@@ -109,7 +112,10 @@ public:
     clear() override final;
 
     virtual size_t
-    catch_up(volumedriver::DryRun dry_run) override final;
+    catch_up(volumedriver::DryRun) override final;
+
+    virtual TableCounters
+    get_counters(volumedriver::Reset) override final;
 
     void
     stop();
@@ -132,6 +138,9 @@ private:
 
     volumedriver::NSIDMap nsid_map_;
 
+    boost::mutex counters_lock_;
+    TableCounters counters_;
+
     void
     start_(const std::chrono::milliseconds& ramp_up);
 
@@ -149,6 +158,9 @@ private:
 
     void
     prevent_updates_on_slaves_(const char* desc);
+
+    void
+    update_counters_(const volumedriver::MetaDataStoreBuilder::Result&);
 };
 
 typedef std::shared_ptr<Table> TablePtr;

--- a/src/volumedriver/metadata-server/WeakTable.h
+++ b/src/volumedriver/metadata-server/WeakTable.h
@@ -89,6 +89,12 @@ public:
         return lock_()->catch_up(dry_run);
     }
 
+    virtual TableCounters
+    get_counters(volumedriver::Reset reset) override final
+    {
+        return lock_()->get_counters(reset);
+    }
+
     MAKE_EXCEPTION(Exception,
                    fungi::IOException);
 


### PR DESCRIPTION
At the heart of this PR is a fix for MDS slaves that used to check the corks too coarsely grained, potentially leading to the corks not being found which in turn causes a full rebuild instead of cheaper incremental ones.
While at it this also comes with a few minor cleanups and counters for MDS tables are introduced which might come in handy for testing and debugging purposes.