### PR TITLE
AmqpEventPublisher: revise internal locking

### DIFF
--- a/src/filesystem/AmqpEventPublisher.cpp
+++ b/src/filesystem/AmqpEventPublisher.cpp
@@ -21,18 +21,23 @@
 #include <sys/socket.h>
 
 #include <boost/property_tree/ptree.hpp>
+#include <boost/thread/lock_guard.hpp>
 
 #include <amqp.h>
 
 #include <youtils/Assert.h>
 #include <youtils/Catchers.h>
+#include <youtils/ScopeExit.h>
 #include <youtils/System.h>
 
 namespace volumedriverfs
 {
 
-#define LOCK()                                  \
-    std::lock_guard<lock_type> gl__(lock_)
+#define LOCK_MGMT()                                             \
+    boost::lock_guard<decltype(mgmt_lock_)> gml__(mgmt_lock_)
+
+#define LOCK_CHANNEL()                                                  \
+    boost::lock_guard<decltype(channel_lock_)> gcl__(channel_lock_)
 
 namespace bpt = boost::property_tree;
 namespace ip = initialized_params;
@@ -69,10 +74,10 @@ check_uri(const AmqpUri& uri)
 }
 
 void
-check_uris(const ip::PARAMETER_TYPE(events_amqp_uris)& uris)
+check_uris(const AmqpUris& uris)
 {
-    std::for_each(uris.value().begin(),
-                  uris.value().end(),
+    std::for_each(uris.begin(),
+                  uris.end(),
                   check_uri);
 }
 
@@ -99,6 +104,13 @@ enable_keepalive(AmqpClient::Channel& channel)
                                     keep_intvl);
 }
 
+template<typename T>
+boost::shared_ptr<typename T::ValueType>
+extract_param(const bpt::ptree& pt)
+{
+    return boost::make_shared<typename T::ValueType>(T(pt).value());
+}
+
 }
 
 AmqpEventPublisher::AmqpEventPublisher(const ClusterId& cluster_id,
@@ -107,13 +119,13 @@ AmqpEventPublisher::AmqpEventPublisher(const ClusterId& cluster_id,
                                        const RegisterComponent registrate)
     : VolumeDriverComponent(registrate, pt)
     , index_(0)
-    , events_amqp_uris(pt)
-    , events_amqp_exchange(pt)
-    , events_amqp_routing_key(pt)
+    , uris_(extract_param<ip::PARAMETER_TYPE(events_amqp_uris)>(pt))
+    , exchange_(extract_param<ip::PARAMETER_TYPE(events_amqp_exchange)>(pt))
+    , routing_key_(extract_param<ip::PARAMETER_TYPE(events_amqp_routing_key)>(pt))
     , cluster_id_(cluster_id)
     , node_id_(node_id)
 {
-    check_uris(events_amqp_uris);
+    check_uris(*uris_);
 
     if (not enabled_())
     {
@@ -124,14 +136,15 @@ AmqpEventPublisher::AmqpEventPublisher(const ClusterId& cluster_id,
 bool
 AmqpEventPublisher::enabled() const
 {
-    LOCK();
+    LOCK_MGMT();
     return enabled_();
 }
 
 bool
 AmqpEventPublisher::enabled_() const
 {
-    return not events_amqp_uris.value().empty();
+    VERIFY(uris_ != nullptr);
+    return not uris_->empty();
 }
 
 const char*
@@ -145,16 +158,20 @@ namespace
 
 template<typename T>
 void
-do_update(T& t,
+do_update(boost::shared_ptr<typename T::ValueType>& ptr,
           const bpt::ptree& pt,
           yt::UpdateReport& urep,
           bool& updated)
 {
+    VERIFY(ptr != nullptr);
+
+    T t(*ptr);
     const T u(pt);
 
     if (u.value() != t.value())
     {
         updated = true;
+        ptr = boost::make_shared<typename T::ValueType>(u.value());
     }
 
     t.update(pt,
@@ -164,59 +181,78 @@ do_update(T& t,
 }
 
 void
-AmqpEventPublisher::update(const boost::property_tree::ptree& pt,
+AmqpEventPublisher::update(const bpt::ptree& pt,
                            yt::UpdateReport& urep)
 {
-    LOCK();
+    LOCK_MGMT();
 
     bool updated = false;
 
-    do_update(events_amqp_uris,
-              pt,
-              urep,
-              updated);
+    do_update<ip::PARAMETER_TYPE(events_amqp_uris)>(uris_,
+                                                    pt,
+                                                    urep,
+                                                    updated);
 
-    do_update(events_amqp_exchange,
-              pt,
-              urep,
-              updated);
+    do_update<ip::PARAMETER_TYPE(events_amqp_exchange)>(exchange_,
+                                                        pt,
+                                                        urep,
+                                                        updated);
 
-    do_update(events_amqp_routing_key,
-              pt,
-              urep,
-              updated);
+    do_update<ip::PARAMETER_TYPE(events_amqp_routing_key)>(routing_key_,
+                                                           pt,
+                                                           urep,
+                                                           updated);
 
     if (updated)
     {
         index_ = 0;
-        channel_.reset();
+        channel_ = nullptr;
     }
 }
 
+namespace
+{
+
+template<typename T>
 void
-AmqpEventPublisher::persist(boost::property_tree::ptree& pt,
+do_persist(const boost::shared_ptr<typename T::ValueType>& ptr,
+           bpt::ptree& pt,
+           const ReportDefault report_default)
+{
+    VERIFY(ptr != nullptr);
+    T t(*ptr);
+    t.persist(pt,
+              report_default);
+}
+
+}
+
+void
+AmqpEventPublisher::persist(bpt::ptree& pt,
                             const ReportDefault report_default) const
 {
-    LOCK();
+    LOCK_MGMT();
 
-#define P(var)                                  \
-    (var).persist(pt, report_default)
+    do_persist<ip::PARAMETER_TYPE(events_amqp_uris)>(uris_,
+                                                     pt,
+                                                     report_default);
+    do_persist<ip::PARAMETER_TYPE(events_amqp_exchange)>(exchange_,
+                                                         pt,
+                                                         report_default);
 
-    P(events_amqp_uris);
-    P(events_amqp_exchange);
-    P(events_amqp_routing_key);
-
-#undef P
+    do_persist<ip::PARAMETER_TYPE(events_amqp_routing_key)>(routing_key_,
+                                                            pt,
+                                                            report_default);
 }
 
 bool
-AmqpEventPublisher::checkConfig(const boost::property_tree::ptree& pt,
+AmqpEventPublisher::checkConfig(const bpt::ptree& pt,
                                 yt::ConfigurationReport& crep) const
 {
-    const decltype(events_amqp_uris) uris(pt);
+    const ip::PARAMETER_TYPE(events_amqp_uris) uris(pt);
     try
     {
-        check_uris(uris);
+        check_uris(uris.value());
         return true;
     }
     CATCH_STD_ALL_EWHAT({
@@ -234,59 +270,111 @@ AmqpEventPublisher::publish(const events::Event& ev) noexcept
     try
     {
         ASSERT(ev.IsInitialized());
-        LOCK();
+
+        boost::unique_lock<decltype(mgmt_lock_)> u(mgmt_lock_);
 
         if (enabled_())
         {
-            // a lot of copying but we don't care for now.
-            events::EventMessage evmsg;
-            evmsg.set_cluster_id(cluster_id_.str());
-            evmsg.set_node_id(node_id_.str());
+            // create copies so any config changes during the unlocked
+            // section below do not interfere.
+            boost::shared_ptr<AmqpUris> uris(uris_);
+            boost::shared_ptr<AmqpExchange> exchange(exchange_);
+            boost::shared_ptr<AmqpRoutingKey> routing_key(routing_key_);
+            unsigned idx = index_;
 
-            *evmsg.mutable_event() = ev;
-            std::string s;
-            evmsg.SerializeToString(&s);
-            auto msg(AmqpClient::BasicMessage::Create(s));
+            VERIFY(uris != nullptr);
+            VERIFY(exchange != nullptr);
+            VERIFY(routing_key != nullptr);
+            VERIFY(idx < uris->size());
 
-            const unsigned attempts = events_amqp_uris.value().size();
-            for (unsigned i = 0; i < attempts; ++i)
+            AmqpClient::Channel::ptr_t chan = channel_;
+
             {
-                const AmqpUri uri = events_amqp_uris.value()[index_];
-
-                try
-                {
-                    if (channel_ == nullptr)
-                    {
-                        LOG_INFO("Trying to establish channel with " << uri);
-                        channel_ = AmqpClient::Channel::CreateFromUri(uri.str(),
-                                                                      max_frame_size);
-                        VERIFY(channel_);
-                        enable_keepalive(*channel_);
-                    }
-
-                    channel_->BasicPublish(events_amqp_exchange.value(),
-                                           events_amqp_routing_key.value(),
-                                           msg);
-
-                    LOG_TRACE("Published event " << ev.GetDescriptor()->full_name() <<
-                              " to " << uri);
-                    return;
-                }
-                CATCH_STD_ALL_EWHAT({
-                        LOG_WARN("Failed to publish event " <<
-                                 ev.GetDescriptor()->full_name() <<
-                                 " to " << uri << ": " << EWHAT);
-                        channel_ = nullptr;
-                        index_ = (index_ + 1) % attempts;
-                    });
+                u.unlock();
+                auto on_exit(yt::make_scope_exit([&]
+                                                 {
+                                                     u.lock();
+                                                 }));
+                publish_(ev,
+                         uris,
+                         exchange,
+                         routing_key,
+                         chan,
+                         idx);
             }
 
-            LOG_ERROR("Failed to publish event " << ev.GetDescriptor()->full_name() <<
-                      " - dropping it");
+            if (uris == uris_ and
+                exchange == exchange_ and
+                routing_key == routing_key_)
+            {
+                VERIFY(idx < uris_->size());
+                index_ = idx;
+                channel_ = chan;
+            }
         }
     }
     CATCH_STD_ALL_LOG_IGNORE("Failed to publish event");
     TODO("AR: the logging could emit an exception, violating noexcept?");
+}
+
+
+void
+AmqpEventPublisher::publish_(const events::Event& ev,
+                             const boost::shared_ptr<AmqpUris>& uris,
+                             const boost::shared_ptr<AmqpExchange>& exchange,
+                             const boost::shared_ptr<AmqpRoutingKey>& routing_key,
+                             AmqpClient::Channel::ptr_t& chan,
+                             unsigned& idx) const
+{
+    VERIFY(idx < uris->size());
+
+    // a lot of copying but we don't care for now.
+    events::EventMessage evmsg;
+    evmsg.set_cluster_id(cluster_id_.str());
+    evmsg.set_node_id(node_id_.str());
+    *evmsg.mutable_event() = ev;
+
+    std::string s;
+    evmsg.SerializeToString(&s);
+
+    LOCK_CHANNEL();
+
+    AmqpClient::BasicMessage::ptr_t msg(AmqpClient::BasicMessage::Create(s));
+
+    const unsigned attempts = uris->size();
+
+    for (unsigned i = 0; i < attempts; ++i)
+    {
+        const AmqpUri& uri(uris->at(idx));
+
+        try
+        {
+            if (chan == nullptr)
+            {
+                LOG_INFO("Trying to establish channel with " << uri);
+                chan = AmqpClient::Channel::CreateFromUri(uri.str(),
+                                                          max_frame_size);
+                VERIFY(chan);
+                enable_keepalive(*chan);
+            }
+
+            chan->BasicPublish(*exchange,
+                               *routing_key,
+                               msg);
+
+            return;
+        }
+        CATCH_STD_ALL_EWHAT({
+                LOG_WARN("Failed to publish event " <<
+                         ev.GetDescriptor()->full_name() <<
+                         " to " << uri << ": " << EWHAT);
+                chan = nullptr;
+                idx = (idx + 1) % attempts;
+            });
+    }
+
+    LOG_ERROR("Failed to publish event " << ev.GetDescriptor()->full_name() <<
+              " - dropping it");
 }
 
 }

--- a/src/filesystem/AmqpEventPublisher.h
+++ b/src/filesystem/AmqpEventPublisher.h
@@ -20,9 +20,8 @@
 #include "FileSystemParameters.h"
 #include "NodeId.h"
 
-#include <mutex>
-
 #include <boost/property_tree/ptree_fwd.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include <SimpleAmqpClient/SimpleAmqpClient.h>
 
@@ -48,9 +47,9 @@ class AmqpEventPublisher
 {
 public:
     explicit AmqpEventPublisher(const ClusterId& cluster_id,
-                            const NodeId& node_id,
-                            const boost::property_tree::ptree& pt,
-                            const RegisterComponent registrate = RegisterComponent::T);
+                                const NodeId& node_id,
+                                const boost::property_tree::ptree& pt,
+                                const RegisterComponent registrate = RegisterComponent::T);
 
     virtual ~AmqpEventPublisher() = default;
 
@@ -86,22 +85,58 @@ public:
 private:
     DECLARE_LOGGER("AmqpEventPublisher");
 
+    // Work around deficiencies in the AMQP lib(s) we're using:
+    // SimpleAmqpClient's publish calls is blocking (NB: newer versions of
+    // -lrabbitmq-c seem to have grown support for non-blocking sockets, cf.
+    // https://github.com/alanxz/rabbitmq-c/pull/256) and there were several
+    // occurences of calls being stuck waiting for a message from the server
+    // side that never arrived. The TCP keepalive support added on top of it
+    // does not solve the problem completely as in some cases the server was
+    // in a zombie state, keeping the TCP connection open but never sending
+    // the expected reply back.
+    // That lead to interesting lockups with a simple locking scheme where a
+    // management call was trying to update the configuration while another
+    // thread was stuck in a call to SimpleAmqpClient while holding the lock.
+    //
+    // To safeguard us against this the following locking scheme is employed:
+    // * mgmt_lock_ protects (besides the config params such as uris_) the
+    //   Channel::ptr_t (boost::shared_ptr).
+    // * channel_lock_ is used to prevent concurrent invocations of Channel
+    //   methods from different threads as the underlying -lrabbitmq-c is not
+    //   thread safe.
+    //
+    // In case the above doesn't make it clear already: the mgmt_lock_ should
+    // not be held while the channel_ lock is acquired to call into
+    // SimpleAmqpClient.
+    //
+    // That still leaves the problem that threads invoking publish could
+    // lock up on the channel_lock_ - callers (cf. EventHandler) have to
+    // deal with it.
+    using Mutex = boost::mutex;
+    mutable Mutex mgmt_lock_;
+    mutable Mutex channel_lock_;
+
+    // Indicates which entry of the events_amqp_uris vector is currently active.
     unsigned index_;
     AmqpClient::Channel::ptr_t channel_;
 
-    DECLARE_PARAMETER(events_amqp_uris);
-    DECLARE_PARAMETER(events_amqp_exchange);
-    DECLARE_PARAMETER(events_amqp_routing_key);
+    boost::shared_ptr<AmqpUris> uris_;
+    boost::shared_ptr<AmqpExchange> exchange_;
+    boost::shared_ptr<AmqpRoutingKey> routing_key_;
 
     const ClusterId cluster_id_;
     const NodeId node_id_;
 
-    // Protects the channel - the underlying -lrabbitmq-c is not thread safe.
-    typedef std::mutex lock_type;
-    mutable lock_type lock_;
-
     bool
     enabled_() const;
+
+    void
+    publish_(const events::Event&,
+             const boost::shared_ptr<AmqpUris>&,
+             const boost::shared_ptr<AmqpExchange>&,
+             const boost::shared_ptr<AmqpRoutingKey>&,
+             AmqpClient::Channel::ptr_t&,
+             unsigned& uris_index) const;
 };
 
 }


### PR DESCRIPTION
There used to be a single lock to serialize reconfiguration as well as
access to the underlying SimplAmqpClient Channel. Calling a method of
the latter was however observed to block indefinitely (waiting for a
message from the RabbitMQ server) which is rather undesirable behaviour
while holding a lock.
Since there's no way to reliably time out all calls of Channel methods,
the locking was revised to at least avoid reconfigurations getting stuck
on this.
That still means that event submissions can get stuck but this was
addressed earlier on already by moving the actual submission to a thread
that consumes events from a bounded queue - cf. b4e8e6b1d3

Addresses OVS-4527

NB: Do not delete this branch as it might have to be merged into other branches as well.