### PR TITLE
AmqpEventPublisher: fix another config param regression left by f32272b

### DIFF
--- a/src/filesystem/AmqpEventPublisher.cpp
+++ b/src/filesystem/AmqpEventPublisher.cpp
@@ -158,16 +158,17 @@ do_update(boost::shared_ptr<T>& ptr,
 {
     VERIFY(ptr != nullptr);
 
-    const T u(pt);
+    auto u(boost::make_shared<T>(pt));
 
-    if (u.value() != ptr->value())
-    {
-        updated = true;
-        ptr = boost::make_shared<T>(pt);
-    }
-
+    const bool need_update = u->value() != ptr->value();
     ptr->update(pt,
                 urep);
+
+    if (need_update)
+    {
+        std::swap(ptr, u);
+        updated = true;
+    }
 }
 
 }


### PR DESCRIPTION
The update call that adds to the UpdateReport argument was performed on
the newly created parameter, IOW if an update was actually performed the
UpdateReport itself indicated the opposite.