### PR TITLE
Fix filedriver error handling

### DIFF
--- a/src/filedriver/ContainerManager.cpp
+++ b/src/filedriver/ContainerManager.cpp
@@ -101,9 +101,9 @@ ContainerManager::find_throw_(const ContainerId& cid)
     if (c == nullptr)
     {
         LOG_ERROR("Container " << cid << " does not exist");
-        throw fungi::IOException("Container does not exist",
-                                 cid.c_str(),
-                                 ENOENT);
+        throw ContainerDoesNotExistException("Container does not exist",
+                                             cid.c_str(),
+                                             ENOENT);
     }
 
     return c;
@@ -119,9 +119,9 @@ ContainerManager::create(const ContainerId& cid)
     if (find_locked_(cid))
     {
         LOG_ERROR("Cannot create " << cid << " as it exists already");
-        throw fungi::IOException("Cannot create container as it exists already",
-                                 cid.str().c_str(),
-                                 EEXIST);
+        throw ContainerExistsAlreadyException("Cannot create container as it exists already",
+                                              cid.str().c_str(),
+                                              EEXIST);
     }
     else
     {
@@ -200,9 +200,9 @@ ContainerManager::unlink(const ContainerId& cid)
     if (c == nullptr)
     {
         LOG_ERROR("Container " << cid << " does not exist");
-        throw fungi::IOException("Container does not exist",
-                                 cid.c_str(),
-                                 ENOENT);
+        throw ContainerDoesNotExistException("Container does not exist",
+                                             cid.c_str(),
+                                             ENOENT);
     }
 
     c->unlink();

--- a/src/filedriver/ContainerManager.h
+++ b/src/filedriver/ContainerManager.h
@@ -28,6 +28,7 @@
 #include <boost/thread/mutex.hpp>
 
 #include <youtils/ConfigurationReport.h>
+#include <youtils/IOException.h>
 #include <youtils/Logging.h>
 #include <youtils/UpdateReport.h>
 #include <youtils/VolumeDriverComponent.h>
@@ -43,6 +44,10 @@ class ContainerManager
     : public youtils::VolumeDriverComponent
 {
 public:
+    MAKE_EXCEPTION(Exception, fungi::IOException);
+    MAKE_EXCEPTION(ContainerDoesNotExistException, Exception);
+    MAKE_EXCEPTION(ContainerExistsAlreadyException, Exception);
+
     ContainerManager(backend::BackendConnectionManagerPtr cm,
                      const boost::property_tree::ptree& pt,
                      const RegisterComponent registerize = RegisterComponent::T);

--- a/src/filesystem/LocalNode.h
+++ b/src/filesystem/LocalNode.h
@@ -370,6 +370,14 @@ private:
 
     void
     collect_scrub_garbage_(backend::Garbage);
+
+    template<typename ReturnType,
+             typename... Args>
+    ReturnType
+    convert_fdriver_exceptions_(ReturnType (filedriver::ContainerManager::*mem_fun)(const filedriver::ContainerId&,
+                                                                                    Args...),
+                                const Object&,
+                                Args...);
 };
 
 }


### PR DESCRIPTION
If filedriver does not find extents locally, the error should be translated to "ObjectNotRunningHere" which in turn will prompt upper layers to refresh potentially stale registrations in its cache before retrying.