### PR TITLE
Feature/sco written to backend action

### DIFF
--- a/src/volumedriver/Makefile.am
+++ b/src/volumedriver/Makefile.am
@@ -170,6 +170,7 @@ libvolumedriver_la_SOURCES = \
 	SCOCacheNamespace.cpp \
 	SCO.cpp \
 	SCOFetcher.cpp \
+	SCOWrittenToBackendAction.cpp \
 	SCOPool.cpp \
 	Scrubber.cpp \
 	ScrubberAdapter.cpp \

--- a/src/volumedriver/OpenSCO.cpp
+++ b/src/volumedriver/OpenSCO.cpp
@@ -24,6 +24,7 @@ namespace volumedriver
 {
 
 namespace bid = boost::interprocess::ipcdetail;
+namespace yt = youtils;
 
 void
 intrusive_ptr_add_ref(OpenSCO* sco)
@@ -156,6 +157,12 @@ SCO
 OpenSCO::sco_name() const
 {
     return sco_->getSCO();
+}
+
+void
+OpenSCO::purge_from_page_cache()
+{
+    fd_.fadvise(yt::FAdvise::DontNeed);
 }
 
 }

--- a/src/volumedriver/OpenSCO.h
+++ b/src/volumedriver/OpenSCO.h
@@ -46,6 +46,9 @@ public:
     void
     sync();
 
+    void
+    purge_from_page_cache();
+
     // Z42: find a better name
     SCO
     sco_name() const;

--- a/src/volumedriver/SCOWrittenToBackendAction.cpp
+++ b/src/volumedriver/SCOWrittenToBackendAction.cpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#include "SCOWrittenToBackendAction.h"
+
+#include <iostream>
+
+#include <boost/bimap.hpp>
+
+#include <youtils/StreamUtils.h>
+
+namespace volumedriver
+{
+
+namespace yt = youtils;
+
+namespace
+{
+
+void
+reminder(SCOWrittenToBackendAction) __attribute__((unused));
+
+void
+reminder(SCOWrittenToBackendAction m)
+{
+    switch (m)
+    {
+    case SCOWrittenToBackendAction::SetDisposable:
+    case SCOWrittenToBackendAction::SetDisposableAndPurgeFromPageCache:
+    case SCOWrittenToBackendAction::PurgeFromSCOCache:
+        // If the compiler yells at you that you've forgotten dealing with an enum
+        // value here chances are that it's also missing from the translations map
+        // below. If so add it NOW.
+        break;
+    }
+}
+
+using TranslationsMap = boost::bimap<SCOWrittenToBackendAction, std::string>;
+
+TranslationsMap
+init_translations()
+{
+    const std::vector<TranslationsMap::value_type> initv{
+        { SCOWrittenToBackendAction::SetDisposable, "SetDisposable" },
+        { SCOWrittenToBackendAction::SetDisposableAndPurgeFromPageCache, "SetDisposableAndPurgeFromPageCache" },
+        { SCOWrittenToBackendAction::PurgeFromSCOCache, "PurgeFromSCOCache" },
+    };
+
+    return TranslationsMap(initv.begin(),
+                           initv.end());
+}
+
+}
+
+std::ostream&
+operator<<(std::ostream& os,
+           const SCOWrittenToBackendAction b)
+{
+    static const TranslationsMap translations(init_translations());
+    return yt::StreamUtils::stream_out(translations.left,
+                                       os,
+                                       b);
+}
+
+std::istream&
+operator>>(std::istream& is,
+           SCOWrittenToBackendAction& b)
+{
+    static const TranslationsMap translations(init_translations());
+    return yt::StreamUtils::stream_in(translations.right,
+                                      is,
+                                      b);
+}
+
+
+}

--- a/src/volumedriver/SCOWrittenToBackendAction.h
+++ b/src/volumedriver/SCOWrittenToBackendAction.h
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#ifndef VD_SCO_WRITTEN_TO_BACKEND_ACTION_H_
+#define VD_SCO_WRITTEN_TO_BACKEND_ACTION_H_
+
+#include <iosfwd>
+
+namespace volumedriver
+{
+
+enum class SCOWrittenToBackendAction
+{
+    SetDisposable,
+    SetDisposableAndPurgeFromPageCache,
+    PurgeFromSCOCache,
+};
+
+std::ostream&
+operator<<(std::ostream&,
+           const SCOWrittenToBackendAction);
+
+std::istream&
+operator>>(std::istream&,
+           SCOWrittenToBackendAction&);
+
+}
+
+#endif // !VD_SCO_WRITTEN_TO_BACKEND_ACTION_H_

--- a/src/volumedriver/VolManager.cpp
+++ b/src/volumedriver/VolManager.cpp
@@ -138,6 +138,7 @@ try
           , dtl_check_interval_in_seconds(pt)
           , read_cache_default_behaviour(pt)
           , read_cache_default_mode(pt)
+          , sco_written_to_backend_action(pt)
           , clean_interval(pt)
           , sap_persist_interval(pt)
           , required_tlog_freespace(pt)
@@ -1777,6 +1778,7 @@ VolManager::update(const boost::property_tree::ptree& pt,
     freespace_check_interval.update(pt, report);
     read_cache_default_behaviour.update(pt, report);
     read_cache_default_mode.update(pt, report);
+    sco_written_to_backend_action.update(pt, report);
     clean_interval.update(pt, report);
     sap_persist_interval.update(pt, report);
     required_meta_freespace.update(pt, report);
@@ -1802,6 +1804,7 @@ VolManager::persist(boost::property_tree::ptree& pt,
     freespace_check_interval.persist(pt, reportDefault);
     read_cache_default_behaviour.persist(pt, reportDefault);
     read_cache_default_mode.persist(pt, reportDefault);
+    sco_written_to_backend_action.persist(pt, reportDefault);
     clean_interval.persist(pt, reportDefault);
     sap_persist_interval.persist(pt, reportDefault);
     required_tlog_freespace.persist(pt, reportDefault);
@@ -1845,6 +1848,12 @@ VolManager::effective_metadata_cache_capacity(const VolumeConfig& cfg) const
     return cfg.metadata_cache_capacity_ ?
         *cfg.metadata_cache_capacity_ :
         metadata_cache_capacity.value();
+}
+
+SCOWrittenToBackendAction
+VolManager::get_sco_written_to_backend_action() const
+{
+    return sco_written_to_backend_action.value();
 }
 
 }

--- a/src/volumedriver/VolManager.h
+++ b/src/volumedriver/VolManager.h
@@ -469,6 +469,9 @@ public:
     ClusterCacheMode
     get_cluster_cache_default_mode() const;
 
+    SCOWrittenToBackendAction
+    get_sco_written_to_backend_action() const;
+
     size_t
     effective_metadata_cache_capacity(const VolumeConfig&) const;
 
@@ -514,6 +517,7 @@ private:
 private:
     DECLARE_PARAMETER(read_cache_default_behaviour);
     DECLARE_PARAMETER(read_cache_default_mode);
+    DECLARE_PARAMETER(sco_written_to_backend_action);
 
 private:
     DECLARE_PARAMETER(clean_interval);

--- a/src/volumedriver/VolumeDriverParameters.cpp
+++ b/src/volumedriver/VolumeDriverParameters.cpp
@@ -112,6 +112,13 @@ DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(read_cache_default_mode,
                                       ShowDocumentation::T,
                                       volumedriver::ClusterCacheMode::ContentBased);
 
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(sco_written_to_backend_action,
+                                      volmanager_component_name,
+                                      "sco_written_to_backend_action",
+                                      "Default SCO cache behaviour (SetDisposable, SetDisposableAndPurgeFromPageCache, PurgeFromSCOCache)",
+                                      ShowDocumentation::T,
+                                      volumedriver::SCOWrittenToBackendAction::SetDisposable);
+
 DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(required_tlog_freespace,
                                       volmanager_component_name,
                                       "required_tlog_freespace",

--- a/src/volumedriver/VolumeDriverParameters.h
+++ b/src/volumedriver/VolumeDriverParameters.h
@@ -20,6 +20,7 @@
 #include "ClusterCacheMode.h"
 #include "LockStoreType.h"
 #include "MountPointConfig.h"
+#include "SCOWrittenToBackendAction.h"
 #include "Types.h"
 
 #include <youtils/ArakoonNodeConfig.h>
@@ -52,6 +53,8 @@ DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(read_cache_default_behaviour,
                                                   volumedriver::ClusterCacheBehaviour);
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(read_cache_default_mode,
                                                   volumedriver::ClusterCacheMode);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(sco_written_to_backend_action,
+                                                  volumedriver::SCOWrittenToBackendAction);
 // TODO these should have a dimensioned value constructor.
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(required_meta_freespace,
                                                   std::atomic<uint64_t>);

--- a/src/volumedriver/test/Makefile.am
+++ b/src/volumedriver/test/Makefile.am
@@ -89,6 +89,7 @@ volumedriver_test_SOURCES = \
 	SCOCacheMapTest.cpp \
 	SCOCacheNamespaceTest.cpp \
 	SCOCacheTest.cpp \
+	SCOWrittenToBackendActionTest.cpp \
 	ScrubberTest.cpp \
 	ScrubWorkTest.cpp \
 	SimpleBackupRestoreTest.cpp \

--- a/src/volumedriver/test/SCOWrittenToBackendActionTest.cpp
+++ b/src/volumedriver/test/SCOWrittenToBackendActionTest.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+
+#include "../SCOWrittenToBackendAction.h"
+
+#include "VolManagerTestSetup.h"
+
+namespace volumedrivertest
+{
+
+using namespace volumedriver;
+
+class SCOWrittenToBackendActionTest
+    : public VolManagerTestSetup
+{
+protected:
+    SCOWrittenToBackendActionTest()
+        : VolManagerTestSetup("SCOWrittenToBackendActionTest")
+    {}
+};
+
+TEST_P(SCOWrittenToBackendActionTest, enum_streaming)
+{
+    auto check([](const SCOWrittenToBackendAction a)
+               {
+                   std::stringstream ss;
+                   ss << a;
+                   EXPECT_TRUE(ss.good());
+
+                   SCOWrittenToBackendAction b = SCOWrittenToBackendAction::SetDisposable;
+                   ss >> b;
+
+                   EXPECT_FALSE(ss.bad());
+                   EXPECT_FALSE(ss.fail());
+                   EXPECT_TRUE(ss.eof());
+
+                   EXPECT_EQ(a, b);
+               });
+
+    check(SCOWrittenToBackendAction::SetDisposable);
+    check(SCOWrittenToBackendAction::SetDisposableAndPurgeFromPageCache);
+    check(SCOWrittenToBackendAction::PurgeFromSCOCache);
+}
+
+TEST_P(SCOWrittenToBackendActionTest, enum_streaming_failure)
+{
+    std::stringstream ss("fail");
+    SCOWrittenToBackendAction a = SCOWrittenToBackendAction::SetDisposable;
+    ss >> a;
+
+    EXPECT_TRUE(ss.fail());
+    EXPECT_EQ(SCOWrittenToBackendAction::SetDisposable,
+              a);
+}
+
+INSTANTIATE_TEST_CASE_P(SCOWrittenToBackendActionTests,
+                        SCOWrittenToBackendActionTest,
+                        ::testing::Values(VolManagerTestSetup::default_test_config()));
+
+}

--- a/src/volumedriver/test/SCOWrittenToBackendActionTest.cpp
+++ b/src/volumedriver/test/SCOWrittenToBackendActionTest.cpp
@@ -18,10 +18,18 @@
 
 #include "VolManagerTestSetup.h"
 
+#include <sys/mman.h>
+
+#include <youtils/ScopeExit.h>
+
 namespace volumedrivertest
 {
 
 using namespace volumedriver;
+
+namespace bpt = boost::property_tree;
+namespace ip = initialized_params;
+namespace yt = youtils;
 
 class SCOWrittenToBackendActionTest
     : public VolManagerTestSetup
@@ -30,6 +38,158 @@ protected:
     SCOWrittenToBackendActionTest()
         : VolManagerTestSetup("SCOWrittenToBackendActionTest")
     {}
+
+    void
+    set_action(SCOWrittenToBackendAction a)
+    {
+        bpt::ptree pt;
+        VolManager& vm = *VolManager::get();
+        vm.persistConfiguration(pt);
+
+        ip::PARAMETER_TYPE(sco_written_to_backend_action)(a).persist(pt);
+        UpdateReport urep;
+        ConfigurationReport crep;
+
+        vm.updateConfiguration(pt,
+                               urep,
+                               crep);
+
+        EXPECT_EQ(a,
+                  vm.get_sco_written_to_backend_action());
+    }
+
+    void
+    verify_absence_from_page_cache(Volume& v, SCO sco)
+    {
+        CachedSCOPtr csp(VolManager::get()->getSCOCache()->findSCO(v.getNamespace(),
+                                                                   sco));
+        ASSERT_TRUE(csp != nullptr);
+
+        const size_t page_size = sysconf(_SC_PAGESIZE);
+        ASSERT_LT(0,
+                  page_size);
+
+        const size_t size = csp->getSize();
+        ASSERT_EQ(0,
+                  size % page_size);
+
+        const int fd = ::open(csp->path().string().c_str(),
+                              O_RDONLY);
+
+        ASSERT_LE(0,
+                  fd);
+
+        auto close_fd(yt::make_scope_exit([&]
+                                          {
+                                              ::close(fd);
+                                          }));
+
+        void* m = ::mmap(0,
+                         size,
+                         PROT_READ,
+                         MAP_PRIVATE,
+                         fd,
+                         0);
+        ASSERT_TRUE(m != MAP_FAILED);
+
+        auto unmap_fd(yt::make_scope_exit([&]
+                                          {
+                                              ::munmap(m,
+                                                       size);
+                                          }));
+
+        std::vector<uint8_t> vec((size + page_size - 1) / page_size);
+
+        ASSERT_EQ(0,
+                  ::mincore(m,
+                            size,
+                            vec.data()));
+
+        for (auto& b : vec)
+        {
+            EXPECT_EQ(0,
+                      b);
+        }
+    }
+
+    using SCOSet = std::set<SCO>;
+
+    void
+    check_disposables_in_set(SCONameList scol,
+                             SCOSet scos)
+    {
+        for (const auto& s : scol)
+        {
+            EXPECT_EQ(1,
+                      scos.erase(s));
+        }
+
+        EXPECT_TRUE(scos.empty());
+    }
+
+    using CheckFun = std::function<void(Volume&,
+                                        SCOSet)>;
+
+    void
+    test(SCOWrittenToBackendAction a,
+         CheckFun check_fun)
+    {
+        set_action(a);
+
+        auto wrns(make_random_namespace());
+        SharedVolumePtr v(newVolume(*wrns));
+
+        const TLogMultiplier tm(v->getEffectiveTLogMultiplier());
+
+        ASSERT_NE(TLogMultiplier(0),
+                  tm);
+
+        const SCOMultiplier sm(v->getSCOMultiplier());
+        const ClusterSize cs(v->getClusterSize());
+
+        SCONameList scos;
+        SCOCache& sco_cache = *VolManager::get()->getSCOCache();
+
+        {
+            SCOPED_BLOCK_BACKEND(*v);
+
+            writeToVolume(*v,
+                          0,
+                          cs * sm * tm,
+                          "of no importance whatsoever");
+
+            sco_cache.getSCONameList(wrns->ns(),
+                                     scos,
+                                     true);
+
+            ASSERT_TRUE(scos.empty());
+
+            sco_cache.getSCONameList(wrns->ns(),
+                                     scos,
+                                     false);
+
+            ASSERT_FALSE(scos.empty());
+        }
+
+        waitForThisBackendWrite(*v);
+
+        SCOSet scoset;
+        for (const auto& s : scos)
+        {
+            auto res(scoset.insert(s));
+            ASSERT_TRUE(res.second);
+        }
+
+        // don't forget to remove the current SCO from the set:
+        ASSERT_FALSE(scoset.empty());
+        scoset.erase(*scoset.rbegin());
+
+        EXPECT_EQ(tm,
+                  scoset.size());
+
+        check_fun(*v,
+                  std::move(scoset));
+    }
 };
 
 TEST_P(SCOWrittenToBackendActionTest, enum_streaming)
@@ -64,6 +224,58 @@ TEST_P(SCOWrittenToBackendActionTest, enum_streaming_failure)
     EXPECT_TRUE(ss.fail());
     EXPECT_EQ(SCOWrittenToBackendAction::SetDisposable,
               a);
+}
+
+TEST_P(SCOWrittenToBackendActionTest, set_disposable)
+{
+    test(SCOWrittenToBackendAction::SetDisposable,
+         [&](Volume& v,
+             SCOSet scos)
+         {
+             SCONameList disposables;
+             VolManager::get()->getSCOCache()->getSCONameList(v.getNamespace(),
+                                                              disposables,
+                                                              true);
+             check_disposables_in_set(std::move(disposables),
+                                      std::move(scos));
+         });
+}
+
+TEST_P(SCOWrittenToBackendActionTest, set_disposable_and_drop_from_page_cache)
+{
+    test(SCOWrittenToBackendAction::SetDisposableAndPurgeFromPageCache,
+         [&](Volume& v,
+             SCOSet scos)
+         {
+             SCONameList disposables;
+             VolManager::get()->getSCOCache()->getSCONameList(v.getNamespace(),
+                                                              disposables,
+                                                              true);
+
+             for (const auto& sco : disposables)
+             {
+                 verify_absence_from_page_cache(v,
+                                                sco);
+             }
+
+             check_disposables_in_set(std::move(disposables),
+                                      std::move(scos));
+
+         });
+}
+
+TEST_P(SCOWrittenToBackendActionTest, purge_from_sco_cache)
+{
+    test(SCOWrittenToBackendAction::PurgeFromSCOCache,
+         [&](Volume& v,
+             SCOSet)
+         {
+             SCONameList disposables;
+             VolManager::get()->getSCOCache()->getSCONameList(v.getNamespace(),
+                                                              disposables,
+                                                              true);
+             EXPECT_TRUE(disposables.empty());
+         });
 }
 
 INSTANTIATE_TEST_CASE_P(SCOWrittenToBackendActionTests,

--- a/src/volumedriver/test/VolumeDriverConfigurationTest.cpp
+++ b/src/volumedriver/test/VolumeDriverConfigurationTest.cpp
@@ -470,7 +470,7 @@ TEST_P(VolumeDriverConfigurationTest, num_threads)
             LOG_INFO("updated: " << u.parameter_name);
         }
 
-        EXPECT_EQ(41U,
+        EXPECT_EQ(42U,
                   u_rep.no_update_size());
     }
 
@@ -491,7 +491,7 @@ TEST_P(VolumeDriverConfigurationTest, num_threads)
             std::cerr << u.parameter_name << std::endl;
         }
 
-        EXPECT_EQ(42U,
+        EXPECT_EQ(43U,
                   u_rep.no_update_size());
     }
 }

--- a/src/youtils/FileDescriptor.cpp
+++ b/src/youtils/FileDescriptor.cpp
@@ -385,4 +385,29 @@ FileDescriptor::truncate(uint64_t length)
                                     FileDescriptorException::Exception::TruncateException);
     }
 }
+
+void
+FileDescriptor::fadvise(FAdvise adv)
+{
+    int fadv = POSIX_FADV_NORMAL;
+
+    switch (adv)
+    {
+    case FAdvise::DontNeed:
+        fadv = POSIX_FADV_DONTNEED;
+        break;
+    }
+
+    ASSERT(fd_ >= 0);
+    int ret = ::posix_fadvise(fd_,
+                              0,
+                              0,
+                              fadv);
+    if (ret < 0)
+    {
+        throw FileDescriptorException(errno,
+                                      FileDescriptorException::Exception::FAdviseException);
+    }
+}
+
 }

--- a/src/youtils/FileDescriptor.h
+++ b/src/youtils/FileDescriptor.h
@@ -27,7 +27,7 @@ struct stat;
 
 namespace youtilstest
 {
-class LowLevelFileTest;
+class FileDescriptorTest;
 }
 
 namespace youtils
@@ -89,7 +89,7 @@ enum class FAdvise
 
 class FileDescriptor
 {
-    friend class youtilstest::LowLevelFileTest;
+    friend class youtilstest::FileDescriptorTest;
 
 public:
     FileDescriptor(const fs::path& path,

--- a/src/youtils/FileDescriptor.h
+++ b/src/youtils/FileDescriptor.h
@@ -25,6 +25,11 @@ BOOLEAN_ENUM(SyncOnCloseAndDestructor);
 struct statvfs;
 struct stat;
 
+namespace youtilstest
+{
+class LowLevelFileTest;
+}
+
 namespace youtils
 {
 
@@ -46,6 +51,7 @@ public:
         TruncateException,
         LockException,
         UnlockException,
+        FAdviseException,
     };
 
     FileDescriptorException(int errnum,
@@ -76,11 +82,16 @@ enum class Whence
     SeekEnd
 };
 
+enum class FAdvise
+{
+    DontNeed,
+};
 
 class FileDescriptor
 {
-public:
+    friend class youtilstest::LowLevelFileTest;
 
+public:
     FileDescriptor(const fs::path& path,
                    FDMode mode,
                    CreateIfNecessary create_if_necessary = CreateIfNecessary::F,
@@ -157,9 +168,12 @@ public:
     const fs::path&
     path() const;
 
+    void
+    fadvise(FAdvise);
 
 private:
     DECLARE_LOGGER("FileDescriptor");
+
     const fs::path path_;
     int fd_;
     const FDMode mode_;

--- a/src/youtils/test/FileDescriptorTest.cpp
+++ b/src/youtils/test/FileDescriptorTest.cpp
@@ -28,12 +28,12 @@ namespace youtilstest
 {
 using namespace youtils;
 
-class LowLevelFileTest
+class FileDescriptorTest
     : public TestBase
 {
 public:
-    LowLevelFileTest()
-        :directory_(getTempPath("LowLevelFileTest"))
+    FileDescriptorTest()
+        :directory_(getTempPath("FileDescriptorTest"))
     {}
 
     void
@@ -59,7 +59,7 @@ protected:
     fs::path directory_;
 };
 
-TEST_F(LowLevelFileTest, mixedBag)
+TEST_F(FileDescriptorTest, mixedBag)
 {
     fs::path p(directory_ / "testfile");
     EXPECT_THROW(FileDescriptor f(p, FDMode::Write),
@@ -119,7 +119,7 @@ TEST_F(LowLevelFileTest, mixedBag)
     EXPECT_EQ(2 * buf1.size() + buf2.size(), fs::file_size(p));
 }
 
-TEST_F(LowLevelFileTest, seek1)
+TEST_F(FileDescriptorTest, seek1)
 {
     fs::path p = directory_ / "testfile";
     EXPECT_THROW(FileDescriptor f(p, FDMode::Read),
@@ -140,7 +140,7 @@ TEST_F(LowLevelFileTest, seek1)
     EXPECT_EQ(f.tell(), 6);
 }
 
-TEST_F(LowLevelFileTest, locking)
+TEST_F(FileDescriptorTest, locking)
 {
     const fs::path p(directory_ / "lockfile");
     FileDescriptor f(p,
@@ -158,7 +158,7 @@ TEST_F(LowLevelFileTest, locking)
     ASSERT_FALSE(static_cast<bool>(v));
 }
 
-TEST_F(LowLevelFileTest, purge_from_page_cache)
+TEST_F(FileDescriptorTest, purge_from_page_cache)
 {
     const fs::path p(directory_ / "some_file");
     FileDescriptor f(p,

--- a/src/youtils/test/LowLevelFileTest.cpp
+++ b/src/youtils/test/LowLevelFileTest.cpp
@@ -28,9 +28,6 @@ namespace youtilstest
 {
 using namespace youtils;
 
-// the same as SimpleIO
-using TestFile = FileDescriptor;
-
 class LowLevelFileTest
     : public TestBase
 {
@@ -53,7 +50,7 @@ public:
     }
 
     static int
-    get_fd(TestFile& f)
+    get_fd(FileDescriptor& f)
     {
         return f.fd_;
     }
@@ -65,7 +62,7 @@ protected:
 TEST_F(LowLevelFileTest, mixedBag)
 {
     fs::path p(directory_ / "testfile");
-    EXPECT_THROW(TestFile f(p, FDMode::Write),
+    EXPECT_THROW(FileDescriptor f(p, FDMode::Write),
                  FileDescriptorException);
 
     std::vector<uint8_t> buf1(2048);
@@ -77,7 +74,7 @@ TEST_F(LowLevelFileTest, mixedBag)
     std::vector<uint8_t> out(4096);
 
     {
-        TestFile f(p, FDMode::Write, CreateIfNecessary::T);
+        FileDescriptor f(p, FDMode::Write, CreateIfNecessary::T);
 
         EXPECT_EQ(buf1.size(), f.write(&buf1[0], buf1.size()));
         EXPECT_THROW(f.read(&out[0], out.size()),
@@ -85,7 +82,7 @@ TEST_F(LowLevelFileTest, mixedBag)
     }
 
     {
-        TestFile g(p, FDMode::ReadWrite, CreateIfNecessary::F);
+        FileDescriptor g(p, FDMode::ReadWrite, CreateIfNecessary::F);
 
         g.seek(0, Whence::SeekEnd);
         EXPECT_EQ(buf2.size(), g.write(&buf2[0], buf2.size()));
@@ -93,7 +90,7 @@ TEST_F(LowLevelFileTest, mixedBag)
     }
 
     {
-        TestFile h(p, FDMode::Read, CreateIfNecessary::F);
+        FileDescriptor h(p, FDMode::Read, CreateIfNecessary::F);
         EXPECT_THROW(h.pwrite(&buf2[0], buf2.size(), 0),
                      FileDescriptorException);
 
@@ -125,10 +122,10 @@ TEST_F(LowLevelFileTest, mixedBag)
 TEST_F(LowLevelFileTest, seek1)
 {
     fs::path p = directory_ / "testfile";
-    EXPECT_THROW(TestFile f(p, FDMode::Read),
+    EXPECT_THROW(FileDescriptor f(p, FDMode::Read),
                  FileDescriptorException);
     FileUtils::touch(p);
-    TestFile f(p, FDMode::Read);
+    FileDescriptor f(p, FDMode::Read);
     EXPECT_THROW(f.seek(-25, Whence::SeekCur),
                  FileDescriptorException);
     EXPECT_EQ(f.tell(),0);
@@ -146,15 +143,15 @@ TEST_F(LowLevelFileTest, seek1)
 TEST_F(LowLevelFileTest, locking)
 {
     const fs::path p(directory_ / "lockfile");
-    TestFile f(p,
-               FDMode::Write,
-               CreateIfNecessary::T);
+    FileDescriptor f(p,
+                     FDMode::Write,
+                     CreateIfNecessary::T);
 
     std::unique_lock<decltype(f)> u(f);
     ASSERT_TRUE(static_cast<bool>(u));
 
-    TestFile g(p,
-               FDMode::Write);
+    FileDescriptor g(p,
+                     FDMode::Write);
 
     std::unique_lock<decltype(g)> v(g,
                                     std::try_to_lock);
@@ -164,9 +161,9 @@ TEST_F(LowLevelFileTest, locking)
 TEST_F(LowLevelFileTest, purge_from_page_cache)
 {
     const fs::path p(directory_ / "some_file");
-    TestFile f(p,
-               FDMode::ReadWrite,
-               CreateIfNecessary::T);
+    FileDescriptor f(p,
+                     FDMode::ReadWrite,
+                     CreateIfNecessary::T);
 
     const size_t page_size = ::sysconf(_SC_PAGESIZE);
     ASSERT_LT(0,

--- a/src/youtils/test/Makefile.am
+++ b/src/youtils/test/Makefile.am
@@ -38,6 +38,7 @@ youtils_test_SOURCES = \
 	EtcdReplyTest.cpp \
 	EtcdUrlTest.cpp \
 	FileRangeTest.cpp \
+	FileDescriptorTest.cpp \
 	FileUtilsTest.cpp \
 	GeneratorTest.cpp \
 	GlobalLockTest.cpp \
@@ -47,7 +48,6 @@ youtils_test_SOURCES = \
 	InitializedParamTest.cpp \
 	LocORemTest.cpp \
 	LoggingTest.cpp \
-	LowLevelFileTest.cpp \
 	LRUCacheTest.cpp \
 	LRUCacheTooTest.cpp \
 	main.cpp \


### PR DESCRIPTION
Control how local copies of SCOs that are safely written to the backend are handled:
* mark as disposable and keep in SCO cache: current behaviour, default
* mark as disposable and keep in SCO cache but purge from page cache (if present)
* remove from SCO cache
