### PR TITLE
DTL: revise corking when retrieving entries / SCOs

### DIFF
--- a/src/volumedriver/FailOverCacheProxy.cpp
+++ b/src/volumedriver/FailOverCacheProxy.cpp
@@ -195,7 +195,7 @@ FailOverCacheProxy::getEntries(SCOProcessorFun processor)
     OUT_ENUM(*stream_, GetEntries);
     *stream_ << fungi::IOBaseStream::uncork;
 
-    getObject_(processor);
+    getObject_(processor, true);
 }
 
 uint64_t
@@ -206,17 +206,28 @@ FailOverCacheProxy::getSCOFromFailOver(SCO a,
     OUT_ENUM(*stream_, GetSCO);
     *stream_ << a;
     *stream_ << fungi::IOBaseStream::uncork;
-    return getObject_(processor);
+    return getObject_(processor, false);
 }
 
 uint64_t
-FailOverCacheProxy::getObject_(SCOProcessorFun processor)
+FailOverCacheProxy::getObject_(SCOProcessorFun processor,
+                               bool cork_per_cluster)
 {
     fungi::Buffer buf;
-    *stream_ >> fungi::IOBaseStream::cork;
     uint64_t ret = 0;
+
+    if (not cork_per_cluster)
+    {
+        *stream_ >> fungi::IOBaseStream::cork;
+    }
+
     while (true)
     {
+        if (cork_per_cluster)
+        {
+            *stream_ >> fungi::IOBaseStream::cork;
+        }
+
         ClusterLocation cli;
         *stream_ >> cli;
         if(cli.isNull())

--- a/src/volumedriver/FailOverCacheProxy.h
+++ b/src/volumedriver/FailOverCacheProxy.h
@@ -92,7 +92,8 @@ private:
     checkStreamOK(const std::string& ex);
 
     uint64_t
-    getObject_(SCOProcessorFun processor);
+    getObject_(SCOProcessorFun,
+               bool cork_per_cluster);
 
     fungi::Socket* socket_;
     fungi :: IOBaseStream *stream_;

--- a/src/volumedriver/failovercache/FailOverCacheProtocol.cpp
+++ b/src/volumedriver/failovercache/FailOverCacheProtocol.cpp
@@ -322,24 +322,20 @@ FailOverCacheProtocol::Clear_()
 
 void
 FailOverCacheProtocol::processFailOverCacheEntry(volumedriver::ClusterLocation cli,
-                                         int64_t lba,
-                                         const byte* buf,
-                                         int64_t size)
+                                                 int64_t lba,
+                                                 const byte* buf,
+                                                 int64_t size)
 {
     // Y42 better logging here
     LOG_TRACE("Sending Entry for lba " << lba );
-    if (use_rs_) // make small but finished packets with RDMA
-    {
-        *stream_ << fungi::IOBaseStream::cork;
-    }
+    *stream_ << fungi::IOBaseStream::cork;
+
     *stream_ << cli;
     *stream_ << lba;
     const fungi::WrapByteArray a((byte*)buf, (int32_t)size);
     *stream_ << a;
-    if (use_rs_) // make small but finished packets with RDMA
-    {
-        *stream_ << fungi::IOBaseStream::uncork;
-    }
+
+    *stream_ << fungi::IOBaseStream::uncork;
 }
 
 void
@@ -380,6 +376,7 @@ FailOverCacheProtocol::getEntries_()
     {
         try
         {
+            *stream_ << fungi::IOBaseStream::cork;
             volumedriver::ClusterLocation end_cli;
             *stream_ << end_cli;
             *stream_ << fungi::IOBaseStream::uncork;
@@ -395,7 +392,6 @@ FailOverCacheProtocol::getEntries_()
         }
 
     } BOOST_SCOPE_EXIT_END;
-    *stream_ << fungi::IOBaseStream::cork;
     cache_->getEntries(this);
 }
 
@@ -412,7 +408,6 @@ FailOverCacheProtocol::getSCO_()
     {
         try
         {
-
             volumedriver::ClusterLocation end_cli;
             *stream_ << end_cli;
             *stream_ << fungi::IOBaseStream::uncork;

--- a/src/volumedriver/failovercache/test/failovercache_tester.cpp
+++ b/src/volumedriver/failovercache/test/failovercache_tester.cpp
@@ -626,4 +626,48 @@ TEST_F(FailOverCacheTest, Stress)
     }
 }
 
+// https://github.com/openvstorage/volumedriver/issues/19 :
+// The corking mechanism lead to too many clusters being queued up on the sender
+// (server side), which eventually complained with std::bad_alloc when trying to
+// send yet another one.
+TEST_F(FailOverCacheTest, get_entries_xxl)
+{
+    const LBASize lba_size(512);
+    const ClusterMultiplier cmult(8);
+    const ClusterSize csize(lba_size * cmult);
+
+    FailOverCacheProxy
+        cache(FailOverCacheTestMain::failovercache_config(),
+              FailOverCacheTestMain::ns(),
+              csize,
+              300);
+
+    const SCOMultiplier smult(4096);
+
+    FailOverCacheEntryFactory factory(csize,
+                                      smult);
+
+    const size_t test_size = 2ULL << 30;
+    const size_t count = test_size / csize;
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        ClusterLocation loc;
+        std::vector<FailOverCacheEntry> vec = { factory(loc), };
+        cache.addEntries(std::move(vec));
+    }
+
+    size_t seen = 0;
+    cache.getEntries([&](ClusterLocation,
+                         uint64_t,
+                         const uint8_t*,
+                         size_t)
+                     {
+                         ++seen;
+                     });
+
+    EXPECT_EQ(count,
+              seen);
+}
+
 }


### PR DESCRIPTION
... to prevent std::bad_alloc being thrown if too many entries end up
inside the cork.

Addresses #19 .