### PR TITLE
Feature/etcd get with quorum

### DIFF
--- a/src/filesystem/ConfigFetcher.cpp
+++ b/src/filesystem/ConfigFetcher.cpp
@@ -76,7 +76,8 @@ ConfigFetcher::operator()(VerifyConfig verify_config)
         etcd::Client<yt::EtcdReply> client(etcd_url->host,
                                            etcd_url->port);
 
-        const yt::EtcdReply reply(client.Get(etcd_url->key));
+        const yt::EtcdReply reply(client.Get(etcd_url->key,
+                                             true));
         const boost::optional<yt::EtcdReply::Error> err(reply.error());
         if (err)
         {


### PR DESCRIPTION
Set `quorum=true` when getting values out of etcd to avoid reading outdated data (at the expense of more overhead).

Manual testing:

`tcpdump -s 0 -A port 2379 -i lo | grep quorum`
`[...]`
`...N...NGET /v2/keys/ovs/framework/messagequeue?quorum=true HTTP/1.1`
`........GET /v2/keys/ovs/vpools/93168b00-ceca-4cbd-aec4-bb3faf929139/hosts/ar-pools0z0QTxO57RGeLDZ/config?quorum=true HTTP/1.1`
`[...]`

The last line originates from retrieving the config when instantiating a `LocalStorageRouterClient` in the Python API:
`In [1]: import storagerouterclient as src`
` `
`In [2]: client = src.LocalStorageRouterClient('etcd://127.0.0.1:2379/ovs/vpools/93168b00-ceca-4cbd-aec4-bb3faf929139/hosts/ar-pools0z0QTxO57RGeLDZ/config')`
