### PR TITLE
Feature/ovs log format

### DIFF
--- a/src/youtils/Logger.cpp
+++ b/src/youtils/Logger.cpp
@@ -170,7 +170,7 @@ redis_log_formatter(const bl::record_view& rec,
     const time_type& the_time =
         bl::extract_or_throw<time_type>(timestamp_key, rec);
     static const char* time_format_tpl =
-        "%4.4d-%2.2d-%2.2d %2.2d:%2.2d:%2.2d %6.6d %+02.2d%02.2d %s";
+        "%4.4d-%2.2d-%2.2d %2.2d:%2.2d:%2.2d %6.6d %+02.2d%02.2d";
     char tsbuf[128];
     struct tm bt;
     localtime_r(&the_time.tv_sec, &bt);
@@ -186,12 +186,14 @@ redis_log_formatter(const bl::record_view& rec,
              the_time.tv_usec,
              // #warning "check this time zone conversion for negative numbers"
              bt.tm_gmtoff / 3600,
-             (bt.tm_gmtoff % 3600) / 60,
-             bt.tm_zone);
+             (bt.tm_gmtoff % 3600) / 60);
 
     static const pid_t pid(::getpid());
     static const std::string hostname(boost::asio::ip::host_name());
     static uint64_t seqnum = 0;
+
+    std::stringstream sseq;
+    sseq << std::hex << std::setw(8) << std::setfill('0') << seqnum++;
 
     os <<
         tsbuf <<
@@ -207,7 +209,7 @@ redis_log_formatter(const bl::record_view& rec,
         bl::extract_or_throw<LOGGER_ATTRIBUTE_ID_TYPE>(LOGGER_ATTRIBUTE_ID,
                                                        rec) <<
         sep <<
-        seqnum++ <<
+        sseq.str() <<
         sep <<
         bl::extract_or_throw<Severity>("Severity", rec) <<
         sep <<

--- a/src/youtils/Logger.cpp
+++ b/src/youtils/Logger.cpp
@@ -162,8 +162,8 @@ default_log_formatter(const bl::record_view& rec,
 }
 
 void
-redis_log_formatter(const bl::record_view& rec,
-                    bl::formatting_ostream& os)
+ovs_log_formatter(const bl::record_view& rec,
+                  bl::formatting_ostream& os)
 {
     static const char* sep = " - ";
 
@@ -355,7 +355,7 @@ make_console_sink()
     boost::shared_ptr<std::ostream> stream(&std::clog,
                                            boost::null_deleter());
     sink->locked_backend()->add_stream(stream);
-    sink->set_formatter(&default_log_formatter);
+    sink->set_formatter(&ovs_log_formatter);
 
     return sink;
 }
@@ -389,7 +389,7 @@ make_file_sink(const fs::path& fname,
 
     using FileSink = bl::sinks::synchronous_sink<bl::sinks::text_file_backend>;
     auto sink(boost::make_shared<FileSink>(backend));
-    sink->set_formatter(&default_log_formatter);
+    sink->set_formatter(&ovs_log_formatter);
 
     return sink;
 }
@@ -403,7 +403,7 @@ make_redis_sink(const RedisUrl& url)
     using RedisSink = bl::sinks::asynchronous_sink<RedisBackend,
           bl::sinks::bounded_fifo_queue<100, bl::sinks::drop_on_overflow>>;
     auto sink(boost::make_shared<RedisSink>(backend));
-    sink->set_formatter(&redis_log_formatter);
+    sink->set_formatter(&ovs_log_formatter);
     return sink;
 }
 


### PR DESCRIPTION
FR #31 : use the OVS standard log format (fixed bugs in the voldrv's implementation of it while at it) not only for logging to redis but also when logging to file / console. Random example:

```
2016-06-01 16:07:16 985541 +0200 - blackadder - 20079/0x00007fa6128d3780 - youtils_test/ArakoonTestSetup - 00000002 - info - start_nodes: Started arakoon /usr/bin/arakoon
```