### PR TITLE
Feature/sco cache async namespace removal

### DIFF
--- a/src/volumedriver/CachedSCO.cpp
+++ b/src/volumedriver/CachedSCO.cpp
@@ -26,29 +26,28 @@
 #include "SCOCacheNamespace.h"
 #include "SCOCache.h"
 #include "OpenSCO.h"
-#include <boost/interprocess/detail/atomic.hpp>
+
 namespace volumedriver
 {
-
-namespace bid = boost::interprocess::ipcdetail;
 
 void
 intrusive_ptr_add_ref(CachedSCO* sco)
 {
-    bid::atomic_inc32(&sco->refcnt_);
+    sco->refcnt_++;
 }
 
 void
 intrusive_ptr_release(CachedSCO* sco)
 {
-    // ...::atomic_dec32() (and ..::atomic_inc32() too) returns the old value!
-    if (bid::atomic_dec32(&sco->refcnt_) == 1)
+    if (sco and --sco->refcnt_ == 0)
     {
         delete sco;
     }
 }
 
-namespace {
+namespace
+{
+
 const std::string
 makeFileName(const Namespace& nsName,
              SCO scoName,
@@ -58,6 +57,7 @@ makeFileName(const Namespace& nsName,
     p /= scoName.str();
     return p.string();
 }
+
 }
 
 CachedSCO::CachedSCO(SCOCacheNamespace* nspace,
@@ -261,7 +261,7 @@ CachedSCO::incRefCount(uint32_t num)
 uint32_t
 CachedSCO::use_count()
 {
-    return bid::atomic_read32(&refcnt_);
+    return refcnt_;
 }
 
 void

--- a/src/volumedriver/CachedSCO.cpp
+++ b/src/volumedriver/CachedSCO.cpp
@@ -128,17 +128,10 @@ CachedSCO::~CachedSCO()
     {
         try
         {
-            fs::remove(path_);
+            mntPoint_->addToGarbage(path_);
             mntPoint_->updateUsedSize(-size_);
         }
-        catch (std::exception& e)
-        {
-            LOG_ERROR("Failed to unlink " << path_ << ": " << e.what());
-        }
-        catch (...)
-        {
-            LOG_ERROR("Failed to unlink " << path_ << ": unknown exception");
-        }
+        CATCH_STD_ALL_LOG_IGNORE("Failed to add " << path_ << " to garbage");
     }
 }
 

--- a/src/volumedriver/CachedSCO.cpp
+++ b/src/volumedriver/CachedSCO.cpp
@@ -13,6 +13,12 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
+#include "CachedSCO.h"
+#include "OpenSCO.h"
+#include "SCOCache.h"
+#include "SCOCacheMountPoint.h"
+#include "SCOCacheNamespace.h"
+
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -21,14 +27,10 @@
 
 #include <youtils/IOException.h>
 
-#include "CachedSCO.h"
-#include "SCOCacheMountPoint.h"
-#include "SCOCacheNamespace.h"
-#include "SCOCache.h"
-#include "OpenSCO.h"
-
 namespace volumedriver
 {
+
+namespace yt = youtils;
 
 void
 intrusive_ptr_add_ref(CachedSCO* sco)
@@ -247,9 +249,10 @@ CachedSCO::getMountPoint()
 }
 
 OpenSCOPtr
-CachedSCO::open(FDMode mode)
+CachedSCO::open(yt::FDMode mode)
 {
-    return OpenSCOPtr(new OpenSCO(this, mode));
+    return OpenSCOPtr(new OpenSCO(this,
+                                  mode));
 }
 
 void

--- a/src/volumedriver/CachedSCO.h
+++ b/src/volumedriver/CachedSCO.h
@@ -27,8 +27,6 @@
 namespace volumedriver
 {
 
-using youtils::FDMode;
-
 class SCOCacheMountPoint;
 class SCOCacheNamespace;
 
@@ -70,7 +68,7 @@ public:
     setXVal(float);
 
     OpenSCOPtr
-    open(FDMode mode);
+    open(youtils::FDMode mode);
 
     void
     incRefCount(uint32_t num);

--- a/src/volumedriver/CachedSCO.h
+++ b/src/volumedriver/CachedSCO.h
@@ -21,8 +21,8 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/intrusive/set.hpp>
+
 #include <youtils/FileDescriptor.h>
-#include <youtils/SpinLock.h>
 
 namespace volumedriver
 {

--- a/src/volumedriver/CachedSCO.h
+++ b/src/volumedriver/CachedSCO.h
@@ -20,7 +20,6 @@
 #include "Types.h"
 
 #include <boost/filesystem.hpp>
-#include <boost/interprocess/detail/atomic.hpp>
 #include <boost/intrusive/set.hpp>
 #include <youtils/FileDescriptor.h>
 #include <youtils/SpinLock.h>
@@ -96,7 +95,7 @@ private:
     float xVal_;
     bool disposable_;
     bool unlink_on_destruction_;
-    volatile boost::uint32_t refcnt_;
+    std::atomic<uint32_t> refcnt_;
 
     // protect the following four from being called arbitrarily in the code:
     //

--- a/src/volumedriver/CachedSCO.h
+++ b/src/volumedriver/CachedSCO.h
@@ -81,13 +81,13 @@ public:
     void
     remove();
 
-    const fs::path&
+    const boost::filesystem::path&
     path() const;
 
 private:
     DECLARE_LOGGER("CachedSCO");
 
-    const fs::path path_;
+    const boost::filesystem::path path_;
     SCOCacheNamespace* const nspace_;
     SCO scoName_;
     SCOCacheMountPointPtr mntPoint_;
@@ -103,7 +103,7 @@ private:
     CachedSCO(SCOCacheNamespace* nspace,
               SCO scoName,
               SCOCacheMountPointPtr mntPoint,
-              const fs::path& path);
+              const boost::filesystem::path& path);
 
     // - create a new SCO, only allowed from SCOCacheMountPoint
     CachedSCO(SCOCacheNamespace* nspace,

--- a/src/volumedriver/CachedSCO.h
+++ b/src/volumedriver/CachedSCO.h
@@ -28,7 +28,6 @@
 namespace volumedriver
 {
 
-namespace bi = boost::intrusive;
 using youtils::FDMode;
 
 class SCOCacheMountPoint;
@@ -38,7 +37,7 @@ class SCOCacheNamespace;
 typedef boost::intrusive_ptr<SCOCacheMountPoint> SCOCacheMountPointPtr;
 
 class CachedSCO
-    : public bi::set_base_hook<bi::link_mode<bi::auto_unlink> >
+    : public boost::intrusive::set_base_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink> >
 {
     friend class SCOCacheMountPoint;
     friend class CachedSCOTest;

--- a/src/volumedriver/SCOCache.cpp
+++ b/src/volumedriver/SCOCache.cpp
@@ -140,8 +140,7 @@ SCOCache::~SCOCache()
 
 }
 
-
-namespace arne
+namespace
 {
 
 class MountPointOfflinedChecker
@@ -289,7 +288,7 @@ SCOCache::initMountPoints_()
 
     // init new mountpoints:
     {
-        arne::NewMountPointInitialiser init(mpErrorCount_);
+        NewMountPointInitialiser init(mpErrorCount_);
         newOnes.remove_if(init);
     }
 
@@ -297,16 +296,16 @@ SCOCache::initMountPoints_()
 
     // drop duplicates:
     {
-        arne::MountPointCompare cmp;
+        MountPointCompare cmp;
         mountPoints_.sort(cmp);
 
-        arne::MountPointDupChecker chk;
+        MountPointDupChecker chk;
         mountPoints_.unique(chk);
     }
 
     // drop previously offlined mountpoints:
     {
-        arne::MountPointOfflinedChecker chk(mpErrorCount_);
+        MountPointOfflinedChecker chk(mpErrorCount_);
         mountPoints_.remove_if(chk);
     }
 
@@ -323,7 +322,6 @@ SCOCache::initMountPoints_()
         throw fungi::IOException("no sco cache mountpoints available");
     }
 }
-
 
 void
 SCOCache::destroy_()

--- a/src/volumedriver/SCOCacheMountPoint.cpp
+++ b/src/volumedriver/SCOCacheMountPoint.cpp
@@ -34,6 +34,8 @@
 namespace volumedriver
 {
 
+namespace bu = boost::uuids;
+namespace fs = boost::filesystem;
 namespace yt = youtils;
 
 #define USED_LOCK()                             \

--- a/src/volumedriver/SCOCacheMountPoint.cpp
+++ b/src/volumedriver/SCOCacheMountPoint.cpp
@@ -36,19 +36,17 @@ namespace volumedriver
 #define USED_LOCK()                             \
     fungi::ScopedSpinLock __l(usedLock_)
 
-namespace bid = boost::interprocess::ipcdetail;
-
 void
 intrusive_ptr_add_ref(SCOCacheMountPoint* mp)
 {
-    bid::atomic_inc32(&mp->refcnt_);
+    ASSERT(mp);
+    ++mp->refcnt_;
 }
 
 void
 intrusive_ptr_release(SCOCacheMountPoint* mp)
 {
-    // ...::atomic_dec32() (and ..::atomic_inc32() too) returns the old value!
-    if (bid::atomic_dec32(&mp->refcnt_) == 1)
+    if (mp and --mp->refcnt_ == 0)
     {
         delete mp;
     }

--- a/src/volumedriver/SCOCacheMountPoint.h
+++ b/src/volumedriver/SCOCacheMountPoint.h
@@ -21,7 +21,6 @@
 #include <list>
 
 #include <boost/filesystem.hpp>
-#include <boost/interprocess/detail/atomic.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/serialization/utility.hpp>
 
@@ -131,7 +130,7 @@ private:
     const fs::path path_;
     uint64_t capacity_;
     uint64_t used_;
-    volatile boost::uint32_t refcnt_;
+    std::atomic<uint32_t> refcnt_;
     boost::optional<uint32_t> choking_;
     bool offline_;
     bu::uuid uuid_;

--- a/src/volumedriver/SCOCacheMountPoint.h
+++ b/src/volumedriver/SCOCacheMountPoint.h
@@ -33,9 +33,6 @@
 namespace volumedriver
 {
 
-namespace fs = boost::filesystem;
-namespace bu = boost::uuids;
-
 class SCOCache;
 class SCOCacheNamespace;
 
@@ -55,7 +52,7 @@ public:
     void
     newMountPointStage2(uint64_t errcount);
 
-    const bu::uuid&
+    const boost::uuids::uuid&
     uuid() const;
 
     void
@@ -64,7 +61,7 @@ public:
     uint64_t
     getErrorCount() const;
 
-    const fs::path&
+    const boost::filesystem::path&
     getPath() const;
 
     uint64_t
@@ -131,14 +128,14 @@ private:
 
     mutable fungi::SpinLock usedLock_;
     SCOCache& scoCache_;
-    const fs::path path_;
-    const fs::path garbage_path_;
+    const boost::filesystem::path path_;
+    const boost::filesystem::path garbage_path_;
     uint64_t capacity_;
     uint64_t used_;
     std::atomic<uint32_t> refcnt_;
     boost::optional<uint32_t> choking_;
     bool offline_;
-    bu::uuid uuid_;
+    boost::uuids::uuid uuid_;
     uint64_t errcount_;
     bool initialised_;
     std::unique_ptr<youtils::DeferredFileRemover> deferred_file_remover_;
@@ -175,7 +172,7 @@ private:
     friend void
     intrusive_ptr_release(SCOCacheMountPoint*);
 
-    fs::path
+    boost::filesystem::path
     lockFilePath_() const;
 
     void

--- a/src/volumedriver/test/CachedSCOTest.cpp
+++ b/src/volumedriver/test/CachedSCOTest.cpp
@@ -56,8 +56,8 @@ public:
 
 
 protected:
-    virtual void
-    SetUp()
+    void
+    SetUp() override final
     {
         throttle_usecs = 1000;
         SCOCacheTestSetup::SetUp();
@@ -81,7 +81,7 @@ protected:
         PARAMETER_TYPE(trigger_gap)(yt::DimensionedValue(1)).persist(pt);
         PARAMETER_TYPE(backoff_gap)(yt::DimensionedValue(1)).persist(pt);
 
-        scoCache_.reset(new SCOCache(pt));
+        scoCache_ = std::make_unique<SCOCache>(pt);
 
         scoCache_->addNamespace(nspace_,
                                 0,
@@ -90,9 +90,16 @@ protected:
     }
 
     void
+    TearDown() override final
+    {
+        stopSCOCache();
+        SCOCacheTestSetup::TearDown();
+    }
+
+    void
     stopSCOCache()
     {
-        scoCache_.reset(0);
+        scoCache_ = nullptr;
     }
 
     CachedSCOPtr

--- a/src/volumedriver/test/SCOCacheConstructorTest.cpp
+++ b/src/volumedriver/test/SCOCacheConstructorTest.cpp
@@ -32,19 +32,6 @@ public:
     {}
 
 protected:
-    virtual void
-    SetUp()
-    {
-        SCOCacheTestSetup::SetUp();
-    }
-
-    virtual void
-    TearDown()
-    {
-        SCOCacheTestSetup::TearDown();
-    }
-    // temporary helper code
-
     std::atomic<uint32_t> throttling;
 };
 

--- a/src/volumedriver/test/SCOCacheTest.cpp
+++ b/src/volumedriver/test/SCOCacheTest.cpp
@@ -58,8 +58,8 @@ public:
 protected:
     DECLARE_LOGGER("SCOCacheTest");
 
-    virtual void
-    SetUp()
+    void
+    SetUp() override final
     {
         SCOCacheTestSetup::SetUp();
 
@@ -85,9 +85,10 @@ protected:
         scoCache_ = std::make_unique<SCOCache>(pt);
     }
 
-    virtual void
-    TearDown()
+    void
+    TearDown() override final
     {
+        scoCache_ = nullptr;
         SCOCacheTestSetup::TearDown();
     }
 

--- a/src/volumedriver/test/SCOCacheTestSetup.h
+++ b/src/volumedriver/test/SCOCacheTestSetup.h
@@ -40,7 +40,7 @@ protected:
     {}
 
     virtual void
-    SetUp()
+    SetUp() override
     {
         const std::string s(testing::UnitTest::GetInstance()->current_test_info()->test_case_name());
         pathPfx_ = getTempPath(s);
@@ -51,7 +51,7 @@ protected:
     }
 
     virtual void
-    TearDown()
+    TearDown() override
     {
         uninitialize_connection_manager();
         fs::remove_all(pathPfx_);

--- a/src/youtils/DeferredFileRemover.cpp
+++ b/src/youtils/DeferredFileRemover.cpp
@@ -1,0 +1,137 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#include "Catchers.h"
+#include "DeferredFileRemover.h"
+#include "ScopeExit.h"
+#include "UUID.h"
+
+namespace youtils
+{
+
+#define LOCK()                                  \
+    boost::lock_guard<decltype(lock_)> lg__(lock_)
+
+namespace fs = boost::filesystem;
+
+DeferredFileRemover::DeferredFileRemover(const fs::path& path)
+    : path_(path)
+    , state_(State::Work)
+{
+    fs::create_directories(path_);
+
+    thread_ = boost::thread(boost::bind(&DeferredFileRemover::work_,
+                                        this));
+}
+
+DeferredFileRemover::~DeferredFileRemover()
+{
+    try
+    {
+        {
+            LOCK();
+            state_ = State::Stop;
+            cond_.notify_all();
+        }
+
+        thread_.join();
+    }
+    CATCH_STD_ALL_LOG_IGNORE(path_ << ": failed to stop instance");
+}
+
+void
+DeferredFileRemover::schedule_removal(const fs::path& from)
+{
+    const fs::path to(path_ / UUID().str());
+    fs::rename(from,
+               to);
+
+    LOCK();
+    state_ = State::Work;
+    cond_.notify_all();
+}
+
+void
+DeferredFileRemover::work_()
+{
+    try
+    {
+        while (true)
+        {
+            boost::unique_lock<decltype(lock_)> u(lock_);
+            switch (state_)
+            {
+            case State::Idle:
+                {
+                    caller_cond_.notify_all();
+                    cond_.wait(u,
+                               [&]
+                               {
+                                   return state_ != State::Idle;
+                               });
+                    break;
+                }
+            case State::Work:
+                {
+                    state_ = State::Idle;
+                    u.unlock();
+
+                    auto lock_again(make_scope_exit([&]
+                                                    {
+                                                        u.lock();
+                                                    }));
+
+                    collect_garbage_();
+                    break;
+                }
+            case State::Stop:
+                caller_cond_.notify_all();
+                return;
+            }
+        }
+    }
+    CATCH_STD_ALL_EWHAT({
+            LOG_ERROR(path_ << ": collector thread caught exception: " << EWHAT << " - exiting");
+        });
+}
+
+void
+DeferredFileRemover::collect_garbage_()
+{
+    const fs::directory_iterator end;
+    for (fs::directory_iterator it(path_); it != end; ++it)
+    {
+        try
+        {
+            fs::remove(it->path());
+        }
+        CATCH_STD_ALL_LOG_IGNORE("Failed to remove " << it->path());
+    }
+}
+
+void
+DeferredFileRemover::wait_for_completion_()
+{
+    boost::unique_lock<decltype(lock_)> u(lock_);
+    caller_cond_.wait(u,
+                      [&]
+                      {
+                          return
+                              state_ == State::Idle or
+                              state_ == State::Stop;
+                      });
+}
+
+}

--- a/src/youtils/DeferredFileRemover.h
+++ b/src/youtils/DeferredFileRemover.h
@@ -1,0 +1,89 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#ifndef DEFERRED_FILE_REMOVER_H_
+#define DEFERRED_FILE_REMOVER_H_
+
+#include "Logging.h"
+
+#include <boost/filesystem.hpp>
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/thread.hpp>
+
+namespace youtilstest
+{
+
+class DeferredFileRemoverTest;
+
+}
+
+namespace youtils
+{
+
+class DeferredFileRemover
+{
+public:
+    explicit DeferredFileRemover(const boost::filesystem::path&);
+
+    ~DeferredFileRemover();
+
+    DeferredFileRemover(const DeferredFileRemover&) = delete;
+
+    DeferredFileRemover&
+    operator=(const DeferredFileRemover&) = delete;
+
+    void
+    schedule_removal(const boost::filesystem::path&);
+
+    boost::filesystem::path
+    path() const
+    {
+        return path_;
+    }
+
+private:
+    DECLARE_LOGGER("DeferredFileRemover");
+
+    enum class State
+    {
+        Idle,
+        Work,
+        Stop
+    };
+
+    boost::filesystem::path path_;
+    boost::mutex lock_;
+    boost::condition_variable cond_;
+    boost::condition_variable caller_cond_;
+    State state_;
+    boost::thread thread_;
+
+    friend class youtilstest::DeferredFileRemoverTest;
+
+    // not bulletproof against newly added work; only for testing purposes.
+    void
+    wait_for_completion_();
+
+    void
+    work_();
+
+    void
+    collect_garbage_();
+};
+
+}
+
+#endif // !DEFERRED_FILE_REMOVER_H_

--- a/src/youtils/Makefile.am
+++ b/src/youtils/Makefile.am
@@ -55,6 +55,7 @@ libyoutils_la_SOURCES = \
 	ConfigurationReport.cpp \
 	CorbaTestSetup.cpp \
 	cpu_timer.cpp \
+	DeferredFileRemover.cpp \
 	DimensionedValue.cpp \
 	EtcdUrl.cpp \
 	EtcdReply.cpp \

--- a/src/youtils/test/DeferredFileRemoverTest.cpp
+++ b/src/youtils/test/DeferredFileRemoverTest.cpp
@@ -1,0 +1,208 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#include "../DeferredFileRemover.h"
+#include "../FileDescriptor.h"
+#include "../FileUtils.h"
+#include "../System.h"
+#include "../TestBase.h"
+#include "../Timer.h"
+#include "../UUID.h"
+
+#include <boost/lexical_cast.hpp>
+
+namespace youtilstest
+{
+
+using namespace youtils;
+namespace fs = boost::filesystem;
+
+class DeferredFileRemoverTest
+    : public TestBase
+{
+public:
+    DeferredFileRemoverTest()
+        : root_(getTempPath("DeferredFileRemoverTest"))
+    {}
+
+    virtual void
+    SetUp()
+    {
+        fs::remove_all(root_);
+        fs::create_directories(root_);
+    }
+
+    virtual void
+    TearDown()
+    {
+        fs::remove_all(root_);
+    }
+
+    std::tuple<std::vector<fs::path>, size_t>
+    fill()
+    {
+        const size_t num_files = System::get_env_with_default("DEFERRED_FILE_REMOVER_TEST_NUM_FILES",
+                                                              100ULL);
+        const size_t file_size = System::get_env_with_default("DEFERRED_FILE_REMOVER_TEST_FILE_SIZE",
+                                                              1ULL << 20);
+
+        return std::make_pair(fill(num_files,
+                                   file_size),
+                              file_size);
+    }
+
+    std::vector<fs::path>
+    fill(const size_t num_files,
+         const size_t file_size)
+    {
+        const std::vector<uint8_t> wbuf(file_size, 'q');
+        std::vector<fs::path> paths;
+        paths.reserve(num_files);
+
+        for (size_t i = 0; i < num_files; ++i)
+        {
+            paths.emplace_back(root_ / boost::lexical_cast<std::string>(i));
+            FileDescriptor fd(paths.back(),
+                              FDMode::Write,
+                              CreateIfNecessary::T);
+            EXPECT_EQ(wbuf.size(),
+                      fd.write(wbuf.data(),
+                               wbuf.size()));
+        }
+
+        return paths;
+    }
+
+    void
+    wait(DeferredFileRemover& remover)
+    {
+        remover.wait_for_completion_();
+    }
+
+    using RemoveFun = std::function<void(const std::vector<fs::path>&)>;
+
+    void
+    perf(RemoveFun fun)
+    {
+        std::vector<fs::path> paths;
+        size_t file_size = 0;
+
+        std::tie(paths, file_size) = fill();
+
+        SteadyTimer t;
+        fun(paths);
+
+        auto elapsed = t.elapsed();
+        std::cout << "removing " << paths.size() <<
+            " files of " << file_size <<
+            " bytes took " << elapsed << std::endl;
+    }
+
+protected:
+    const fs::path root_;
+};
+
+TEST_F(DeferredFileRemoverTest, basics)
+{
+    const std::vector<fs::path> paths(fill(1, 1ULL << 10));
+    ASSERT_EQ(1, paths.size());
+
+    const fs::directory_iterator end;
+
+    bool found = false;
+    for (fs::directory_iterator it(root_); it != end; ++it)
+    {
+        ASSERT_EQ(paths.front(),
+                  it->path());
+        found = true;
+    }
+
+    ASSERT_TRUE(found);
+
+    const fs::path garbage_path(root_ / "garbage");
+    {
+        DeferredFileRemover remover(garbage_path);
+        remover.schedule_removal(paths.front());
+        wait(remover);
+    }
+
+    std::vector<fs::path> paths2;
+    for (fs::directory_iterator it(root_); it != end; ++it)
+    {
+        paths2.emplace_back(it->path());
+    }
+
+    ASSERT_EQ(1,
+              paths2.size());
+    ASSERT_EQ(garbage_path,
+              paths2.front());
+
+    ASSERT_TRUE(fs::is_directory(garbage_path));
+    ASSERT_TRUE(fs::is_empty(garbage_path));
+}
+
+TEST_F(DeferredFileRemoverTest, restart)
+{
+    const fs::path p(root_ / "garbage");
+    fs::create_directories(p);
+
+    for (size_t i = 0; i < 100; ++i)
+    {
+        FileUtils::touch(p / boost::lexical_cast<std::string>(i));
+    }
+
+    ASSERT_FALSE(fs::is_empty(p));
+
+    DeferredFileRemover remover(p);
+    wait(remover);
+
+    ASSERT_TRUE(fs::is_empty(p));
+}
+
+TEST_F(DeferredFileRemoverTest, direct_removal_performance)
+{
+    perf([&](const std::vector<fs::path>& paths)
+         {
+             for (const auto& p : paths)
+             {
+                 fs::remove(p);
+             }
+         });
+}
+
+TEST_F(DeferredFileRemoverTest, remover_removal_performance)
+{
+    // keep in mind that this includes the setup cost
+    perf([&](const std::vector<fs::path>&)
+         {
+             DeferredFileRemover r(root_);
+             wait(r);
+         });
+}
+
+TEST_F(DeferredFileRemoverTest, deferred_removal_performance)
+{
+    DeferredFileRemover remover(root_ / "garbage");
+
+    perf([&](const std::vector<fs::path>& paths)
+         {
+             for (const auto& p : paths)
+             {
+                 remover.schedule_removal(p);
+             }
+         });
+}
+
+}

--- a/src/youtils/test/Makefile.am
+++ b/src/youtils/test/Makefile.am
@@ -32,6 +32,7 @@ youtils_test_SOURCES = \
 	BooleanEnumTest.cpp \
 	CheckSumTest.cpp \
 	ChooserTest.cpp \
+	DeferredFileRemoverTest.cpp \
 	DenyLockService.cpp \
 	DimensionedValueTest.cpp \
 	EtcdReplyTest.cpp \


### PR DESCRIPTION
At the heart of this PR is a change that should speed up the shutdown of a volume (e.g. during migration) by removing the data from the SCO cache asynchronously: the SCOs are simply moved out of the way to another directory where an async process will take care of finally removing them

Microbenchmark is included, with a random test output from jenkins:
```
[ RUN      ] DeferredFileRemoverTest.direct_removal_performance
removing 100 files of 1048576 bytes took 18539912 nanoseconds
[       OK ] DeferredFileRemoverTest.direct_removal_performance (4631 ms)
[ RUN      ] DeferredFileRemoverTest.remover_removal_performance
removing 100 files of 1048576 bytes took 19304517 nanoseconds
[       OK ] DeferredFileRemoverTest.remover_removal_performance (4464 ms)
[ RUN      ] DeferredFileRemoverTest.deferred_removal_performance
removing 100 files of 1048576 bytes took 2703535 nanoseconds
[       OK ] DeferredFileRemoverTest.deferred_removal_performance (4773 ms)
```

The remaining changesets are mostly of cosmetic nature.