### PR TITLE
Feature/shm support for multiple instances

### DIFF
--- a/src/filesystem/ShmCommon.h
+++ b/src/filesystem/ShmCommon.h
@@ -16,13 +16,35 @@
 #ifndef __SHM_COMMON_H
 #define __SHM_COMMON_H
 
+#include <string>
+
 struct ShmSegmentDetails
 {
-    static const char* Name()
+    std::string cluster_id;
+    std::string vrouter_id;
+
+    const std::string
+    id() const
     {
-        return "openvstorage_segment";
+        using namespace std::literals::string_literals;
+        return cluster_id + "-"s + vrouter_id;
     }
 
+    const std::string
+    control_endpoint() const
+    {
+        using namespace std::literals::string_literals;
+        // TODO: make the location configurable
+        return "/tmp/ovs-shm-ctl-"s + id() + ".socket"s;
+    }
+
+    ShmSegmentDetails(const std::string& cid,
+                      const std::string& vid)
+        : cluster_id(cid)
+        , vrouter_id(vid)
+    {}
+
+    ~ShmSegmentDetails() = default;
 };
 
 #endif // __SHM_COMMON_H

--- a/src/filesystem/ShmControlChannelProtocol.h
+++ b/src/filesystem/ShmControlChannelProtocol.h
@@ -30,14 +30,6 @@ enum class ShmConnectionState
     Disconnected,
 };
 
-struct ShmConnectionDetails
-{
-    static const char* Endpoint()
-    {
-        return "/tmp/ovs-shm-ctl.socket";
-    }
-};
-
 enum class ShmMsgOpcode
 {
     Idle,

--- a/src/filesystem/ShmControlChannelServer.h
+++ b/src/filesystem/ShmControlChannelServer.h
@@ -344,6 +344,12 @@ public:
         boost::filesystem::remove_all(segment_details_.control_endpoint());
     }
 
+    const ShmSegmentDetails&
+    shm_segment_details() const
+    {
+        return segment_details_;
+    }
+
 private:
     boost::asio::io_service io_service_;
     boost::asio::local::stream_protocol::acceptor acceptor_;

--- a/src/filesystem/ShmIdlInterface.idl
+++ b/src/filesystem/ShmIdlInterface.idl
@@ -16,6 +16,11 @@ module ShmIdlInterface {
     unsigned long long volume_size_in_bytes;
     };
 
+    struct HelloReply {
+    string cluster_id;
+    string vrouter_id;
+    };
+
     exception VolumeNameAlreadyRegistered {
     string volume_name;
     };
@@ -65,6 +70,10 @@ module ShmIdlInterface {
     typedef sequence<string> StringSequence;
 
     interface VolumeFactory {
+
+    ShmIdlInterface::HelloReply
+    hello(in string client_name);
+
     void
     create_volume(in string volume_name,
                   in unsigned long long volume_size_in_bytes)

--- a/src/filesystem/ShmIdlInterface.idl
+++ b/src/filesystem/ShmIdlInterface.idl
@@ -2,6 +2,8 @@
 module ShmIdlInterface {
 
     struct CreateShmArguments {
+    string cluster_id;
+    string vrouter_id;
     string volume_name;
     boolean for_creation;
     };

--- a/src/filesystem/ShmInterface.h
+++ b/src/filesystem/ShmInterface.h
@@ -54,6 +54,19 @@ public:
 
     typedef ShmServer<Handler> ServerType;
 
+    ShmIdlInterface::HelloReply*
+    hello(const std::string& sender_id)
+    {
+        LOG_INFO(sender_id << " says 'Hi'");
+
+        ShmIdlInterface::HelloReply_var reply(new ShmIdlInterface::HelloReply());
+        const ShmSegmentDetails& segment_details = shm_ctl_server_.shm_segment_details();
+        reply->cluster_id = segment_details.cluster_id.c_str();
+        reply->vrouter_id = segment_details.vrouter_id.c_str();
+
+        return reply._retn();
+    }
+
     ShmIdlInterface::CreateResult*
     create_shm_interface(const ShmIdlInterface::CreateShmArguments& args)
     {

--- a/src/filesystem/ShmInterface.h
+++ b/src/filesystem/ShmInterface.h
@@ -36,7 +36,7 @@ public:
                  handler_args_t& handler_args)
         : orb_helper_(orb_helper)
         , handler_args_(handler_args)
-        , shm_ctl_server_(ShmConnectionDetails::Endpoint())
+        , shm_ctl_server_(handler_args_.segment_details)
     {
         shm_ctl_server_.create_control_channel(boost::bind(&ShmInterface::try_stop_volume,
                                                            this,

--- a/src/filesystem/ShmOrbInterface.cpp
+++ b/src/filesystem/ShmOrbInterface.cpp
@@ -52,7 +52,8 @@ ShmOrbInterface::run(std::promise<void> promise)
         typedef ShmVolumeDriverHandler::construction_args handler_args_t;
         handler_args_t handler_args =
         {
-            fs_
+            fs_,
+            segment_details_,
         };
 
         POA_ShmIdlInterface::VolumeFactory_tie<ShmVolumeFactory>
@@ -67,9 +68,9 @@ ShmOrbInterface::run(std::promise<void> promise)
         try
         {
             orb_helper_.bindObjectToName(obj1,
-                                         vd_context_name,
+                                         fs_.object_router().cluster_id().str(),
                                          vd_context_kind,
-                                         vd_object_name,
+                                         fs_.object_router().node_id().str(),
                                          vd_object_kind);
         }
         CATCH_STD_ALL_EWHAT({
@@ -119,9 +120,9 @@ ShmOrbInterface::stop_all_and_exit()
 {
     try
     {
-        CORBA::Object_var obj = orb_helper_.getObjectReference(vd_context_name,
+        CORBA::Object_var obj = orb_helper_.getObjectReference(fs_.object_router().cluster_id().str(),
                                                                vd_context_kind,
-                                                               vd_object_name,
+                                                               fs_.object_router().node_id().str(),
                                                                vd_object_kind);
         ShmIdlInterface::VolumeFactory_var volumefactory_ref_ =
             ShmIdlInterface::VolumeFactory::_narrow(obj);
@@ -147,7 +148,7 @@ ShmOrbInterface::~ShmOrbInterface()
 {
     try
     {
-        bi::shared_memory_object::remove(ShmSegmentDetails::Name());
+        bi::shared_memory_object::remove(segment_details_.id().c_str());
     }
     catch (bi::interprocess_exception&)
     {

--- a/src/filesystem/ShmOrbInterface.h
+++ b/src/filesystem/ShmOrbInterface.h
@@ -41,14 +41,15 @@ public:
     , shm_region_size(pt)
     , fs_(fs)
     , orb_helper_("volumedriverfs_shm_server")
+    , segment_details_(fs_.object_router().cluster_id().str(),
+                       fs_.object_router().node_id().str())
     {
         try
         {
-            boost::interprocess::shared_memory_object::remove(ShmSegmentDetails::Name());
-            shm_segment_ =
-                boost::interprocess::managed_shared_memory(boost::interprocess::create_only,
-                                                           ShmSegmentDetails::Name(),
-                                                           shm_size());
+            boost::interprocess::shared_memory_object::remove(segment_details_.id().c_str());
+            shm_segment_ = boost::interprocess::managed_shared_memory(boost::interprocess::create_only,
+                                                                      segment_details_.id().c_str(),
+                                                                      shm_size());
         }
         catch (boost::interprocess::interprocess_exception&)
         {
@@ -98,6 +99,7 @@ private:
 
     FileSystem& fs_;
     youtils::OrbHelper orb_helper_;
+    const ShmSegmentDetails segment_details_;
     boost::interprocess::managed_shared_memory shm_segment_;
 };
 

--- a/src/filesystem/ShmOrbInterface.h
+++ b/src/filesystem/ShmOrbInterface.h
@@ -16,7 +16,7 @@
 #ifndef __SHM_ORB_INTERFACE_H_
 #define __SHM_ORB_INTERFACE_H_
 
-#include "ShmCommon.h"
+#include "ShmSegmentDetails.h"
 
 #include <future>
 

--- a/src/filesystem/ShmProtocol.h
+++ b/src/filesystem/ShmProtocol.h
@@ -22,10 +22,9 @@
 namespace volumedriverfs
 {
 
-const std::string vd_context_name("volumedriver");
-const std::string vd_context_kind("storage");
-const std::string vd_object_name("volumedriver_shm_interface");
-const std::string vd_object_kind("storage");
+// TODO: only declare these here (extern). Convert them into static members of a struct?
+const std::string vd_context_kind("vrouter_cluster_id");
+const std::string vd_object_kind("vrouter");
 
 const uint64_t max_write_queue_size = 128;
 const uint64_t max_read_queue_size = 128;
@@ -40,6 +39,7 @@ struct ShmWriteRequest
     boost::interprocess::managed_shared_memory::handle_t handle;
 };
 
+// TODO: no static vars in a header.
 static const uint64_t writerequest_size = sizeof(ShmWriteRequest);
 
 struct ShmReadRequest

--- a/src/filesystem/ShmSegmentDetails.h
+++ b/src/filesystem/ShmSegmentDetails.h
@@ -13,8 +13,8 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
-#ifndef __SHM_COMMON_H
-#define __SHM_COMMON_H
+#ifndef __SHM_SEGMENT_DETAILS_H
+#define __SHM_SEGMENT_DETAILS_H
 
 #include <string>
 
@@ -47,4 +47,4 @@ struct ShmSegmentDetails
     ~ShmSegmentDetails() = default;
 };
 
-#endif // __SHM_COMMON_H
+#endif // __SHM_SEGMENT_DETAILS_H

--- a/src/filesystem/ShmVolumeCache.h
+++ b/src/filesystem/ShmVolumeCache.h
@@ -15,7 +15,7 @@
 #ifndef __SHM_VOLUME_CACHE_H
 #define __SHM_VOLUME_CACHE_H
 
-#include "ShmCommon.h"
+#include "ShmSegmentDetails.h"
 
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <set>

--- a/src/filesystem/ShmVolumeCache.h
+++ b/src/filesystem/ShmVolumeCache.h
@@ -28,12 +28,12 @@ namespace ipc = boost::interprocess;
 class ShmVolumeCache
 {
 public:
-    ShmVolumeCache()
+    explicit ShmVolumeCache(const ShmSegmentDetails& segment_details)
     {
         try
         {
             shm_segment_ = ipc::managed_shared_memory(ipc::open_only,
-                                                      ShmSegmentDetails::Name());
+                                                      segment_details.id().c_str());
         }
         catch (ipc::interprocess_exception&)
         {

--- a/src/filesystem/ShmVolumeDriverHandler.h
+++ b/src/filesystem/ShmVolumeDriverHandler.h
@@ -37,14 +37,15 @@ public:
     struct construction_args
     {
         FileSystem& fs;
+        ShmSegmentDetails segment_details;
     };
 
     ShmVolumeDriverHandler(const ::ShmIdlInterface::CreateShmArguments& args,
                            construction_args& handler_args)
         : fs_(handler_args.fs)
         , shm_segment_(new boost::interprocess::managed_shared_memory(boost::interprocess::open_only,
-                                                                      ShmSegmentDetails::Name()))
-    {
+                                                                      ShmSegmentDetails(std::string(args.cluster_id),
+                                                                                        std::string(args.vrouter_id)).id().c_str())) {
         open(std::string(args.volume_name));
 
         LOG_INFO("created a new volume handler for volume '" <<

--- a/src/filesystem/ShmVolumeDriverHandler.h
+++ b/src/filesystem/ShmVolumeDriverHandler.h
@@ -19,7 +19,7 @@
 #include "FileSystem.h"
 #include "ObjectRouter.h"
 #include "PythonClient.h"
-#include "ShmCommon.h"
+#include "ShmSegmentDetails.h"
 
 #include <boost/interprocess/managed_shared_memory.hpp>
 

--- a/src/filesystem/c-api/Makefile.am
+++ b/src/filesystem/c-api/Makefile.am
@@ -16,6 +16,7 @@ libovsvolumedriver_la_SOURCES = \
 	AioCompletion.cpp \
 	../ShmIdlInterface.cpp \
 	ShmClient.cpp \
+	ShmOrbClient.cpp \
 	NetworkXioClient.cpp \
 	TracePoints_tp.c \
 	libovsvolumedriver.cpp

--- a/src/filesystem/c-api/ShmClient.cpp
+++ b/src/filesystem/c-api/ShmClient.cpp
@@ -13,8 +13,8 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
-#include "../ShmCommon.h"
 #include "ShmClient.h"
+#include "../ShmSegmentDetails.h"
 
 #include <youtils/Assert.h>
 #include <youtils/UUID.h>

--- a/src/filesystem/c-api/ShmClient.cpp
+++ b/src/filesystem/c-api/ShmClient.cpp
@@ -40,7 +40,6 @@ ShmClient::ShmClient(const ShmSegmentDetails& segment_details,
                    segment_details.id().c_str())
     , segment_details_(segment_details)
     , vname_(vname)
-    , vsize_(create_result.volume_size_in_bytes)
     , key_(create_result.writerequest_uuid)
 {}
 

--- a/src/filesystem/c-api/ShmClient.h
+++ b/src/filesystem/c-api/ShmClient.h
@@ -94,12 +94,6 @@ public:
     stat(const std::string& volume_name,
          struct stat *st);
 
-    uint64_t
-    volume_size_in_bytes() const
-    {
-        return vsize_;
-    }
-
     const std::string&
     get_key() const
     {
@@ -145,7 +139,6 @@ private:
 
     const ShmSegmentDetails segment_details_;
     const std::string vname_;
-    const size_t vsize_;
     const std::string key_;
 };
 

--- a/src/filesystem/c-api/ShmClient.h
+++ b/src/filesystem/c-api/ShmClient.h
@@ -16,11 +16,11 @@
 #ifndef __SHM_CLIENT_H_
 #define __SHM_CLIENT_H_
 
-#include "../ShmCommon.h"
+#include "ShmIdlInterface.h"
+
 #include "../ShmIdlInterface.h"
 #include "../ShmProtocol.h"
-
-#include "ShmIdlInterface.h"
+#include "../ShmSegmentDetails.h"
 
 #include <boost/interprocess/ipc/message_queue.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>

--- a/src/filesystem/c-api/ShmControlChannelClient.h
+++ b/src/filesystem/c-api/ShmControlChannelClient.h
@@ -25,9 +25,9 @@
 class ShmControlChannelClient
 {
 public:
-    ShmControlChannelClient()
+    ShmControlChannelClient(const ShmSegmentDetails& segment_details)
     : socket_(io_service_)
-    , ep_(ShmConnectionDetails::Endpoint())
+    , ep_(segment_details.control_endpoint())
     {}
 
     ~ShmControlChannelClient()

--- a/src/filesystem/c-api/ShmOrbClient.cpp
+++ b/src/filesystem/c-api/ShmOrbClient.cpp
@@ -101,6 +101,12 @@ ShmOrbClient::ShmOrbClient(const ShmSegmentDetails& segment_details)
     , volume_factory_ref_(get_volume_factory_reference_())
 {}
 
+std::unique_ptr<ShmIdlInterface::HelloReply>
+ShmOrbClient::hello(const std::string& sender_id)
+{
+    return std::unique_ptr<ShmIdlInterface::HelloReply>(volume_factory_ref_->hello(sender_id.c_str()));
+}
+
 std::unique_ptr<ShmClient>
 ShmOrbClient::open(const std::string& volname)
 {

--- a/src/filesystem/c-api/ShmOrbClient.cpp
+++ b/src/filesystem/c-api/ShmOrbClient.cpp
@@ -1,0 +1,225 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#include "ShmClient.h"
+#include "ShmIdlInterface.h"
+#include "ShmOrbClient.h"
+#include "ShmProtocol.h"
+#include "ShmSegmentDetails.h"
+
+#include <youtils/Assert.h>
+#include <youtils/UUID.h>
+#include <youtils/OrbHelper.h>
+
+namespace volumedriverfs
+{
+
+namespace yt = youtils;
+
+namespace
+{
+
+// Does OmniORB support multiple ORBs by now? Older messages on the mailing list
+// say it doesn't so for now we'll use a singleton.
+// Do we need locking around OrbHelper calls?
+DECLARE_LOGGER("ShmOrbClientUtils");
+
+boost::mutex orb_helper_lock;
+std::unique_ptr<yt::OrbHelper> orb_helper_instance;
+
+#define LOCK_ORB_HELPER()                                               \
+    boost::lock_guard<decltype(orb_helper_lock)> g(orb_helper_lock)
+
+youtils::OrbHelper&
+orb_helper()
+{
+    LOCK_ORB_HELPER();
+
+    if (not orb_helper_instance)
+    {
+        orb_helper_instance = std::make_unique<yt::OrbHelper>("ShmOrbClient");
+    }
+
+    return *orb_helper_instance;
+}
+
+}
+
+void
+ShmOrbClient::init()
+{
+    LOCK_ORB_HELPER();
+
+    VERIFY(not orb_helper_instance);
+    orb_helper_instance = std::make_unique<yt::OrbHelper>("ShmOrbClient");
+}
+
+void
+ShmOrbClient::fini()
+{
+    LOCK_ORB_HELPER();
+    VERIFY(orb_helper_instance);
+    orb_helper_instance = nullptr;
+}
+
+CORBA::Object_var
+ShmOrbClient::get_object_reference_()
+{
+    CORBA::Object_var obj = orb_helper().getObjectReference(segment_details_.cluster_id,
+                                                            vd_context_kind,
+                                                            segment_details_.vrouter_id,
+                                                            vd_object_kind);
+
+    assert(not CORBA::is_nil(obj));
+    return obj;
+}
+
+ShmIdlInterface::VolumeFactory_var
+ShmOrbClient::get_volume_factory_reference_()
+{
+    CORBA::Object_var obj = get_object_reference_();
+    ShmIdlInterface::VolumeFactory_var vref = ShmIdlInterface::VolumeFactory::_narrow(obj);
+    assert(not CORBA::is_nil(vref));
+
+    return vref;
+}
+
+ShmOrbClient::ShmOrbClient(const ShmSegmentDetails& segment_details)
+    : segment_details_(segment_details)
+    , volume_factory_ref_(get_volume_factory_reference_())
+{}
+
+std::unique_ptr<ShmClient>
+ShmOrbClient::open(const std::string& volname)
+{
+    ShmIdlInterface::CreateShmArguments args;
+    args.cluster_id = segment_details_.cluster_id.c_str();
+    args.vrouter_id = segment_details_.vrouter_id.c_str();
+    args.volume_name = volname.c_str();
+
+    std::unique_ptr<ShmIdlInterface::CreateResult> res(volume_factory_ref_->create_shm_interface(args));
+    assert(youtils::UUID::isUUIDString(res->writerequest_uuid));
+    assert(youtils::UUID::isUUIDString(res->writereply_uuid));
+    assert(youtils::UUID::isUUIDString(res->readrequest_uuid));
+    assert(youtils::UUID::isUUIDString(res->readreply_uuid));
+
+    return std::unique_ptr<ShmClient>(new ShmClient(segment_details_,
+                                                    volname,
+                                                    *res));
+}
+
+void
+ShmOrbClient::create_volume(const std::string& volume_name,
+                            const uint64_t volume_size)
+{
+    volume_factory_ref_->create_volume(volume_name.c_str(),
+                                       volume_size);
+}
+
+void
+ShmOrbClient::remove_volume(const std::string& volume_name)
+{
+    volume_factory_ref_->remove_volume(volume_name.c_str());
+}
+
+void
+ShmOrbClient::truncate_volume(const std::string& volume_name,
+                              const uint64_t volume_size)
+{
+    volume_factory_ref_->truncate_volume(volume_name.c_str(),
+                                         volume_size);
+}
+
+void
+ShmOrbClient::create_snapshot(const std::string& volume_name,
+                              const std::string& snapshot_name,
+                              const int64_t timeout)
+{
+    volume_factory_ref_->create_snapshot(volume_name.c_str(),
+                                         snapshot_name.c_str(),
+                                         timeout);
+}
+
+void
+ShmOrbClient::rollback_snapshot(const std::string& volume_name,
+                                const std::string& snapshot_name)
+{
+    volume_factory_ref_->rollback_snapshot(volume_name.c_str(),
+                                           snapshot_name.c_str());
+}
+
+void
+ShmOrbClient::delete_snapshot(const std::string& volume_name,
+                              const std::string& snapshot_name)
+{
+    volume_factory_ref_->delete_snapshot(volume_name.c_str(),
+                                         snapshot_name.c_str());
+}
+
+std::vector<std::string>
+ShmOrbClient::list_snapshots(const std::string& volume_name,
+                             uint64_t *size)
+{
+    ShmIdlInterface::StringSequence_var results;
+    CORBA::ULongLong c_size;
+    std::vector<std::string> snaps;
+    volume_factory_ref_->list_snapshots(volume_name.c_str(),
+                                        results.out(),
+                                        c_size);
+    for (unsigned int i = 0; i < results->length(); i++)
+    {
+        snaps.push_back(results[i].in());
+    }
+    *size = c_size;
+    return snaps;
+}
+
+int
+ShmOrbClient::is_snapshot_synced(const std::string& volume_name,
+                                 const std::string& snapshot_name)
+{
+    return volume_factory_ref_->is_snapshot_synced(volume_name.c_str(),
+                                                   snapshot_name.c_str());
+}
+
+std::vector<std::string>
+ShmOrbClient::list_volumes()
+{
+    ShmIdlInterface::StringSequence_var results;
+    std::vector<std::string> volumes;
+    volume_factory_ref_->list_volumes(results.out());
+    for (unsigned int i = 0; i < results->length(); i++)
+    {
+        volumes.push_back(results[i].in());
+    }
+    return volumes;
+}
+
+void
+ShmOrbClient::stat(const std::string& volume_name,
+                   struct stat& st)
+{
+    uint64_t vol_size = volume_factory_ref_->stat_volume(volume_name.c_str());
+    st.st_blksize = 512;
+    st.st_size = vol_size;
+}
+
+void
+ShmOrbClient::stop_volume_(const std::string& vname)
+{
+    volume_factory_ref_->stop_volume(vname.c_str());
+}
+
+}

--- a/src/filesystem/c-api/ShmOrbClient.h
+++ b/src/filesystem/c-api/ShmOrbClient.h
@@ -1,0 +1,112 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#ifndef __SHM_ORB_CLIENT_H_
+#define __SHM_ORB_CLIENT_H_
+
+#include "ShmIdlInterface.h"
+
+#include "../ShmSegmentDetails.h"
+
+#include <youtils/Logging.h>
+#include <youtils/OrbHelper.h>
+
+namespace volumedriverfs
+{
+
+class ShmClient;
+
+class ShmOrbClient
+    : public std::enable_shared_from_this<ShmOrbClient>
+{
+public:
+    explicit ShmOrbClient(const ShmSegmentDetails&);
+
+    ~ShmOrbClient() = default;
+
+    std::unique_ptr<ShmClient>
+    open(const std::string& volname);
+
+    void
+    create_volume(const std::string& volume_name,
+                  const uint64_t volume_size);
+
+    void
+    remove_volume(const std::string& volume_name);
+
+    void
+    truncate_volume(const std::string& volume_name,
+                    const uint64_t volume_size);
+
+    void
+    create_snapshot(const std::string& volume_name,
+                    const std::string& snapshot_name,
+                    const int64_t timeout);
+
+    void
+    rollback_snapshot(const std::string& volume_name,
+                      const std::string& snapshot_name);
+
+    void
+    delete_snapshot(const std::string& volume_name,
+                    const std::string& snapshot_name);
+
+    std::vector<std::string>
+    list_snapshots(const std::string& volume_name,
+                   uint64_t *size);
+
+    int
+    is_snapshot_synced(const std::string& volume_name,
+                       const std::string& snapshot_name);
+
+    std::vector<std::string>
+    list_volumes();
+
+    void
+    stat(const std::string& volume_name,
+         struct stat&);
+
+    static void
+    init();
+
+    static void
+    fini();
+
+    const ShmSegmentDetails&
+    shm_segment_details() const
+    {
+        return segment_details_;
+    }
+
+private:
+    friend class ShmClient;
+
+    const ShmSegmentDetails segment_details_;
+
+    ShmIdlInterface::VolumeFactory_var volume_factory_ref_;
+
+    CORBA::Object_var
+    get_object_reference_();
+
+    ShmIdlInterface::VolumeFactory_var
+    get_volume_factory_reference_();
+
+    void
+    stop_volume_(const std::string&);
+};
+
+} //namespace volumedriverfs
+
+#endif

--- a/src/filesystem/c-api/ShmOrbClient.h
+++ b/src/filesystem/c-api/ShmOrbClient.h
@@ -36,6 +36,9 @@ public:
 
     ~ShmOrbClient() = default;
 
+    std::unique_ptr<ShmIdlInterface::HelloReply>
+    hello(const std::string& sender_id);
+
     std::unique_ptr<ShmClient>
     open(const std::string& volname);
 

--- a/src/filesystem/c-api/VolumeCacheHandler.h
+++ b/src/filesystem/c-api/VolumeCacheHandler.h
@@ -28,7 +28,7 @@
 class VolumeCacheHandler
 {
 public:
-    VolumeCacheHandler(volumedriverfs::ShmClientPtr shm_client,
+    VolumeCacheHandler(volumedriverfs::ShmClient& shm_client,
                        ShmControlChannelClientPtr ctl_client)
     : shm_client_(shm_client)
     , ctl_client_(ctl_client)
@@ -172,7 +172,7 @@ public:
 
 private:
     typedef std::queue<void*> BufferQueue;
-    volumedriverfs::ShmClientPtr shm_client_;
+    volumedriverfs::ShmClient& shm_client_;
     ShmControlChannelClientPtr ctl_client_;
 
     enum BufferSize
@@ -247,7 +247,7 @@ private:
         bool ret = ctl_client_->allocate(handle, size);
         if (ret)
         {
-            void *ptr = shm_client_->get_address_from_handle(handle);
+            void *ptr = shm_client_.get_address_from_handle(handle);
             return ptr;
         }
         return NULL;
@@ -257,7 +257,7 @@ private:
     ctl_channel_deallocate(void *buf)
     {
         boost::interprocess::managed_shared_memory::handle_t handle =
-            shm_client_->get_handle_from_address(buf);
+            shm_client_.get_handle_from_address(buf);
         return (ctl_client_->deallocate(handle) ? 0 : -1);
     }
 

--- a/src/filesystem/c-api/common.h
+++ b/src/filesystem/c-api/common.h
@@ -16,6 +16,10 @@
 #ifndef __LIB_OVS_COMMON_H
 #define __LIB_OVS_COMMON_H
 
+#include "../ShmCommon.h"
+
+#include <boost/optional.hpp>
+
 #define ATTRIBUTE_UNUSED __attribute__((unused))
 
 #include <string>
@@ -46,6 +50,7 @@ struct ovs_context_attr_t
     std::string host;
     int port;
     uint64_t network_qdepth;
+    boost::optional<ShmSegmentDetails> shm_segment_details;
 };
 
 struct ovs_buffer

--- a/src/filesystem/c-api/common.h
+++ b/src/filesystem/c-api/common.h
@@ -16,7 +16,7 @@
 #ifndef __LIB_OVS_COMMON_H
 #define __LIB_OVS_COMMON_H
 
-#include "../ShmCommon.h"
+#include "../ShmSegmentDetails.h"
 
 #include <boost/optional.hpp>
 

--- a/src/filesystem/c-api/context.h
+++ b/src/filesystem/c-api/context.h
@@ -18,6 +18,10 @@
 
 #include <boost/asio.hpp>
 
+#include "NetworkXioClient.h"
+
+#include "../ShmControlChannelProtocol.h"
+
 struct ovs_context_t
 {
     TransportType transport;

--- a/src/filesystem/c-api/volumedriver.h
+++ b/src/filesystem/c-api/volumedriver.h
@@ -71,7 +71,8 @@ ovs_ctx_attr_destroy(ovs_ctx_attr_t *attr);
  * Set transport type
  * param attr: Context attributes object
  * param transport: Transport string ("shm", "tcp", "rdma)
- * param host: Host string (FQDN or ASCII)
+ * param host: Host string (FQDN or ASCII) in case of "tcp" or "rdma",
+ *            "<cluster_id>/<vrouter_id>" in case of "shm"
  * param port: TCP/RDMA port number
  * return: 0 on success, -1 on fail
  */

--- a/src/filesystem/test/FileSystemTestSetup.h
+++ b/src/filesystem/test/FileSystemTestSetup.h
@@ -252,7 +252,10 @@ protected:
     static volumedriverfs::ClusterId
     vrouter_cluster_id()
     {
-        return volumedriverfs::ClusterId("volumedriverfs-cluster");
+        using namespace std::literals::string_literals;
+
+        static const volumedriverfs::ClusterId cid("vfs-cluster-"s + youtils::UUID().str());
+        return cid;
     }
 
     static volumedriverfs::NodeId


### PR DESCRIPTION
This one allows multiple volumedriver instances on the same node to offer an SHM interface - for that it is necessary that users of the C API (blktap et al) are updated to pass in the cluster (vpool) and node (vrouter) identifier of the instance they want to connect to.
This change does not break the API but existing clients (that don't pass that info in) will not be able to successfully connect anymore. Cf. #21 .
