### PR TITLE
Feature/object registry get all registrations

### DIFF
--- a/src/filesystem-python-client/ObjectRegistryClient.cpp
+++ b/src/filesystem-python-client/ObjectRegistryClient.cpp
@@ -99,6 +99,12 @@ public:
         return registry_()->list();
     }
 
+    std::vector<ObjectRegistrationPtr>
+    get_all_registrations() const
+    {
+        return registry_()->get_all_registrations();
+    }
+
     ObjectRegistrationPtr
     find(const ObjectId& oid) const
     {
@@ -223,6 +229,8 @@ ObjectRegistryClient::registerize()
              "@return ObjectType\n")
         ;
 
+    REGISTER_ITERABLE_CONVERTER(std::vector<ObjectRegistrationPtr>);
+
     bpy::class_<Wrapper>("ObjectRegistryClient",
                          "debugging tool for the ObjectRegistry",
                          bpy::init<const ClusterId&,
@@ -238,6 +246,9 @@ ObjectRegistryClient::registerize()
         .def("list",
              &Wrapper::list,
              "get a list of registered ObjectId's")
+        .def("get_all_registrations",
+             &Wrapper::get_all_registrations,
+             "get a list of all ObjectRegistrations")
         .def("find",
              &Wrapper::find,
              bpy::args("object_id"),

--- a/src/filesystem-python-client/ObjectRegistryClient.cpp
+++ b/src/filesystem-python-client/ObjectRegistryClient.cpp
@@ -93,7 +93,7 @@ public:
     Wrapper&
     operator=(const Wrapper&) = default;
 
-    std::list<ObjectId>
+    std::vector<ObjectId>
     list() const
     {
         return registry_()->list();
@@ -194,7 +194,7 @@ foc_config_mode(const ObjectRegistration* reg)
 void
 ObjectRegistryClient::registerize()
 {
-    REGISTER_ITERABLE_CONVERTER(std::list<ObjectId>);
+    REGISTER_ITERABLE_CONVERTER(std::vector<ObjectId>);
 
     bpy::class_<ObjectRegistration,
                 boost::shared_ptr<ObjectRegistration>>("ObjectRegistration",

--- a/src/filesystem-python-client/ObjectRegistryClient.cpp
+++ b/src/filesystem-python-client/ObjectRegistryClient.cpp
@@ -189,6 +189,12 @@ foc_config_mode(const ObjectRegistration* reg)
     return reg->foc_config_mode;
 }
 
+ObjectType
+object_type(const ObjectRegistration* reg)
+{
+    return reg->object().type;
+}
+
 }
 
 void
@@ -212,6 +218,9 @@ ObjectRegistryClient::registerize()
         .def("dtl_config_mode",
              foc_config_mode,
              "@return DTLConfigMode\n")
+        .def("object_type",
+             object_type,
+             "@return ObjectType\n")
         ;
 
     bpy::class_<Wrapper>("ObjectRegistryClient",

--- a/src/filesystem/CachedObjectRegistry.cpp
+++ b/src/filesystem/CachedObjectRegistry.cpp
@@ -156,10 +156,10 @@ CachedObjectRegistry::drop_cache()
     cache_.clear();
 }
 
-std::list<ObjectId>
+std::vector<ObjectId>
 CachedObjectRegistry::list(RefreshCache refresh_cache)
 {
-    std::list<ObjectId> objs(registry_.list());
+    std::vector<ObjectId> objs(registry_.list());
 
     if (refresh_cache == RefreshCache::T)
     {

--- a/src/filesystem/CachedObjectRegistry.h
+++ b/src/filesystem/CachedObjectRegistry.h
@@ -100,8 +100,7 @@ public:
     find(const ObjectId&,
          IgnoreCache);
 
-    // use a vector instead?
-    std::list<ObjectId>
+    std::vector<ObjectId>
     list(RefreshCache = RefreshCache::F);
 
     ObjectRegistrationPtr

--- a/src/filesystem/HierarchicalArakoon.h
+++ b/src/filesystem/HierarchicalArakoon.h
@@ -361,7 +361,7 @@ public:
                      return Traits::deserialize(is);
                  });
 
-        return find_(path).as_istream<typename Traits::DeserializedType>(fun);
+        return find_(path).as_istream<typename Traits::DeserializedType>(std::move(fun));
     }
 
     template<typename T,
@@ -388,7 +388,7 @@ public:
                                         id.str().c_str(),
                                         ENOENT);
         }
-        return buf.as_istream<typename Traits::DeserializedType>(fun);
+        return buf.as_istream<typename Traits::DeserializedType>(std::move(fun));
     }
 
     void

--- a/src/filesystem/LocalNode.cpp
+++ b/src/filesystem/LocalNode.cpp
@@ -154,7 +154,7 @@ LocalNode::destroy(ObjectRegistry& registry,
     TODO("AR: push volume namespace removal down to voldrv");
     fd::ContainerManager::destroy(cm, pt);
 
-    const std::list<ObjectId> l(registry.list());
+    const std::vector<ObjectId> l(registry.list());
     for (const auto& o : l)
     {
         const ObjectRegistrationPtr reg(registry.find(o));

--- a/src/filesystem/ObjectRegistry.cpp
+++ b/src/filesystem/ObjectRegistry.cpp
@@ -52,25 +52,29 @@ serialize_volume_registration(const ObjectRegistration& reg)
 }
 
 ObjectRegistrationPtr
+deserialize_volume_registration(std::istream& is)
+{
+    ObjectRegistration* reg = nullptr;
+
+    try
+    {
+        iarchive_type ia(is);
+        ia >> reg;
+        return ObjectRegistrationPtr(reg);
+    }
+    catch (...)
+    {
+        delete reg;
+        throw;
+    }
+}
+
+ObjectRegistrationPtr
 deserialize_volume_registration(const ara::buffer& buf)
 {
-    return buf.as_istream<ObjectRegistrationPtr>([](std::istream& is) ->
-                                                 ObjectRegistrationPtr
-        {
-            ObjectRegistration* reg = nullptr;
-
-            try
-            {
-                iarchive_type ia(is);
-                ia >> reg;
-                return ObjectRegistrationPtr(reg);
-            }
-            catch (...)
-            {
-                delete reg;
-                throw;
-            }
-        });
+    using FunPtr = ObjectRegistrationPtr(*)(std::istream&);
+    FunPtr fun = deserialize_volume_registration;
+    return buf.as_istream<ObjectRegistrationPtr>(fun);
 }
 
 }

--- a/src/filesystem/ObjectRegistry.cpp
+++ b/src/filesystem/ObjectRegistry.cpp
@@ -117,7 +117,7 @@ ObjectRegistry::destroy()
 {
     LOG_INFO("Removing object registrations for " << cluster_id_);
 
-    std::list<ObjectId> l(list());
+    std::vector<ObjectId> l(list());
 
     for (const auto& o : l)
     {
@@ -245,7 +245,7 @@ ObjectRegistry::find_throw(const ObjectId& vol_id)
     }
 }
 
-std::list<ObjectId>
+std::vector<ObjectId>
 ObjectRegistry::list()
 {
     LOG_TRACE(ID() << ": getting list of registrations");
@@ -259,7 +259,8 @@ ObjectRegistry::list()
 
     ara::value_list l(larakoon_->prefix(prefix()));
 
-    std::list<ObjectId> vols;
+    std::vector<ObjectId> vols;
+    vols.reserve(l.size());
 
     ara::arakoon_buffer val;
     ara::value_list::iterator it(l.begin());
@@ -270,7 +271,7 @@ ObjectRegistry::list()
 
         std::string s(static_cast<const char*>(val.second) + pfx.size(),
                       val.first - pfx.size());
-        vols.push_back(ObjectId(s));
+        vols.emplace_back(ObjectId(s));
     }
 
     return vols;

--- a/src/filesystem/ObjectRegistry.h
+++ b/src/filesystem/ObjectRegistry.h
@@ -107,9 +107,11 @@ public:
     ObjectRegistrationPtr
     find(const ObjectId& vol_id);
 
-    // use a vector instead?
-    std::list<ObjectId>
+    std::vector<ObjectId>
     list();
+
+    std::vector<ObjectRegistrationPtr>
+    get_all_registrations(const size_t batch_size = 1024);
 
     ObjectRegistrationPtr
     prepare_migrate(arakoon::sequence& seq,

--- a/src/filesystem/test/ObjectRegistryTest.cpp
+++ b/src/filesystem/test/ObjectRegistryTest.cpp
@@ -27,9 +27,10 @@
 namespace volumedriverfstest
 {
 
+using namespace volumedriverfs;
+
 namespace be = backend;
 namespace vd = volumedriver;
-namespace vfs = volumedriverfs;
 namespace yt = youtils;
 
 class ObjectRegistryTest
@@ -46,29 +47,48 @@ protected:
     SetUp() override
     {
         RegistryTestSetup::SetUp();
-        object_registry_.reset(new vfs::ObjectRegistry(cluster_id_,
-                                                       node_id_,
-                                                       registry_));
+        object_registry_.reset(new ObjectRegistry(cluster_id_,
+                                                  node_id_,
+                                                  registry_));
     }
 
-    const vfs::ClusterId cluster_id_;
-    const vfs::NodeId node_id_;
-    std::unique_ptr<vfs::ObjectRegistry> object_registry_;
+    std::set<ObjectId>
+    fill(const size_t count)
+    {
+        std::set<ObjectId> vols;
+
+        for (unsigned i = 0; i < count; ++i)
+        {
+            const std::string s(yt::UUID().str());
+            const ObjectId id(s);
+            object_registry_->register_base_volume(id,
+                                                   be::Namespace(s));
+
+            const auto res(vols.insert(id));
+            EXPECT_TRUE(res.second);
+        }
+
+        return vols;
+    }
+
+    const ClusterId cluster_id_;
+    const NodeId node_id_;
+    std::unique_ptr<ObjectRegistry> object_registry_;
 };
 
 TEST_F(ObjectRegistryTest, register_lookup_and_unregister)
 {
-    const vfs::ObjectId vol_id("volume");
+    const ObjectId vol_id("volume");
 
     EXPECT_FALSE(object_registry_->find(vol_id));
     EXPECT_THROW(object_registry_->unregister(vol_id),
-                 vfs::ObjectNotRegisteredException);
+                 ObjectNotRegisteredException);
 
     const be::Namespace nspace;
 
     object_registry_->register_base_volume(vol_id, nspace);
 
-    vfs::ObjectRegistrationPtr reg(object_registry_->find(vol_id));
+    ObjectRegistrationPtr reg(object_registry_->find(vol_id));
     ASSERT_TRUE(reg != nullptr);
 
     EXPECT_EQ(vol_id, reg->volume_id);
@@ -78,7 +98,7 @@ TEST_F(ObjectRegistryTest, register_lookup_and_unregister)
     object_registry_->unregister(vol_id);
     EXPECT_TRUE(object_registry_->find(vol_id) == nullptr);
     EXPECT_THROW(object_registry_->find_throw(vol_id),
-                 vfs::ObjectNotRegisteredException);
+                 ObjectNotRegisteredException);
 }
 
 TEST_F(ObjectRegistryTest, destruction)
@@ -87,12 +107,12 @@ TEST_F(ObjectRegistryTest, destruction)
 
     {
         const be::Namespace nspace;
-        const vfs::ObjectId oid("volume");
+        const ObjectId oid("volume");
 
         object_registry_->register_base_volume(oid, nspace);
     }
 
-    const vfs::ObjectId tmpl("template");
+    const ObjectId tmpl("template");
 
     {
         const be::Namespace nspace;
@@ -103,7 +123,7 @@ TEST_F(ObjectRegistryTest, destruction)
 
     {
         const be::Namespace nspace;
-        const vfs::ObjectId oid("clone");
+        const ObjectId oid("clone");
 
         object_registry_->register_clone(oid,
                                          nspace,
@@ -113,7 +133,7 @@ TEST_F(ObjectRegistryTest, destruction)
 
     {
         const be::Namespace nspace;
-        const vfs::ObjectId oid("file");
+        const ObjectId oid("file");
 
         object_registry_->register_file(oid);
     }
@@ -127,15 +147,15 @@ TEST_F(ObjectRegistryTest, destruction)
 
 TEST_F(ObjectRegistryTest, reregister)
 {
-    const vfs::ObjectId vol_id("volume");
+    const ObjectId vol_id("volume");
     const be::Namespace nspace;
 
     object_registry_->register_base_volume(vol_id, nspace);
     EXPECT_THROW(object_registry_->register_base_volume(vol_id,
                                                         nspace),
-                 vfs::ObjectAlreadyRegisteredException);
+                 ObjectAlreadyRegisteredException);
 
-    const vfs::ObjectRegistrationPtr reg(object_registry_->find(vol_id));
+    const ObjectRegistrationPtr reg(object_registry_->find(vol_id));
     ASSERT_TRUE(reg != nullptr);
 
     EXPECT_EQ(vol_id, reg->volume_id);
@@ -148,48 +168,48 @@ TEST_F(ObjectRegistryTest, reregister)
 
 TEST_F(ObjectRegistryTest, migrate_inexistent)
 {
-    const vfs::ObjectId vol_id("volume");
+    const ObjectId vol_id("volume");
 
     EXPECT_THROW(object_registry_->migrate(vol_id,
-                                           vfs::NodeId("from"),
-                                           vfs::NodeId("to")),
-                 vfs::ObjectNotRegisteredException);
+                                           NodeId("from"),
+                                           NodeId("to")),
+                 ObjectNotRegisteredException);
 }
 
 TEST_F(ObjectRegistryTest, migrate_from_wrong_node)
 {
-    const vfs::ObjectId vol_id("volume");
+    const ObjectId vol_id("volume");
     const be::Namespace nspace;
 
     object_registry_->register_base_volume(vol_id,
                                            nspace);
 
-    const vfs::NodeId node_id("from");
+    const NodeId node_id("from");
     EXPECT_TRUE(node_id != object_registry_->node_id());
 
     EXPECT_THROW(object_registry_->migrate(vol_id,
                                            node_id,
                                            object_registry_->node_id()),
-                 vfs::WrongOwnerException);
+                 WrongOwnerException);
 }
 
 TEST_F(ObjectRegistryTest, migrate)
 {
-    const vfs::NodeId node("othernode");
+    const NodeId node("othernode");
     ASSERT_TRUE(object_registry_->node_id() != node);
 
-    vfs::ObjectRegistry registry(object_registry_->cluster_id(),
-                                 node,
-                                 registry_);
+    ObjectRegistry registry(object_registry_->cluster_id(),
+                            node,
+                            registry_);
 
     EXPECT_TRUE(registry.node_id() == node);
 
-    const vfs::ObjectId vol_id("volume");
+    const ObjectId vol_id("volume");
     const be::Namespace nspace;
 
     registry.register_base_volume(vol_id, nspace);
 
-    vfs::ObjectRegistrationPtr reg(object_registry_->find(vol_id));
+    ObjectRegistrationPtr reg(object_registry_->find(vol_id));
     ASSERT_TRUE(reg != nullptr);
 
     EXPECT_TRUE(reg->node_id == registry.node_id());
@@ -198,7 +218,7 @@ TEST_F(ObjectRegistryTest, migrate)
 
     object_registry_->migrate(vol_id, node, object_registry_->node_id());
 
-    vfs::ObjectRegistrationPtr new_reg(registry.find(vol_id));
+    ObjectRegistrationPtr new_reg(registry.find(vol_id));
     ASSERT_TRUE(new_reg != nullptr);
 
     EXPECT_TRUE(new_reg->node_id == object_registry_->node_id());
@@ -210,23 +230,23 @@ TEST_F(ObjectRegistryTest, migrate)
 
 TEST_F(ObjectRegistryTest, unregister_from_wrong_node)
 {
-    const vfs::NodeId node("othernode");
+    const NodeId node("othernode");
     ASSERT_TRUE(object_registry_->node_id() != node);
 
-    vfs::ObjectRegistry registry(object_registry_->cluster_id(),
-                                 node,
-                                 registry_);
+    ObjectRegistry registry(object_registry_->cluster_id(),
+                            node,
+                            registry_);
 
     EXPECT_TRUE(registry.node_id() == node);
 
-    const vfs::ObjectId vol_id("volume");
+    const ObjectId vol_id("volume");
     const be::Namespace nspace;
 
     registry.register_base_volume(vol_id, nspace);
 
     EXPECT_TRUE(object_registry_->find(vol_id) != nullptr);
     EXPECT_THROW(object_registry_->unregister(vol_id),
-                 vfs::WrongOwnerException);
+                 WrongOwnerException);
 
     registry.unregister(vol_id);
 }
@@ -234,20 +254,9 @@ TEST_F(ObjectRegistryTest, unregister_from_wrong_node)
 TEST_F(ObjectRegistryTest, list_registrations)
 {
     const unsigned count = 1000;
-    std::set<vfs::ObjectId> vols;
+    std::set<ObjectId> vols(fill(count));
 
-    for (unsigned i = 0; i < count; ++i)
-    {
-        const std::string s(yt::UUID().str());
-        const vfs::ObjectId id(s);
-        object_registry_->register_base_volume(id,
-                                   be::Namespace(s));
-
-        const auto res(vols.insert(id));
-        EXPECT_TRUE(res.second);
-    }
-
-    EXPECT_EQ(count, vols.size());
+    ASSERT_EQ(count, vols.size());
 
     const auto voll(object_registry_->list());
 
@@ -261,57 +270,83 @@ TEST_F(ObjectRegistryTest, list_registrations)
     EXPECT_TRUE(vols.empty());
 }
 
+TEST_F(ObjectRegistryTest, get_all_registrations)
+{
+    ASSERT_TRUE(object_registry_->get_all_registrations(1).empty());
+
+    const size_t count = 128;
+    ASSERT_LT(0, count);
+
+    std::set<ObjectId> ids(fill(count));
+    ASSERT_EQ(count,
+              ids.size());
+
+    const size_t batch_size = count - 1;
+    std::vector<ObjectRegistrationPtr> regv(object_registry_->get_all_registrations(batch_size));
+
+    ASSERT_EQ(count,
+              regv.size());
+
+    for (const auto& reg : regv)
+    {
+        EXPECT_EQ(1U,
+                  ids.erase(reg->volume_id)) << "volume id: " << reg->volume_id;
+    }
+
+    EXPECT_TRUE(ids.empty());
+}
+
 TEST_F(ObjectRegistryTest, tree_config)
 {
-    EXPECT_EQ(vfs::ObjectType::Volume,
-              vfs::ObjectTreeConfig::makeBase().object_type);
+    EXPECT_EQ(ObjectType::Volume,
+              ObjectTreeConfig::makeBase().object_type);
 
-    EXPECT_EQ(vfs::ObjectType::Template,
-              vfs::ObjectTreeConfig::makeTemplate(boost::none).object_type);
+    EXPECT_EQ(ObjectType::Template,
+              ObjectTreeConfig::makeTemplate(boost::none).object_type);
 
-    EXPECT_EQ(vfs::ObjectType::Volume,
-              vfs::ObjectTreeConfig::makeClone(vfs::ObjectId("some_id")).object_type);
+    EXPECT_EQ(ObjectType::Volume,
+              ObjectTreeConfig::makeClone(ObjectId("some_id")).object_type);
 
-    EXPECT_EQ(vfs::ObjectType::File,
-              vfs::ObjectTreeConfig::makeFile().object_type);
+    EXPECT_EQ(ObjectType::File,
+              ObjectTreeConfig::makeFile().object_type);
 
     // the following two are rather silly
-    EXPECT_EQ(vfs::ObjectType::Volume,
-              vfs::ObjectTreeConfig::makeParent(vfs::ObjectType::Volume,
-                                                vfs::ObjectTreeConfig::Descendants(),
-                                                boost::none).object_type);
-    EXPECT_EQ(vfs::ObjectType::Template,
-              vfs::ObjectTreeConfig::makeParent(vfs::ObjectType::Template,
-                                                vfs::ObjectTreeConfig::Descendants(),
-                                                boost::none).object_type);
+    EXPECT_EQ(ObjectType::Volume,
+              ObjectTreeConfig::makeParent(ObjectType::Volume,
+                                           ObjectTreeConfig::Descendants(),
+                                           boost::none).object_type);
+    EXPECT_EQ(ObjectType::Template,
+              ObjectTreeConfig::makeParent(ObjectType::Template,
+                                           ObjectTreeConfig::Descendants(),
+                                           boost::none).object_type);
 }
 
 TEST_F(ObjectRegistryTest, unique_prefix)
 {
-    const vfs::ClusterId cluster_id(yt::UUID().str());
-    vfs::ObjectRegistry oregistry(cluster_id,
-                                  node_id_,
-                                  registry_);
+    const ClusterId cluster_id(yt::UUID().str());
+    ObjectRegistry oregistry(cluster_id,
+                             node_id_,
+                             registry_);
 
     EXPECT_NE(oregistry.prefix(), object_registry_->prefix());
 }
 
 TEST_F(ObjectRegistryTest, foc_config_mode)
 {
-    const vfs::ObjectId vol_id("volume");
+    const ObjectId vol_id("volume");
     const be::Namespace nspace;
     object_registry_->register_base_volume(vol_id, nspace);
 
-    vfs::FailOverCacheConfigMode foc_cm = object_registry_->find(vol_id)->foc_config_mode;
-    EXPECT_TRUE(vfs::FailOverCacheConfigMode::Automatic == foc_cm);
+    FailOverCacheConfigMode foc_cm = object_registry_->find(vol_id)->foc_config_mode;
+    EXPECT_TRUE(FailOverCacheConfigMode::Automatic == foc_cm);
 
-    object_registry_->set_foc_config_mode(vol_id, vfs::FailOverCacheConfigMode::Manual);
+    object_registry_->set_foc_config_mode(vol_id, FailOverCacheConfigMode::Manual);
     foc_cm = object_registry_->find(vol_id)->foc_config_mode;
-    EXPECT_TRUE(vfs::FailOverCacheConfigMode::Manual == foc_cm);
+    EXPECT_TRUE(FailOverCacheConfigMode::Manual == foc_cm);
 
-    object_registry_->set_foc_config_mode(vol_id, vfs::FailOverCacheConfigMode::Automatic);
+    object_registry_->set_foc_config_mode(vol_id, FailOverCacheConfigMode::Automatic);
     foc_cm = object_registry_->find(vol_id)->foc_config_mode;
-    EXPECT_TRUE(vfs::FailOverCacheConfigMode::Automatic == foc_cm);
+    EXPECT_TRUE(FailOverCacheConfigMode::Automatic == foc_cm);
 
     // not much else to do at this level
 

--- a/src/filesystem/test/ScrubManagerTest.cpp
+++ b/src/filesystem/test/ScrubManagerTest.cpp
@@ -608,7 +608,7 @@ TEST_F(ScrubManagerTest, random_stress_single_job)
 
     const std::string id(parent.id.str());
 
-    const std::list<ObjectId> regs(object_registry_->list());
+    const std::vector<ObjectId> regs(object_registry_->list());
     ASSERT_FALSE(regs.empty());
 
     std::set<ObjectId> oids(regs.begin(),

--- a/src/youtils/ArakoonInterface.h
+++ b/src/youtils/ArakoonInterface.h
@@ -211,8 +211,11 @@ public:
     }
 
     template<typename R>
+    using StreamFun = std::function<R(std::istream&)>;
+
+    template<typename R>
     R
-    as_istream(std::function<R(std::istream& is)>&& fun) const
+    as_istream(StreamFun<R> fun) const
     {
         boost::iostreams::array_source src(static_cast<const char*>(data_),
                                            size_);

--- a/src/youtils/LockedArakoon.h
+++ b/src/youtils/LockedArakoon.h
@@ -102,6 +102,25 @@ public:
         return arakoon_->prefix<T, Traits>(begin_key, max_elements);
     }
 
+    template<typename K,
+             typename V,
+             typename KTraits = arakoon::DataBufferTraits<K>,
+             typename VTraits = arakoon::DataBufferTraits<V> >
+    arakoon::key_value_list
+    range_entries(const K& begin_key,
+                  const bool begin_key_included,
+                  const V& end_key,
+                  const bool end_key_included,
+                  const ssize_t max_elements)
+    {
+        LOCK();
+        return arakoon_->range_entries<K, V, KTraits, VTraits>(begin_key,
+                                                               begin_key_included,
+                                                               end_key,
+                                                               end_key_included,
+                                                               max_elements);
+    }
+
     void
     delete_prefix(const std::string& pfx)
     {


### PR DESCRIPTION
This makes the implementation of the `list_volumes` Python API call (with `node_id=None`**!**) more efficient.

It also enhances the Python API, in particular the `ObjectRegistryClient` with functionality to retrieve a list of all `ObjectRegistrations`. This can then be filtered to e.g. determine all volumes owned by a certain node as desired by #55.

Usage example:

```
In [1]: import volumedriver.storagerouter.storagerouterclient as src

In [2]: import json

In [3]: j = None

In [4]: with open("/tmp/RemoteTest/remote/volumedriverfs.json") as f:
    j = json.load(f)
   ...: 

In [5]: cid = str(j["volume_router_cluster"]["vrouter_cluster_id"])

In [6]: ara_cid = str(j["volume_registry"]["vregistry_arakoon_cluster_id"])

In [7]: aras = [ src.ArakoonNodeConfig(str(n["node_id"]), str(n["host"]), int(n["port"])) for n in j["volume_registry"]["vregistry_arakoon_cluster_nodes"] ]

In [8]: oreg = src.ObjectRegistryClient(cid, ara_cid, aras)

In [9]: oreg.get_all_registrations()
Out[9]: []

In [10]: !for i in $(seq 0 1); do truncate -s 1M /tmp/RemoteTest/remote/mnt/test${i}-flat.vmdk; done

In [11]: regs = oreg.get_all_registrations()

In [12]: [ r.object_id() for r in regs if r.object_type() != src.ObjectType.FILE and r.node_id() == 'node_1' ]
Out[12]: 
['43657fcc-2680-41f7-8212-25dd015dfd8f',
 '4b70fd7c-aca4-4ecb-964a-1d3199b664e9']
```