### PR TITLE
Feature/scrubber configurable backend

### DIFF
--- a/src/backend/BackendConfig.cpp
+++ b/src/backend/BackendConfig.cpp
@@ -25,12 +25,17 @@
 #include <boost/filesystem.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
+
 #include <youtils/Assert.h>
+#include <youtils/ConfigLocation.h>
+#include <youtils/ConfigFetcher.h>
+#include <youtils/OptionValidators.h>
 
 namespace backend
 {
 namespace fs = boost::filesystem;
 namespace ip = initialized_params;
+namespace yt = youtils;
 
 std::unique_ptr<BackendConfig>
 BackendConfig::makeBackendConfig(const std::string& json_string)
@@ -44,12 +49,10 @@ BackendConfig::makeBackendConfig(const std::string& json_string)
 }
 
 std::unique_ptr<BackendConfig>
-BackendConfig::makeBackendConfig(const fs::path& json_file)
+BackendConfig::makeBackendConfig(const yt::ConfigLocation& loc)
 {
-    boost::property_tree::ptree pt;
-    boost::property_tree::json_parser::read_json(json_file.string(),
-                                                 pt);
-    return makeBackendConfig(pt);
+    yt::ConfigFetcher fetch_config(loc);
+    return makeBackendConfig(fetch_config(VerifyConfig::F));
 }
 
 std::unique_ptr<BackendConfig>

--- a/src/backend/BackendConfig.cpp
+++ b/src/backend/BackendConfig.cpp
@@ -29,7 +29,7 @@
 #include <youtils/Assert.h>
 #include <youtils/ConfigLocation.h>
 #include <youtils/ConfigFetcher.h>
-#include <youtils/OptionValidators.h>
+#include <youtils/JsonString.h>
 
 namespace backend
 {
@@ -38,10 +38,10 @@ namespace ip = initialized_params;
 namespace yt = youtils;
 
 std::unique_ptr<BackendConfig>
-BackendConfig::makeBackendConfig(const std::string& json_string)
+BackendConfig::makeBackendConfig(const yt::JsonString& json_string)
 {
     boost::property_tree::ptree pt;
-    std::stringstream ss(json_string);
+    std::stringstream ss(json_string.str());
 
     boost::property_tree::json_parser::read_json(ss,
                                                  pt);

--- a/src/backend/BackendConfig.h
+++ b/src/backend/BackendConfig.h
@@ -30,6 +30,7 @@
 namespace youtils
 {
 class ConfigLocation;
+class JsonString;
 }
 
 namespace backend
@@ -48,7 +49,7 @@ public:
     makeBackendConfig(const boost::property_tree::ptree&);
 
     static std::unique_ptr<BackendConfig>
-    makeBackendConfig(const std::string& backend_config);
+    makeBackendConfig(const youtils::JsonString&);
 
     static std::unique_ptr<BackendConfig>
     makeBackendConfig(const youtils::ConfigLocation&);

--- a/src/backend/BackendConfig.h
+++ b/src/backend/BackendConfig.h
@@ -23,10 +23,14 @@
 #include <boost/serialization/export.hpp>
 
 #include <youtils/BooleanEnum.h>
-#include <youtils/Logging.h>
 #include <youtils/ConfigurationReport.h>
+#include <youtils/Logging.h>
 #include <youtils/UpdateReport.h>
 
+namespace youtils
+{
+class ConfigLocation;
+}
 
 namespace backend
 {
@@ -47,8 +51,7 @@ public:
     makeBackendConfig(const std::string& backend_config);
 
     static std::unique_ptr<BackendConfig>
-    makeBackendConfig(const boost::filesystem::path& json_file);
-
+    makeBackendConfig(const youtils::ConfigLocation&);
 
     virtual std::unique_ptr<BackendConfig>
     clone() const = 0;

--- a/src/backend/TestWithBackendMainHelper.cpp
+++ b/src/backend/TestWithBackendMainHelper.cpp
@@ -13,30 +13,36 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
+#include "BackendConfig.h"
+#include "BackendParameters.h"
 #include "TestWithBackendMainHelper.h"
-#include <youtils/ScriptFile.h>
-#include <youtils/System.h>
-#include <youtils/FileUtils.h>
-#include <boost/program_options.hpp>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree_fwd.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/ptr_container/ptr_map.hpp>
 
-#include <youtils/BuildInfo.h>
-#include "youtils/TestBase.h"
-#include <youtils/Logger.h>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree_fwd.hpp>
-#include "BackendConfig.h"
-#include "BackendParameters.h"
 #include <pstreams/pstream.h>
+
+#include <youtils/BuildInfo.h>
+#include <youtils/ConfigFetcher.h>
+#include <youtils/FileUtils.h>
+#include <youtils/Logger.h>
+#include <youtils/ScriptFile.h>
+#include <youtils/System.h>
+#include <youtils/TestBase.h>
+#include <youtils/VolumeDriverComponent.h>
+
 #include <youtils/prudence/prudence.h>
 
 namespace backend
 {
 
 namespace fs = boost::filesystem;
+namespace yt = youtils;
 
 struct AlbaConfigurationData
     : public BackendConfigurationData
@@ -82,8 +88,7 @@ TestWithBackendMainHelper::setupTestBackend()
 
     if(backend_config_)
     {
-        boost::property_tree::json_parser::read_json(*youtils::MainHelper::backend_config_,
-                                                     pt);
+        pt = yt::ConfigFetcher(*yt::MainHelper::backend_config_)(VerifyConfig::F);
         auto backend_config_ = BackendConfig::makeBackendConfig(pt);
         using namespace std::string_literals;
 
@@ -116,7 +121,7 @@ TestWithBackendMainHelper::setupTestBackend()
     else
     {
         initialized_params::PARAMETER_TYPE(backend_type)(BackendType::LOCAL).persist(pt);
-        fs::path local_backend_path = youtils::FileUtils::temp_path() / "localbackend";
+        fs::path local_backend_path = yt::FileUtils::temp_path() / "localbackend";
         initialized_params::PARAMETER_TYPE(local_connection_path)(local_backend_path.string()).persist(pt);
         const fs::path p(local_backend_path);
         LOG_INFO("Removing and recreating directory for localbackend " << p);

--- a/src/backend/TestWithBackendMainHelper.cpp
+++ b/src/backend/TestWithBackendMainHelper.cpp
@@ -32,11 +32,14 @@
 #include "BackendParameters.h"
 #include <pstreams/pstream.h>
 #include <youtils/prudence/prudence.h>
+
 namespace backend
 {
 
+namespace fs = boost::filesystem;
 
-struct AlbaConfigurationData : public BackendConfigurationData
+struct AlbaConfigurationData
+    : public BackendConfigurationData
 {
     AlbaConfigurationData(const std::vector<std::string>& prudence_args)
     {
@@ -57,8 +60,6 @@ struct AlbaConfigurationData : public BackendConfigurationData
 
 };
 
-
-namespace fs = boost::filesystem;
 TestWithBackendMainHelper::TestWithBackendMainHelper(int argc,
                                                      char** argv)
     : TestMainHelper(argc,
@@ -69,8 +70,6 @@ TestWithBackendMainHelper::TestWithBackendMainHelper(int argc,
         ("skip-backend-setup",
          po::value<bool>(&skip_backend_setup_)->default_value(false),
          "whether to skip the backend setup");
-
-
 }
 
 std::unique_ptr<BackendConfig>
@@ -81,9 +80,9 @@ TestWithBackendMainHelper::setupTestBackend()
 {
     boost::property_tree::ptree pt;
 
-    if(backend_config_file_)
+    if(backend_config_)
     {
-        boost::property_tree::json_parser::read_json(youtils::MainHelper::backend_config_file_->string(),
+        boost::property_tree::json_parser::read_json(*youtils::MainHelper::backend_config_,
                                                      pt);
         auto backend_config_ = BackendConfig::makeBackendConfig(pt);
         using namespace std::string_literals;
@@ -130,7 +129,6 @@ TestWithBackendMainHelper::setupTestBackend()
 void
 TestWithBackendMainHelper::tearDownTestBackend()
 {
-
     if(backend_config_)
     {
         if(skip_backend_setup_)

--- a/src/backend/test/SerializationTest.cpp
+++ b/src/backend/test/SerializationTest.cpp
@@ -13,6 +13,7 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
+#include <youtils/JsonString.h>
 #include <youtils/StrongTypedString.h>
 #include <youtils/TestBase.h>
 
@@ -30,7 +31,10 @@ STRONG_TYPED_STRING(TestStringType1, backendtest);
 
 namespace backendtest
 {
+
 using namespace backend;
+
+namespace yt = youtils;
 
 class SerializationTest
     : public youtilstest::TestBase
@@ -47,7 +51,7 @@ protected:
                    pt);
 
         {
-            std::unique_ptr<BackendConfig> bc = BackendConfig::makeBackendConfig(ss.str());
+            std::unique_ptr<BackendConfig> bc = BackendConfig::makeBackendConfig(yt::JsonString(ss.str()));
             EXPECT_TRUE(config == *bc.get()) << "Test failed for backend type " << config.name();
         }
     }

--- a/src/filesystem-python-client/LockedClient.cpp
+++ b/src/filesystem-python-client/LockedClient.cpp
@@ -70,7 +70,8 @@ LockedClient::registerize()
               bpy::args("verbose_scrubbing") = scrubbing::ScrubberAdapter::verbose_scrubbing_default,
               bpy::args("scrubber_binary") = "ovs_scrubber",
               bpy::args("severity") = yt::Severity::info,
-              bpy::args("log_sinks") = std::vector<std::string>()),
+              bpy::args("log_sinks") = std::vector<std::string>(),
+              bpy::args("backend_config") = boost::optional<std::string>()),
               "Scrubs a work unit and returns a scrub_result\n"
              "@param work_unit: a string, a opaque string that encodes the scrub work\n"
              "@param region_size_exponent: a number, "
@@ -82,6 +83,7 @@ LockedClient::registerize()
              "@param scrubber_binary: string, scrubber binary to use\n"
              "@param severity: Severity, log level to use\n"
              "@param log_sinks: [ string ], log sinks to use (if empty, stderr is used)\n"
+             "@param backend_config: optional string, backend config location (file, etcd url, ...)\n"
              "@result a (n opaque) string that encodes the scrub result to apply")
         ;
 }

--- a/src/filesystem/LocalPythonClient.cpp
+++ b/src/filesystem/LocalPythonClient.cpp
@@ -25,6 +25,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <youtils/ConfigLocation.h>
 #include <youtils/Logging.h>
 
 namespace volumedriverfs
@@ -35,7 +36,7 @@ namespace vd = volumedriver;
 namespace yt = youtils;
 
 LocalPythonClient::LocalPythonClient(const std::string& config)
-    : config_fetcher_(config)
+    : config_fetcher_(yt::ConfigLocation(config))
 {
     const bpt::ptree pt(config_fetcher_(VerifyConfig::F));
     const ConfigHelper argument_helper(pt);

--- a/src/filesystem/LocalPythonClient.cpp
+++ b/src/filesystem/LocalPythonClient.cpp
@@ -13,7 +13,6 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
-#include "ConfigFetcher.h"
 #include "ConfigHelper.h"
 #include "FileSystem.h"
 #include "LocalPythonClient.h"

--- a/src/filesystem/LocalPythonClient.h
+++ b/src/filesystem/LocalPythonClient.h
@@ -16,7 +16,6 @@
 #ifndef VFS_LOCAL_PYTHON_CLIENT_H_
 #define VFS_LOCAL_PYTHON_CLIENT_H_
 
-#include "ConfigFetcher.h"
 #include "PythonClient.h"
 
 #include <boost/filesystem.hpp>
@@ -24,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include <youtils/ConfigFetcher.h>
 #include <youtils/Logger.h>
 #include <youtils/Logging.h>
 #include <youtils/UpdateReport.h>
@@ -87,7 +87,7 @@ public:
 private:
     DECLARE_LOGGER("LocalPythonClient");
 
-    ConfigFetcher config_fetcher_;
+    youtils::ConfigFetcher config_fetcher_;
 };
 
 }

--- a/src/filesystem/LockedPythonClient.cpp
+++ b/src/filesystem/LockedPythonClient.cpp
@@ -210,7 +210,8 @@ LockedPythonClient::scrub(const std::string& scrub_work,
                           const bool verbose,
                           const std::string& scrubber_name,
                           const yt::Severity severity,
-                          const std::vector<std::string>& log_sinks)
+                          const std::vector<std::string>& log_sinks,
+                          const boost::optional<std::string>& backend_config)
 {
     LOG_INFO(volume_id_ << ": scrubbing " << scrub_work);
 
@@ -218,17 +219,25 @@ LockedPythonClient::scrub(const std::string& scrub_work,
     THROW_UNLESS(locked_section_);
 
     std::vector<std::string> args;
-    args.reserve(13 + 2 * log_sinks.size());
+    args.reserve(13 + 2 * log_sinks.size() + (backend_config ? 2 : 0));
 
     args.emplace_back(scrubber_name);
-    args.emplace_back("--scrub-work");
-    args.emplace_back(scrub_work);
+
+    if (backend_config)
+    {
+        args.emplace_back("--backend-config");
+        args.emplace_back(*backend_config);
+    }
+
     args.emplace_back("--scratch-dir");
     args.emplace_back(scratch_dir);
     args.emplace_back("--region-size-exponent");
     args.emplace_back(boost::lexical_cast<std::string>(region_size_exponent));
     args.emplace_back("--fill-ratio");
     args.emplace_back(boost::lexical_cast<std::string>(fill_ratio));
+    args.emplace_back("--scrub-work");
+    args.emplace_back(scrub_work);
+
     args.emplace_back("--verbose");
     args.emplace_back(boost::lexical_cast<std::string>(verbose));
     args.emplace_back("--loglevel");

--- a/src/filesystem/LockedPythonClient.h
+++ b/src/filesystem/LockedPythonClient.h
@@ -81,7 +81,8 @@ public:
           const bool verbose,
           const std::string& scrubber_name,
           const youtils::Severity,
-          const std::vector<std::string>& log_sinks);
+          const std::vector<std::string>& log_sinks,
+          const boost::optional<std::string>& backend_config);
 
     // Make the following ones private, with access granted only to the
     // global locking code?

--- a/src/filesystem/Main.cpp
+++ b/src/filesystem/Main.cpp
@@ -13,7 +13,6 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
-#include "ConfigFetcher.h"
 #include "FuseInterface.h"
 
 #include <exception>
@@ -30,6 +29,7 @@
 
 #include <youtils/BuildInfo.h>
 #include <youtils/Catchers.h>
+#include <youtils/ConfigFetcher.h>
 #include <youtils/EtcdUrl.h>
 #include <youtils/Logger.h>
 #include <youtils/Logging.h>
@@ -155,7 +155,7 @@ public:
             return 1;
         }
 
-        vfs::ConfigFetcher config_fetcher(config_location_);
+        yt::ConfigFetcher config_fetcher(config_location_);
         const bpt::ptree pt(config_fetcher(VerifyConfig::T));
 
         // These are unblocked again and "handled" by FileSystem::operator(). We do

--- a/src/filesystem/Main.cpp
+++ b/src/filesystem/Main.cpp
@@ -30,6 +30,7 @@
 #include <youtils/BuildInfo.h>
 #include <youtils/Catchers.h>
 #include <youtils/ConfigFetcher.h>
+#include <youtils/ConfigLocation.h>
 #include <youtils/EtcdUrl.h>
 #include <youtils/Logger.h>
 #include <youtils/Logging.h>
@@ -89,11 +90,11 @@ public:
     {
         opts_.add_options()
             ("config-file,C",
-             po::value<std::string>(&config_location_),
+             po::value<yt::MaybeConfigLocation>(&config_location_),
              "volumedriver (json) config file / etcd URL (deprecated, use --config instead!)")
             ("config",
-             po::value<std::string>(&config_location_),
-             "volumedriver (json) config file / etcd URL (deprecated, use --config instead!)")
+             po::value<yt::MaybeConfigLocation>(&config_location_),
+             "volumedriver (json) config file / etcd URL")
             ("lock-file,L",
              po::value<std::string>(&lock_file_),
              "a lock file used for advisory locking to prevent concurrently starting the same instance - the config-file is used if this is not specified")
@@ -121,7 +122,7 @@ public:
     virtual int
     run()
     {
-        if (config_location_.empty())
+        if (not config_location_)
         {
             std::cerr << "No config location specified" << std::endl;
             return 1;
@@ -130,14 +131,14 @@ public:
         umask(0);
 
         const bool lock_config_file = lock_file_.empty();
-        if (lock_config_file and yt::EtcdUrl::is_one(config_location_))
+        if (lock_config_file and yt::EtcdUrl::is_one(config_location_->str()))
         {
             std::cerr << "No lock file specified / config file will not be used as etcd was requested" << std::endl;
             return 1;
         }
 
         const fs::path lock_path(lock_config_file ?
-                                 config_location_ :
+                                 *config_location_ :
                                  lock_file_);
 
         yt::FileDescriptor fd(lock_path,
@@ -155,7 +156,7 @@ public:
             return 1;
         }
 
-        yt::ConfigFetcher config_fetcher(config_location_);
+        yt::ConfigFetcher config_fetcher(*config_location_);
         const bpt::ptree pt(config_fetcher(VerifyConfig::T));
 
         // These are unblocked again and "handled" by FileSystem::operator(). We do
@@ -199,7 +200,7 @@ private:
     DECLARE_LOGGER("VolumeDriverFS");
 
     po::options_description opts_;
-    std::string config_location_;
+    yt::MaybeConfigLocation config_location_;
     std::string lock_file_;
     std::string mountpoint_;
 

--- a/src/filesystem/Makefile.am
+++ b/src/filesystem/Makefile.am
@@ -64,7 +64,6 @@ libvolumedriverfs_la_SOURCES = \
 		ClusterNodeConfig.cpp \
 		ClusterNodeStatus.cpp \
 		ClusterRegistry.cpp \
-		ConfigFetcher.cpp \
 		ConfigHelper.cpp \
 		DataPoints.cpp \
 		DirectoryEntry.cpp \

--- a/src/filesystem/XMLRPC.cpp
+++ b/src/filesystem/XMLRPC.cpp
@@ -13,7 +13,6 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
-#include "ConfigFetcher.h"
 #include "FileSystem.h"
 #include "ObjectRouter.h"
 
@@ -34,6 +33,7 @@
 #include <boost/thread/thread.hpp>
 
 #include <youtils/ArakoonNodeConfig.h>
+#include <youtils/ConfigFetcher.h>
 #include <youtils/DimensionedValue.h>
 #include <youtils/IOException.h>
 #include <youtils/System.h>
@@ -1450,7 +1450,7 @@ UpdateConfiguration::execute_internal(XmlRpc::XmlRpcValue& params,
 
     const boost::variant<yt::UpdateReport,
                          yt::ConfigurationReport>
-        rep(api::updateConfiguration(ConfigFetcher(config)(VerifyConfig::T)));
+        rep(api::updateConfiguration(yt::ConfigFetcher(config)(VerifyConfig::T)));
 
     result = XMLRPCStructs::serialize_to_xmlrpc_value(rep);
 }

--- a/src/filesystem/XMLRPC.cpp
+++ b/src/filesystem/XMLRPC.cpp
@@ -1446,7 +1446,7 @@ UpdateConfiguration::execute_internal(XmlRpc::XmlRpcValue& params,
                                       XmlRpc::XmlRpcValue& result)
 {
     XMLRPCUtils::ensure_arg(params[0], XMLRPCKeys::configuration_path);
-    const std::string config(params[0][XMLRPCKeys::configuration_path]);
+    const yt::ConfigLocation config(params[0][XMLRPCKeys::configuration_path]);
 
     const boost::variant<yt::UpdateReport,
                          yt::ConfigurationReport>

--- a/src/filesystem/failovercache/FailOverCacheHelperMain.cpp
+++ b/src/filesystem/failovercache/FailOverCacheHelperMain.cpp
@@ -23,6 +23,7 @@
 #include <youtils/Assert.h>
 #include <youtils/ConfigFetcher.h>
 #include <youtils/Logging.h>
+#include <youtils/OptionValidators.h>
 
 #include <../ConfigHelper.h>
 
@@ -36,7 +37,7 @@ int
 main(int argc,
      char** argv)
 {
-    std::string config_location;
+    yt::MaybeConfigLocation config_location;
     fs::path failovercache_executable;
     std::vector<std::string> unparsed_options;
     po::options_description desc;
@@ -51,10 +52,10 @@ main(int argc,
          po::value<fs::path>(&failovercache_executable)->default_value("failovercache"),
          "path to the failovercache executable")
         ("config",
-         po::value<std::string>(&config_location),
+         po::value<yt::MaybeConfigLocation>(&config_location),
          "volumedriverfs (json) config file / etcd URL")
         ("config-file,C",
-         po::value<std::string>(&config_location),
+         po::value<yt::MaybeConfigLocation>(&config_location),
          "volumedriverfs (json) config file (deprecated, use --config instead!)");
 
     {
@@ -99,13 +100,13 @@ main(int argc,
     //
     // LOG_INFO("Parsing the property tree in " << config_location_);
 
-    if (config_location.empty())
+    if (not config_location)
     {
         std::cerr << "No config location specified" << std::endl;
         return 1;
     }
 
-    yt::ConfigFetcher config_fetcher(config_location);
+    yt::ConfigFetcher config_fetcher(*config_location);
     const vfs::ConfigHelper argument_helper(config_fetcher(VerifyConfig::F));
 
     // LOG_INFO("Finished parsing property tree");

--- a/src/filesystem/failovercache/FailOverCacheHelperMain.cpp
+++ b/src/filesystem/failovercache/FailOverCacheHelperMain.cpp
@@ -21,14 +21,15 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <youtils/Assert.h>
+#include <youtils/ConfigFetcher.h>
 #include <youtils/Logging.h>
 
-#include <../ConfigFetcher.h>
 #include <../ConfigHelper.h>
 
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;
 namespace vfs = volumedriverfs;
+namespace yt = youtils;
 
 // Not using MainHelper as it only has 2 args itself and routes the rest through.
 int
@@ -104,7 +105,7 @@ main(int argc,
         return 1;
     }
 
-    vfs::ConfigFetcher config_fetcher(config_location);
+    yt::ConfigFetcher config_fetcher(config_location);
     const vfs::ConfigHelper argument_helper(config_fetcher(VerifyConfig::F));
 
     // LOG_INFO("Finished parsing property tree");

--- a/src/filesystem/test/PythonClientTest.cpp
+++ b/src/filesystem/test/PythonClientTest.cpp
@@ -25,10 +25,13 @@
 #include <xmlrpc++0.7/src/XmlRpcClient.h>
 
 #include <youtils/Catchers.h>
+#include <youtils/ConfigLocation.h>
 #include <youtils/IOException.h>
 #include <youtils/InitializedParam.h>
 #include <youtils/FileDescriptor.h>
 #include <youtils/ScopeExit.h>
+
+#include <backend/BackendConfig.h>
 
 #include <volumedriver/metadata-server/Manager.h>
 #include <volumedriver/SnapshotPersistor.h>
@@ -51,6 +54,7 @@
 namespace volumedriverfstest
 {
 
+namespace be = backend;
 namespace bpt = boost::property_tree;
 namespace bpy = boost::python;
 namespace fs = boost::filesystem;
@@ -182,7 +186,9 @@ protected:
 
         const std::string work_str = bpy::extract<std::string>(work_item);
         const ScrubWork work(work_str);
-        const ScrubReply reply(ScrubberAdapter::scrub(work,
+        const yt::ConfigLocation loc(configuration_.string());
+        const ScrubReply reply(ScrubberAdapter::scrub(be::BackendConfig::makeBackendConfig(loc),
+                                                      work,
                                                       "/tmp"));
         return bpy::make_tuple(work.id_.str(),
                                reply.str());
@@ -1863,7 +1869,8 @@ TEST_F(PythonClientTest, locked_scrub)
                                          scrubbing::ScrubberAdapter::verbose_scrubbing_default,
                                          "ovs_scrubber",
                                          yt::Severity::info,
-                                         std::vector<std::string>()));
+                                         std::vector<std::string>(),
+                                         configuration_.string()));
 
     lclient->apply_scrubbing_result(res);
 }

--- a/src/ganesha-filesystem/FileSystemWrapper.cpp
+++ b/src/ganesha-filesystem/FileSystemWrapper.cpp
@@ -18,15 +18,15 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
+#include <youtils/ConfigFetcher.h>
 #include <youtils/VolumeDriverComponent.h>
-
-#include <filesystem/ConfigFetcher.h>
 
 namespace ganesha
 {
 
 namespace fs = boost::filesystem;
 namespace vfs = volumedriverfs;
+namespace yt = youtils;
 
 namespace
 {
@@ -153,7 +153,7 @@ FileSystemWrapper::FileSystemWrapper(const std::string& export_path,
     : export_path_(export_path)
 {
     boost::property_tree::ptree configuration_ptree;
-    vfs::ConfigFetcher config_fetcher(config);
+    yt::ConfigFetcher config_fetcher(config);
     fs_.reset(new FileSystem(config_fetcher(VerifyConfig::T)));
 }
 

--- a/src/ganesha-filesystem/FileSystemWrapper.cpp
+++ b/src/ganesha-filesystem/FileSystemWrapper.cpp
@@ -16,9 +16,9 @@
 #include "FileSystemWrapper.h"
 
 #include <boost/filesystem/path.hpp>
-#include <boost/property_tree/json_parser.hpp>
 
 #include <youtils/ConfigFetcher.h>
+#include <youtils/ConfigLocation.h>
 #include <youtils/VolumeDriverComponent.h>
 
 namespace ganesha
@@ -152,8 +152,8 @@ FileSystemWrapper::FileSystemWrapper(const std::string& export_path,
                                      const std::string& config)
     : export_path_(export_path)
 {
-    boost::property_tree::ptree configuration_ptree;
-    yt::ConfigFetcher config_fetcher(config);
+    const yt::ConfigLocation loc(config);
+    yt::ConfigFetcher config_fetcher(loc);
     fs_.reset(new FileSystem(config_fetcher(VerifyConfig::T)));
 }
 

--- a/src/volumedriver/PythonScrubber.cpp
+++ b/src/volumedriver/PythonScrubber.cpp
@@ -17,13 +17,15 @@
 #include "ScrubWork.h"
 #include "PythonScrubber.h"
 
+#include <iostream>
+#include <string>
+#include <vector>
+
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/enum.hpp>
 
-#include <iostream>
-#include <string>
-#include <vector>
+#include <youtils/OptionValidators.h>
 
 namespace scrubbing
 {
@@ -31,7 +33,9 @@ namespace scrubbing
 namespace python
 {
 
+namespace be = backend;
 namespace bpy = boost::python;
+namespace yt = youtils;
 
 bpy::tuple
 Scrubber::scrub(const std::string& scrub_work_str,
@@ -39,12 +43,21 @@ Scrubber::scrub(const std::string& scrub_work_str,
                 const uint64_t region_size_exponent,
                 const float fill_ratio,
                 const bool apply_immediately,
-                const bool verbose_scrubbing)
+                const bool verbose_scrubbing,
+                const boost::optional<std::string>& backend_config)
 {
     using namespace scrubbing;
 
     const ScrubWork work(scrub_work_str);
-    const ScrubReply reply(ScrubberAdapter::scrub(work,
+
+    std::unique_ptr<be::BackendConfig> bcfg;
+    if (backend_config)
+    {
+        bcfg = be::BackendConfig::makeBackendConfig(yt::ConfigLocation(*backend_config));
+    }
+
+    const ScrubReply reply(ScrubberAdapter::scrub(std::move(bcfg),
+                                                  work,
                                                   scratch_dir,
                                                   region_size_exponent,
                                                   fill_ratio,
@@ -70,7 +83,8 @@ Scrubber::registerize()
               args("region_size_exponent") = ScrubberAdapter::region_size_exponent_default,
               args("fill_ratio") = ScrubberAdapter::fill_ratio_default,
               args("apply_immediately") = ScrubberAdapter::apply_immediately_default,
-              args("verbose_scrubbing") = ScrubberAdapter::verbose_scrubbing_default),
+              args("verbose_scrubbing") = ScrubberAdapter::verbose_scrubbing_default,
+              args("backend_config") = boost::optional<std::string>()),
               "Scrubs a work unit and returns a scrub_result\n",
              "@param work_unit: a string, a opaque string that encodes the scrub work\n"
              "@param region_size_exponent: a number, "
@@ -79,8 +93,8 @@ Scrubber::registerize()
              "@param fill_ratio: a number, giving the sco fill ratio, default 0.9\n"
              "@param apply_immediately: a boolean, "
              "should be set to true only for scrubbing with PIT replicated volumes, default False\n"
-             "@parm verbose_scrubbing: a boolean, "
-             "whether the scrubbing should print it's intermediate result, default True\n"
+             "@parm verbose_scrubbing: a boolean, whether the scrubbing should print it's intermediate result, default True\n"
+             "@param backend_config: optional string, backend config location (file, etcd url, ...)\n"
              "@result a tuple of volume_id and a string that encodes the scrub result to apply")
         .staticmethod("scrub");
 }

--- a/src/volumedriver/PythonScrubber.h
+++ b/src/volumedriver/PythonScrubber.h
@@ -37,7 +37,8 @@ struct Scrubber
           const uint64_t region_size_exponent,
           const float fill_ratio,
           const bool apply_immediately,
-          const bool verbose_scrubbing);
+          const bool verbose_scrubbing,
+          const boost::optional<std::string>& backend_config);
 
     static void
     registerize();

--- a/src/volumedriver/ScrubWork.h
+++ b/src/volumedriver/ScrubWork.h
@@ -24,10 +24,10 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
+#include <youtils/JsonString.h>
 #include <youtils/Serialization.h>
 
 #include <backend/BackendConfig.h>
-
 
 namespace scrubbing
 {
@@ -124,7 +124,7 @@ struct ScrubWork
     {
         std::string backend_config;
         ar & BOOST_SERIALIZATION_NVP(backend_config);
-        backend_config_ = backend::BackendConfig::makeBackendConfig(backend_config);
+        backend_config_ = backend::BackendConfig::makeBackendConfig(youtils::JsonString(backend_config));
 
         ar & BOOST_SERIALIZATION_NVP(ns_);
         ar & BOOST_SERIALIZATION_NVP(id_);

--- a/src/volumedriver/ScrubberAdapter.cpp
+++ b/src/volumedriver/ScrubberAdapter.cpp
@@ -38,7 +38,8 @@ const bool
 ScrubberAdapter::verbose_scrubbing_default = true;
 
 ScrubReply
-ScrubberAdapter::scrub(const ScrubWork& scrub_work,
+ScrubberAdapter::scrub(std::unique_ptr<BackendConfig> backend_config,
+                       const ScrubWork& scrub_work,
                        const fs::path& scratch_dir,
                        const uint64_t region_size_exponent,
                        const float fill_ratio,
@@ -47,7 +48,11 @@ ScrubberAdapter::scrub(const ScrubWork& scrub_work,
 {
     ScrubberArgs scrubber_args;
 
-    scrubber_args.backend_config = scrub_work.backend_config_->clone();
+    scrubber_args.backend_config =
+        backend_config ?
+        std::move(backend_config) :
+        scrub_work.backend_config_->clone();
+
     scrubber_args.name_space = scrub_work.ns_.str();
     scrubber_args.scratch_dir = scratch_dir;
     scrubber_args.snapshot_name = scrub_work.snapshot_name_;

--- a/src/volumedriver/ScrubberAdapter.h
+++ b/src/volumedriver/ScrubberAdapter.h
@@ -46,7 +46,8 @@ struct ScrubberAdapter
     const static bool verbose_scrubbing_default;
 
     static ScrubReply
-    scrub(const ScrubWork&,
+    scrub(std::unique_ptr<backend::BackendConfig>,
+          const ScrubWork&,
           const boost::filesystem::path& workdir,
           const uint64_t region_size_exponent = region_size_exponent_default,
           const float fill_ratio = fill_ratio_default,

--- a/src/volumedriver/scrubber/Main.cpp
+++ b/src/volumedriver/scrubber/Main.cpp
@@ -12,6 +12,7 @@
 // the LICENSE.txt file of the Open vStorage OSE distribution.
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
+
 #include "../ScrubberAdapter.h"
 #include "../ScrubReply.h"
 #include "../ScrubWork.h"
@@ -27,6 +28,7 @@
 namespace
 {
 
+namespace be = backend;
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;
 namespace sc = scrubbing;
@@ -117,7 +119,14 @@ public:
             return ret;
         }
 
-        const ScrubReply reply(ScrubberAdapter::scrub(ScrubWork(scrub_work_str_),
+        std::unique_ptr<be::BackendConfig> bcfg;
+        if (yt::MainHelper::backend_config_)
+        {
+            bcfg = be::BackendConfig::makeBackendConfig(*yt::MainHelper::backend_config_);
+        }
+
+        const ScrubReply reply(ScrubberAdapter::scrub(std::move(bcfg),
+                                                      ScrubWork(scrub_work_str_),
                                                       scratch_dir_,
                                                       region_size_exponent_,
                                                       fill_ratio_,

--- a/src/volumedriver/test/MDSVolumeTest.cpp
+++ b/src/volumedriver/test/MDSVolumeTest.cpp
@@ -441,7 +441,8 @@ protected:
     scrub(const scrubbing::ScrubWork& work,
           double fill_ratio = 1.0)
     {
-        return scrubbing::ScrubberAdapter::scrub(work,
+        return scrubbing::ScrubberAdapter::scrub(VolManager::get()->getBackendConfig().clone(),
+                                                 work,
                                                  getTempPath(testName_),
                                                  5, // region_size_exponent
                                                  fill_ratio, // fill ratio

--- a/src/volumedriver/test/ScrubberTest.cpp
+++ b/src/volumedriver/test/ScrubberTest.cpp
@@ -68,7 +68,8 @@ public:
              bool apply_immediately = false,
              bool verbose_scrubbing = true)
     {
-        return ScrubberAdapter::scrub(scrub_work,
+        return ScrubberAdapter::scrub(VolManager::get()->getBackendConfig().clone(),
+                                      scrub_work,
                                       getTempPath(testName_),
                                       region_size_exponent,
                                       fill_ratio,

--- a/src/youtils/ConfigFetcher.h
+++ b/src/youtils/ConfigFetcher.h
@@ -13,19 +13,20 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
-#ifndef VFS_CONFIG_FETCHER_H_
-#define VFS_CONFIG_FETCHER_H_
+#ifndef YT_CONFIG_FETCHER_H_
+#define YT_CONFIG_FETCHER_H_
 
-#include <youtils/EtcdUrl.h>
-#include <youtils/IOException.h>
-#include <youtils/Logging.h>
-#include <youtils/EtcdReply.h>
-#include <youtils/VolumeDriverComponent.h>
+#include "IOException.h"
+#include "Logging.h"
+#include "EtcdReply.h"
+#include "VolumeDriverComponent.h"
 
 #include <boost/property_tree/ptree_fwd.hpp>
 
-namespace volumedriverfs
+namespace youtils
 {
+
+class EtcdReply;
 
 class ConfigFetcher
 {
@@ -42,14 +43,14 @@ public:
     operator()(VerifyConfig);
 
     std::string
-    parse_config(const youtils::EtcdReply::Records& recs);
+    parse_config(const EtcdReply::Records&);
 
 private:
-    DECLARE_LOGGER("VFSConfigFetcher");
+    DECLARE_LOGGER("ConfigFetcher");
 
     std::string config_;
 };
 
 }
 
-#endif // !VFS_CONFIG_FETCHER_H_
+#endif // !YT_CONFIG_FETCHER_H_

--- a/src/youtils/ConfigFetcher.h
+++ b/src/youtils/ConfigFetcher.h
@@ -16,6 +16,7 @@
 #ifndef YT_CONFIG_FETCHER_H_
 #define YT_CONFIG_FETCHER_H_
 
+#include "ConfigLocation.h"
 #include "IOException.h"
 #include "Logging.h"
 #include "EtcdReply.h"
@@ -33,7 +34,7 @@ class ConfigFetcher
 public:
     MAKE_EXCEPTION(Exception, fungi::IOException);
 
-    explicit ConfigFetcher(const std::string& config)
+    explicit ConfigFetcher(const ConfigLocation& config)
         : config_(config)
     {}
 
@@ -48,7 +49,7 @@ public:
 private:
     DECLARE_LOGGER("ConfigFetcher");
 
-    std::string config_;
+    ConfigLocation config_;
 };
 
 }

--- a/src/youtils/ConfigLocation.h
+++ b/src/youtils/ConfigLocation.h
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#ifndef YT_CONFIG_LOCATION_H_
+#define YT_CONFIG_LOCATION_H_
+
+#include "StrongTypedString.h"
+
+// TODO: in the long run we might want to make it smarter / unify it
+// with Url.h!?
+STRONG_TYPED_STRING(youtils, ConfigLocation);
+
+#endif // !YT_CONFIG_LOCATION_H_

--- a/src/youtils/JsonString.h
+++ b/src/youtils/JsonString.h
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#ifndef YT_JSON_STRING_H_
+#define YT_JSON_STRING_H_
+
+#include "StrongTypedString.h"
+
+// TODO: in the long run we might want to make it smarter / unify it
+// with Url.h!?
+STRONG_TYPED_STRING(youtils, JsonString);
+
+#endif // !YT_JSON_STRING_H_

--- a/src/youtils/MainHelper.cpp
+++ b/src/youtils/MainHelper.cpp
@@ -13,6 +13,7 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
+#include "ConfigLocation.h"
 #include "FileUtils.h"
 #include "Logging.h"
 #include "MainHelper.h"
@@ -231,7 +232,7 @@ MainHelper::parse_standard_options()
 
     if (not backend_config_ and backend_config_file_)
     {
-        backend_config_ = backend_config_file_->string();
+        backend_config_ = ConfigLocation(backend_config_file_->string());
     }
 }
 

--- a/src/youtils/MainHelper.cpp
+++ b/src/youtils/MainHelper.cpp
@@ -30,8 +30,8 @@ namespace bpt = boost::property_tree;
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;
 
-ExistingFile
-MainHelper::backend_config_file_;
+MaybeConfigLocation
+MainHelper::backend_config_;
 
 MainHelper::MainHelper(const constructor_type& args)
     : unparsed_options_(args.second)
@@ -66,7 +66,10 @@ MainHelper::MainHelper(const constructor_type& args)
     backend_options_.add_options()
         ("backend-config-file",
          po::value<ExistingFile>(&backend_config_file_),
-         "backend config file, a json file that holds the backend configuration");
+         "backend config file, a json file that holds the backend configuration (DEPRECATED, use 'backend-config' instead!)")
+        ("backend-config",
+         po::value<decltype(backend_config_)>(&backend_config_),
+         "backend config (file, etcd url, ...)");
 
     standard_options_.add(logging_options_)
         .add(general_options_)
@@ -224,6 +227,11 @@ MainHelper::parse_standard_options()
         std::cout << standard_options_ << std::endl;
         log_extra_help(std::cout);
         exit(0);
+    }
+
+    if (not backend_config_ and backend_config_file_)
+    {
+        backend_config_ = backend_config_file_->string();
     }
 }
 

--- a/src/youtils/MainHelper.h
+++ b/src/youtils/MainHelper.h
@@ -104,7 +104,7 @@ protected:
     std::vector<std::string> unparsed_options_;
 
 public:
-    static ExistingFile backend_config_file_;
+    static MaybeConfigLocation backend_config_;
 
 private:
     std::vector<std::string> args_;
@@ -113,6 +113,8 @@ private:
     boost::program_options::options_description general_options_;
     boost::program_options::options_description standard_options_;
     boost::program_options::options_description backend_options_;
+
+    ExistingFile backend_config_file_;
 
 protected:
     const std::string executable_name_;

--- a/src/youtils/Makefile.am
+++ b/src/youtils/Makefile.am
@@ -53,6 +53,7 @@ libyoutils_la_SOURCES = \
 	Catchers.cpp \
 	Chooser.cpp \
 	ConfigurationReport.cpp \
+	ConfigFetcher.cpp \
 	CorbaTestSetup.cpp \
 	cpu_timer.cpp \
 	DeferredFileRemover.cpp \

--- a/src/youtils/OptionValidators.cpp
+++ b/src/youtils/OptionValidators.cpp
@@ -63,14 +63,14 @@ validate(boost::any& v,
 
     if (EtcdUrl::is_one(s))
     {
-        v = boost::any(MaybeConfigLocation(s));
+        v = boost::any(MaybeConfigLocation(ConfigLocation(s)));
     }
     else
     {
         const fs::path p(s);
         if(fs::exists(p))
         {
-            v = boost::any(MaybeConfigLocation(s));
+            v = boost::any(MaybeConfigLocation(ConfigLocation(s)));
         }
         else
         {

--- a/src/youtils/OptionValidators.cpp
+++ b/src/youtils/OptionValidators.cpp
@@ -13,10 +13,13 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
+#include "EtcdUrl.h"
 #include "OptionValidators.h"
 
 namespace youtils
 {
+
+using namespace boost::program_options;
 namespace fs = ::boost::filesystem;
 
 void
@@ -25,7 +28,6 @@ validate(boost::any& v,
          ExistingFile* /* out */,
          int)
 {
-    using namespace boost::program_options;
     validators::check_first_occurrence(v);
     const std::string& s = validators::get_single_string(values);
     if(s.empty())
@@ -45,4 +47,36 @@ validate(boost::any& v,
         throw validation_error(validation_error::invalid_option_value);
     }
 }
+
+void
+validate(boost::any& v,
+         const std::vector<std::string>& values,
+         MaybeConfigLocation* /* out */,
+         int)
+{
+    validators::check_first_occurrence(v);
+    const std::string& s = validators::get_single_string(values);
+    if(s.empty())
+    {
+        throw validation_error(validation_error::invalid_option_value);
+    }
+
+    if (EtcdUrl::is_one(s))
+    {
+        v = boost::any(MaybeConfigLocation(s));
+    }
+    else
+    {
+        const fs::path p(s);
+        if(fs::exists(p))
+        {
+            v = boost::any(MaybeConfigLocation(s));
+        }
+        else
+        {
+            throw validation_error(validation_error::invalid_option_value);
+        }
+    }
+}
+
 }

--- a/src/youtils/OptionValidators.h
+++ b/src/youtils/OptionValidators.h
@@ -16,6 +16,8 @@
 #ifndef OPTION_VALIDATORS_H_
 #define OPTION_VALIDATORS_H_
 
+#include "ConfigLocation.h"
+
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/optional.hpp>
@@ -40,10 +42,10 @@ validate(boost::any& v,
          int);
 
 struct MaybeConfigLocation
-    : boost::optional<std::string>
+    : boost::optional<ConfigLocation>
 {
-    MaybeConfigLocation(const std::string& loc)
-        : boost::optional<std::string>(loc)
+    MaybeConfigLocation(const ConfigLocation& loc)
+        : boost::optional<ConfigLocation>(loc)
     {}
 
     MaybeConfigLocation() = default;
@@ -55,7 +57,6 @@ validate(boost::any& v,
          MaybeConfigLocation* loc,
          int);
 }
-
 
 #endif // OPTION_VALIDATORS_H_
 

--- a/src/youtils/OptionValidators.h
+++ b/src/youtils/OptionValidators.h
@@ -15,21 +15,22 @@
 
 #ifndef OPTION_VALIDATORS_H_
 #define OPTION_VALIDATORS_H_
+
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/optional.hpp>
+
 namespace youtils
 {
 
-struct ExistingFile : boost::optional<boost::filesystem::path>
+struct ExistingFile
+    : boost::optional<boost::filesystem::path>
 {
     ExistingFile(boost::filesystem::path& pth)
         : boost::optional<boost::filesystem::path>(pth)
     {}
 
-    ExistingFile()
-    {}
-
+    ExistingFile() = default;
 };
 
 void
@@ -38,10 +39,26 @@ validate(boost::any& v,
          ExistingFile* out,
          int);
 
+struct MaybeConfigLocation
+    : boost::optional<std::string>
+{
+    MaybeConfigLocation(const std::string& loc)
+        : boost::optional<std::string>(loc)
+    {}
+
+    MaybeConfigLocation() = default;
+};
+
+void
+validate(boost::any& v,
+         const std::vector<std::string>& values,
+         MaybeConfigLocation* loc,
+         int);
 }
 
 
 #endif // OPTION_VALIDATORS_H_
+
 // Local Variables: **
 // mode: c++ **
 // End: **


### PR DESCRIPTION
The scrubber and its Python API was modified to take an optional backend configuration (any location supported by `ConfigFetcher` will work, i.e. a JSON file or a etcd URI) which if specified overrides the backend configuration in the scrub work retrieved from the volume.

Addresses #53 .

Example:

```
In [42]: with client.make_locked_client(v) as l:
    ws = l.get_scrubbing_workunits()
    for w in ws:
        print "we're scrubbin'"
        res = l.scrub(w, "/tmp/scrubscratch", verbose_scrubbing=False, scrubber_binary="target/clang/bin/ovs_scrubber", severity=src.Severity.fatal, backend_config="/tmp/RemoteTest/remote/volumedriverfs.json")
print res
   ....: 
we're scrubbin'
2016-07-07 21:07:17 793172 +0200 - blackadder - 912/0x00007fe2b14eb940 - scrubber/target/clang/bin/ovs_scrubber - 0000000000000000 -  notice - print_version_data: version: 6.0.2
version revision: 953b9ed2bb41f8c5b4139889a9facf8de6dd03c0
branch: feature/scrubber-configurable-backend
md5 support: yes
revision: 81975ce65f13f110f63ef1f37ec70dd1a46cdd2a
build time: Wed Jul  6 15:34:01 UTC 2016

2016-07-07 21:07:17 793505 +0200 - blackadder - 912/0x00007fe2b14eb940 - scrubber/target/clang/bin/ovs_scrubber - 0000000000000001 -  notice - print_version_data: Command Line Options
2016-07-07 21:07:17 876353 +0200 - blackadder - 912/0x00007fe2b14eb940 - scrubber/target/clang/bin/ovs_scrubber - 0000000000000002 -  notice - at_exit: Time spent executing user instructions (seconds): 0.44000
Time spent in operating system code (seconds): 0.4000
The maximum resident set size used, in kilobytes. 32892
The number of page faults which were serviced without requiring any I/O: 2764
The number of page faults which were serviced by doing I/O: 0
The number of times PROCESSES was swapped entirely out of main memory: 0
The number of times the file system had to read from the disk: 0
The number of times the file system had to write to the disk: 48
The number of signals received: 0
The number of times PROCESSES voluntarily invoked a context switch: 24
The number of times an involuntary context switch took place: 3

<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
<!DOCTYPE boost_serialization>
<boost_serialization signature="serialization::archive" version="11">
<scrubreply class_id="0" tracking_level="0" version="2">
	<ns_ class_id="1" tracking_level="0" version="0">
		<namespace>ddba2423-da88-4c66-9e90-11f33578d5c7</namespace>
	</ns_>
	<snapshot_name_ class_id="2" tracking_level="0" version="0">
		<SnapshotName>Thu Jul 2016 20:34:46 b4334e3d-a16f-4376-908a-6e82f8616c22</SnapshotName>
	</snapshot_name_>
	<scrub_result_name_>scrubbing_result483d1539-beb2-465f-b9e2-ff5cbd994ea0</scrub_result_name_>
</scrubreply>
```