### PR TITLE
Feature/add edge uri to cluster registry

### DIFF
--- a/src/filesystem-python-client/PythonTestHelpers.cpp
+++ b/src/filesystem-python-client/PythonTestHelpers.cpp
@@ -19,6 +19,7 @@
 #include <boost/python/class.hpp>
 
 #include <youtils/ArakoonNodeConfig.h>
+#include <youtils/Uri.h>
 
 #include <volumedriver/Types.h>
 
@@ -125,6 +126,9 @@ PythonTestHelpers::registerize()
         .def("reflect_maybe_chrono_seconds",
              &PythonTestHelpers::reflect<boost::optional<boost::chrono::seconds>>)
         .staticmethod("reflect_maybe_chrono_seconds")
+        .def("reflect_uri",
+             &PythonTestHelpers::reflect<youtils::Uri>)
+        .staticmethod("reflect_uri")
         ;
 }
 

--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -874,26 +874,38 @@ BOOST_PYTHON_MODULE(storagerouterclient)
     REGISTER_STRONG_ARITHMETIC_TYPEDEF_CONVERTER(vfs::XmlRpcPort);
     REGISTER_STRONG_ARITHMETIC_TYPEDEF_CONVERTER(vfs::FailoverCachePort);
 
-    bpy::class_<vfs::ClusterNodeConfig>("ClusterNodeConfig",
-                                        "configuration of a single volumedriverfs cluster node",
-                                        bpy::init<const vfs::NodeId&,
-                                                  const std::string&,
-                                                  vfs::MessagePort,
-                                                  vfs::XmlRpcPort,
-                                                  vfs::FailoverCachePort>((bpy::args("vrouter_id"),
-                                                                           bpy::args("host"),
-                                                                           bpy::args("message_port"),
-                                                                           bpy::args("xmlrpc_port"),
-                                                                           bpy::args("failovercache_port")),
-                                                                          "Create a cluster node configuration\n"
-                                                                          "@param vrouter_id: string, node ID\n"
-                                                                          "@param host: string, hostname or IP address\n"
-                                                                          "@param message_port: uint16_t, TCP port used for communication between nodes\n"
-                                                                          "@param xmlrpc_port: uint16_t, TCP port used for XMLRPC based management\n"
-                                                                          "@param failovercache_port: uint16_t, TCP port of the FailoverCache for this node\n"))
-        .def("__str__", &vfs::ClusterNodeConfig::str)
-        .def("__repr__", &vfs::ClusterNodeConfig::str)
-        .def("__eq__", &vfs::ClusterNodeConfig::operator==)
+    using MaybeUri = boost::optional<youtils::Uri>;
+
+    REGISTER_OPTIONAL_CONVERTER(youtils::Uri);
+
+    bpy::class_<vfs::ClusterNodeConfig>
+        ("ClusterNodeConfig",
+         "configuration of a single volumedriverfs cluster node",
+         bpy::init<const vfs::NodeId&,
+                   const std::string&,
+                   vfs::MessagePort,
+                   vfs::XmlRpcPort,
+                   vfs::FailoverCachePort,
+                   const MaybeUri&>
+         ((bpy::args("vrouter_id"),
+           bpy::args("host"),
+           bpy::args("message_port"),
+           bpy::args("xmlrpc_port"),
+           bpy::args("failovercache_port"),
+           bpy::args("network_server_uri") = MaybeUri()),
+          "Create a cluster node configuration\n"
+          "@param vrouter_id: string, node ID\n"
+          "@param host: string, hostname or IP address\n"
+          "@param message_port: uint16_t, TCP port used for communication between nodes\n"
+          "@param xmlrpc_port: uint16_t, TCP port used for XMLRPC based management\n"
+          "@param failovercache_port: uint16_t, TCP port of the FailoverCache for this node\n"
+          "@param network_server_uri: optional string (URI), URI the network server shall listen on\n"))
+        .def("__str__",
+             &vfs::ClusterNodeConfig::str)
+        .def("__repr__",
+             &vfs::ClusterNodeConfig::str)
+        .def("__eq__",
+             &vfs::ClusterNodeConfig::operator==)
 
 #define DEF_READONLY_PROP_(name)                                \
         .def_readonly(#name, &vfs::ClusterNodeConfig::name)
@@ -903,6 +915,7 @@ BOOST_PYTHON_MODULE(storagerouterclient)
         DEF_READONLY_PROP_(message_port)
         DEF_READONLY_PROP_(xmlrpc_port)
         DEF_READONLY_PROP_(failovercache_port)
+        DEF_READONLY_PROP_(network_server_uri)
 
 #undef DEF_READONLY_PROP_
         ;

--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -866,6 +866,7 @@ BOOST_PYTHON_MODULE(storagerouterclient)
     vfspy::LocalClient::registerize();
     vfspy::ArakoonClient::registerize();
 
+    REGISTER_STRINGY_CONVERTER(youtils::Uri);
     REGISTER_STRINGY_CONVERTER(vfs::ClusterId);
     REGISTER_STRINGY_CONVERTER(vfs::NodeId);
 

--- a/src/filesystem-python-client/StringyConverter.h
+++ b/src/filesystem-python-client/StringyConverter.h
@@ -4,6 +4,7 @@
 #include <typeinfo>
 
 #include <boost/filesystem/path.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/python/object.hpp>
 #include <boost/python/to_python_converter.hpp>
 
@@ -12,6 +13,7 @@
 
 #include <youtils/Assert.h>
 #include <youtils/Logging.h>
+#include <youtils/Uri.h>
 
 // TODO: move to another namespace / location. youtils? youtils::pyconverters?
 namespace volumedriverfs
@@ -40,6 +42,16 @@ struct StringyConverterTraits<boost::filesystem::path>
     str(const boost::filesystem::path& p)
     {
         return p.string();
+    }
+};
+
+template<>
+struct StringyConverterTraits<youtils::Uri>
+{
+    static std::string
+    str(const youtils::Uri& u)
+    {
+        return boost::lexical_cast<std::string>(u);
     }
 };
 

--- a/src/filesystem-python-client/test/fs_python_client_test.py.in
+++ b/src/filesystem-python-client/test/fs_python_client_test.py.in
@@ -124,7 +124,8 @@ class TestHelperTest(unittest.TestCase):
                                       "hostname%i" % i,
                                       10 * i + 1,
                                       10 * i + 2,
-                                      10 * i + 3) for i in xrange(5)]
+                                      10 * i + 3,
+                                      "rdma://hostname%i:23456" % i) for i in xrange(5)]
         self.assertEqual(
             cfg_list, PythonTestHelpers.reflect_cluster_node_config_list(cfg_list))
 
@@ -154,3 +155,7 @@ class TestHelperTest(unittest.TestCase):
     def test_maybe_chrono_seconds(self):
         self.assertEqual(None, PythonTestHelpers.reflect_maybe_chrono_seconds(None))
         self.assertEqual(1234, PythonTestHelpers.reflect_maybe_chrono_seconds(1234))
+
+    def test_uri(self):
+        s = "tcp://127.0.0.1:1234"
+        self.assertEqual(s, PythonTestHelpers.reflect_uri(s))

--- a/src/filesystem/ClusterNodeConfig.h
+++ b/src/filesystem/ClusterNodeConfig.h
@@ -25,6 +25,7 @@
 #include <youtils/Assert.h>
 #include <youtils/OurStrongTypedef.h>
 #include <youtils/Serialization.h>
+#include <youtils/Uri.h>
 
 OUR_STRONG_ARITHMETIC_TYPEDEF(uint16_t, MessagePort, volumedriverfs);
 OUR_STRONG_ARITHMETIC_TYPEDEF(uint16_t, XmlRpcPort, volumedriverfs);
@@ -35,16 +36,20 @@ namespace volumedriverfs
 
 struct ClusterNodeConfig
 {
+    using MaybeUri = boost::optional<youtils::Uri>;
+
     ClusterNodeConfig(const NodeId& id,
                       const std::string& h,
                       MessagePort mport,
                       XmlRpcPort xport,
-                      FailoverCachePort fport)
+                      FailoverCachePort fport,
+                      const MaybeUri& nw_uri)
         : vrouter_id(id)
         , host(h)
         , message_port(mport)
         , xmlrpc_port(xport)
         , failovercache_port(fport)
+        , network_server_uri(nw_uri)
     {
         //we don't allow empty node_id's as the empty string is
         //used in our python API as "don't care"
@@ -59,6 +64,7 @@ struct ClusterNodeConfig
         , message_port(other.message_port)
         , xmlrpc_port(other.xmlrpc_port)
         , failovercache_port(other.failovercache_port)
+        , network_server_uri(other.network_server_uri)
     {}
 
     ClusterNodeConfig&
@@ -71,6 +77,7 @@ struct ClusterNodeConfig
             const_cast<MessagePort&>(message_port) = other.message_port;
             const_cast<XmlRpcPort&>(xmlrpc_port) = other.xmlrpc_port;
             const_cast<FailoverCachePort&>(failovercache_port) = other.failovercache_port;
+            const_cast<MaybeUri&>(network_server_uri) = other.network_server_uri;
         }
 
         return *this;
@@ -84,7 +91,8 @@ struct ClusterNodeConfig
             (host == other.host) and
             (message_port == other.message_port) and
             (xmlrpc_port == other.xmlrpc_port) and
-            (failovercache_port == other.failovercache_port);
+            (failovercache_port == other.failovercache_port) and
+            (network_server_uri == other.network_server_uri);
     }
 
     bool
@@ -93,17 +101,45 @@ struct ClusterNodeConfig
         return not (*this == other);
     }
 
+    BOOST_SERIALIZATION_SPLIT_MEMBER();
+
     template<class Archive>
     void
-    serialize(Archive& ar, const unsigned version)
+    load(Archive& ar, const unsigned version)
     {
-        CHECK_VERSION(version, 1);
+        if (version > 2)
+        {
+            THROW_SERIALIZATION_ERROR(version, 2, 1);
+        }
 
         ar & const_cast<NodeId&>(vrouter_id);
         ar & const_cast<std::string&>(host);
-        ar & static_cast<uint16_t&>(const_cast<MessagePort&>(message_port));
-        ar & static_cast<uint16_t&>(const_cast<XmlRpcPort&>(xmlrpc_port));
-        ar & static_cast<uint16_t&>(const_cast<FailoverCachePort&>(failovercache_port));
+        ar & const_cast<MessagePort&>(message_port);
+        ar & const_cast<XmlRpcPort&>(xmlrpc_port);
+        ar & const_cast<FailoverCachePort&>(failovercache_port);
+
+        if (version > 1)
+        {
+            ar & const_cast<MaybeUri&>(network_server_uri);
+        }
+        else
+        {
+            const_cast<MaybeUri&>(network_server_uri) = boost::none;
+        }
+    }
+
+    template<class Archive>
+    void
+    save(Archive& ar, const unsigned version) const
+    {
+        CHECK_VERSION(version, 2);
+
+        ar & vrouter_id;
+        ar & host;
+        ar & message_port;
+        ar & xmlrpc_port;
+        ar & failovercache_port;
+        ar & network_server_uri;
     }
 
     // for python consumption
@@ -115,6 +151,7 @@ struct ClusterNodeConfig
     const MessagePort message_port;
     const XmlRpcPort xmlrpc_port;
     const FailoverCachePort failovercache_port;
+    const MaybeUri network_server_uri;
 };
 
 std::ostream&
@@ -125,7 +162,7 @@ using ClusterNodeConfigs = std::vector<ClusterNodeConfig>;
 
 }
 
-BOOST_CLASS_VERSION(volumedriverfs::ClusterNodeConfig, 1);
+BOOST_CLASS_VERSION(volumedriverfs::ClusterNodeConfig, 2);
 
 namespace boost
 {
@@ -145,7 +182,8 @@ load_construct_data(Archive& ar,
                                   "",
                                   MessagePort(0),
                                   XmlRpcPort(0),
-                                  FailoverCachePort(0));
+                                  FailoverCachePort(0),
+                                  youtils::Uri());
 }
 
 }

--- a/src/filesystem/ClusterNodeStatus.h
+++ b/src/filesystem/ClusterNodeStatus.h
@@ -110,7 +110,8 @@ load_construct_data(Archive&,
                           "",
                           MessagePort(0),
                           XmlRpcPort(0),
-                          FailoverCachePort(0));
+                          FailoverCachePort(0),
+                          youtils::Uri());
 
     new(status) ClusterNodeStatus(cfg,
                                   ClusterNodeStatus::State::Offline);

--- a/src/filesystem/FileSystemParameters.cpp
+++ b/src/filesystem/FileSystemParameters.cpp
@@ -202,7 +202,7 @@ DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(network_uri,
                                       "network_uri",
                                       "URI to bind network interface",
                                       ShowDocumentation::T,
-                                      "tcp://127.0.0.1:21321"s);
+                                      yt::Uri("tcp://127.0.0.1:21321"));
 
 DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(network_snd_rcv_queue_depth,
                                       network_interface_component_name,

--- a/src/filesystem/FileSystemParameters.h
+++ b/src/filesystem/FileSystemParameters.h
@@ -28,6 +28,7 @@
 
 #include <youtils/ArakoonNodeConfig.h>
 #include <youtils/InitializedParam.h>
+#include <youtils/Uri.h>
 
 #include <volumedriver/FailOverCacheTransport.h>
 #include <volumedriver/MDSNodeConfig.h>
@@ -163,7 +164,7 @@ DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(shm_region_size,
 extern const char network_interface_component_name[];
 
 DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(network_uri,
-                                       std::string);
+                                       youtils::Uri);
 
 DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(network_snd_rcv_queue_depth,
                                        size_t);

--- a/src/filesystem/NetworkXioInterface.cpp
+++ b/src/filesystem/NetworkXioInterface.cpp
@@ -82,4 +82,18 @@ NetworkXioInterface::checkConfig(const bpt::ptree& /*pt*/,
     return res;
 }
 
+yt::Uri
+NetworkXioInterface::uri() const
+{
+    const boost::optional<yt::Uri> uri(fs_.object_router().node_config().network_server_uri);
+    if (uri)
+    {
+        return *uri;
+    }
+    else
+    {
+        return network_uri.value();
+    }
+}
+
 } //namespace volumedriverfs

--- a/src/filesystem/NetworkXioInterface.h
+++ b/src/filesystem/NetworkXioInterface.h
@@ -77,7 +77,7 @@ public:
     void
     shutdown();
 
-    std::string
+    youtils::Uri
     uri() const
     {
         return network_uri.value();

--- a/src/filesystem/NetworkXioInterface.h
+++ b/src/filesystem/NetworkXioInterface.h
@@ -78,10 +78,7 @@ public:
     shutdown();
 
     youtils::Uri
-    uri() const
-    {
-        return network_uri.value();
-    }
+    uri() const;
 
     size_t
     snd_rcv_queue_depth() const

--- a/src/filesystem/NetworkXioServer.cpp
+++ b/src/filesystem/NetworkXioServer.cpp
@@ -13,17 +13,19 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
+#include "NetworkXioServer.h"
+#include "NetworkXioProtocol.h"
+
 #include <libxio.h>
 
 #include <youtils/Assert.h>
-
-#include "NetworkXioServer.h"
-#include "NetworkXioProtocol.h"
 
 #define POLLING_TIME_USEC   20
 
 namespace volumedriverfs
 {
+
+namespace yt = youtils;
 
 template<class T>
 static int
@@ -107,7 +109,7 @@ static_evfd_stop_loop(int fd, int events, void *data)
 }
 
 NetworkXioServer::NetworkXioServer(FileSystem& fs,
-                                   const std::string& uri,
+                                   const yt::Uri& uri,
                                    size_t snd_rcv_queue_depth,
                                    unsigned int workqueue_max_threads)
     : fs_(fs)
@@ -192,7 +194,7 @@ NetworkXioServer::run(std::promise<void> promise)
     LOG_INFO("bind XIO server to '" << uri_ << "'");
     server = std::shared_ptr<xio_server>(xio_bind(ctx.get(),
                                                   &xio_s_ops,
-                                                  uri_.c_str(),
+                                                  boost::lexical_cast<std::string>(uri_).c_str(),
                                                   NULL,
                                                   0,
                                                   this),

--- a/src/filesystem/NetworkXioServer.h
+++ b/src/filesystem/NetworkXioServer.h
@@ -16,15 +16,17 @@
 #ifndef __NETWORK_XIO_SERVER_H_
 #define __NETWORK_XIO_SERVER_H_
 
+#include "FileSystem.h"
+#include "NetworkXioIOHandler.h"
+#include "NetworkXioRequest.h"
+#include "NetworkXioWorkQueue.h"
+
 #include <map>
 #include <tuple>
 #include <memory>
 #include <libxio.h>
 
-#include "FileSystem.h"
-#include "NetworkXioWorkQueue.h"
-#include "NetworkXioIOHandler.h"
-#include "NetworkXioRequest.h"
+#include <youtils/Uri.h>
 
 namespace volumedriverfs
 {
@@ -38,8 +40,8 @@ MAKE_EXCEPTION(FailedRegisterEventHandler, fungi::IOException);
 class NetworkXioServer
 {
 public:
-    NetworkXioServer(FileSystem& fs,
-                     const std::string& uri,
+    NetworkXioServer(FileSystem&,
+                     const youtils::Uri&,
                      size_t snd_rcv_queue_depth,
                      unsigned int workqueue_max_threads);
 
@@ -93,7 +95,7 @@ private:
     DECLARE_LOGGER("NetworkXioServer");
 
     FileSystem& fs_;
-    std::string uri_;
+    youtils::Uri uri_;
     bool stopping;
 
     std::mutex mutex_;

--- a/src/filesystem/test/ClusterRegistryTest.cpp
+++ b/src/filesystem/test/ClusterRegistryTest.cpp
@@ -61,7 +61,8 @@ protected:
                                                      n,
                                                      vfs::MessagePort(i + 1),
                                                      vfs::XmlRpcPort(i + 1),
-                                                     vfs::FailoverCachePort(i + 1)));
+                                                     vfs::FailoverCachePort(i + 1),
+                                                     boost::none));
         }
 
         return configs;

--- a/src/filesystem/test/FileSystemTestSetup.cpp
+++ b/src/filesystem/test/FileSystemTestSetup.cpp
@@ -353,10 +353,6 @@ FileSystemTestSetup::make_config_(bpt::ptree& pt,
         ip::PARAMETER_TYPE(scrub_manager_interval)(scrub_manager_interval_secs_).persist(pt);
     }
 
-    // network server
-    make_edge_config_(pt,
-		      vrouter_id);
-
     // volume_router_cluster
     {
         ip::PARAMETER_TYPE(vrouter_cluster_id)(vrouter_cluster_id()).persist(pt);
@@ -381,16 +377,8 @@ FileSystemTestSetup::make_config_(bpt::ptree& pt,
     return pt;
 }
 
-bpt::ptree&
-FileSystemTestSetup::make_edge_config_(bpt::ptree& pt,
-				       const vfs::NodeId& node_id)
-{
-    ip::PARAMETER_TYPE(network_uri)(make_edge_uri_(node_id)).persist(pt);
-    return pt;
-}
-
 yt::Uri
-FileSystemTestSetup::make_edge_uri_(const vfs::NodeId& node_id)
+FileSystemTestSetup::network_server_uri(const vfs::NodeId& node_id)
 {
     return yt::Uri()
         .scheme(edge_transport())

--- a/src/filesystem/test/FileSystemTestSetup.cpp
+++ b/src/filesystem/test/FileSystemTestSetup.cpp
@@ -385,8 +385,7 @@ bpt::ptree&
 FileSystemTestSetup::make_edge_config_(bpt::ptree& pt,
 				       const vfs::NodeId& node_id)
 {
-    const yt::Uri uri(make_edge_uri_(node_id));
-    ip::PARAMETER_TYPE(network_uri)(boost::lexical_cast<std::string>(uri)).persist(pt);
+    ip::PARAMETER_TYPE(network_uri)(make_edge_uri_(node_id)).persist(pt);
     return pt;
 }
 

--- a/src/filesystem/test/FileSystemTestSetup.cpp
+++ b/src/filesystem/test/FileSystemTestSetup.cpp
@@ -385,12 +385,20 @@ bpt::ptree&
 FileSystemTestSetup::make_edge_config_(bpt::ptree& pt,
 				       const vfs::NodeId& node_id)
 {
-    const std::string uri(edge_transport() + "://"s + address() + ":"s +
-			  boost::lexical_cast<std::string>(node_id == local_node_id() ?
-							   local_edge_port() :
-							   remote_edge_port()));
-    ip::PARAMETER_TYPE(network_uri)(uri).persist(pt);
+    const yt::Uri uri(make_edge_uri_(node_id));
+    ip::PARAMETER_TYPE(network_uri)(boost::lexical_cast<std::string>(uri)).persist(pt);
     return pt;
+}
+
+yt::Uri
+FileSystemTestSetup::make_edge_uri_(const vfs::NodeId& node_id)
+{
+    return yt::Uri()
+        .scheme(edge_transport())
+        .host(address())
+        .port(node_id == local_node_id() ?
+              local_edge_port() :
+              remote_edge_port());
 }
 
 void

--- a/src/filesystem/test/FileSystemTestSetup.h
+++ b/src/filesystem/test/FileSystemTestSetup.h
@@ -169,12 +169,8 @@ protected:
     boost::property_tree::ptree&
     make_registry_config_(boost::property_tree::ptree&) const;
 
-    static boost::property_tree::ptree&
-    make_edge_config_(boost::property_tree::ptree& pt,
-                      const volumedriverfs::NodeId& vrouter_id);
-
     static youtils::Uri
-    make_edge_uri_(const volumedriverfs::NodeId&);
+    network_server_uri(const volumedriverfs::NodeId&);
 
     void
     make_dirs_(const boost::filesystem::path& topdir) const;
@@ -278,7 +274,7 @@ protected:
                                                  volumedriverfs::MessagePort(port_base() + 1),
                                                  volumedriverfs::XmlRpcPort(port_base() + 3),
                                                  volumedriverfs::FailoverCachePort(port_base() + 5),
-                                                 make_edge_uri_(local_node_id()));
+                                                 network_server_uri(local_node_id()));
     }
 
     static volumedriverfs::ClusterNodeConfig
@@ -289,7 +285,7 @@ protected:
                                                  volumedriverfs::MessagePort(port_base() + 2),
                                                  volumedriverfs::XmlRpcPort(port_base() + 4),
                                                  volumedriverfs::FailoverCachePort(port_base() + 6),
-                                                 make_edge_uri_(remote_node_id()));
+                                                 network_server_uri(remote_node_id()));
     }
 
     static uint16_t

--- a/src/filesystem/test/FileSystemTestSetup.h
+++ b/src/filesystem/test/FileSystemTestSetup.h
@@ -173,6 +173,9 @@ protected:
     make_edge_config_(boost::property_tree::ptree& pt,
                       const volumedriverfs::NodeId& vrouter_id);
 
+    static youtils::Uri
+    make_edge_uri_(const volumedriverfs::NodeId&);
+
     void
     make_dirs_(const boost::filesystem::path& topdir) const;
 
@@ -274,7 +277,8 @@ protected:
                                                  address(),
                                                  volumedriverfs::MessagePort(port_base() + 1),
                                                  volumedriverfs::XmlRpcPort(port_base() + 3),
-                                                 volumedriverfs::FailoverCachePort(port_base() + 5));
+                                                 volumedriverfs::FailoverCachePort(port_base() + 5),
+                                                 make_edge_uri_(local_node_id()));
     }
 
     static volumedriverfs::ClusterNodeConfig
@@ -284,7 +288,8 @@ protected:
                                                  address(),
                                                  volumedriverfs::MessagePort(port_base() + 2),
                                                  volumedriverfs::XmlRpcPort(port_base() + 4),
-                                                 volumedriverfs::FailoverCachePort(port_base() + 6));
+                                                 volumedriverfs::FailoverCachePort(port_base() + 6),
+                                                 make_edge_uri_(remote_node_id()));
     }
 
     static uint16_t

--- a/src/filesystem/test/NetworkServerTest.cpp
+++ b/src/filesystem/test/NetworkServerTest.cpp
@@ -101,8 +101,7 @@ public:
         FileSystemTestBase::SetUp();
         bpt::ptree pt;
 
-        net_xio_server_ = std::make_unique<NetworkXioInterface>(make_edge_config_(pt,
-										  local_node_id()),
+        net_xio_server_ = std::make_unique<NetworkXioInterface>(pt,
                                                                 RegisterComponent::F,
                                                                 *fs_);
         std::promise<void> promise;
@@ -277,6 +276,12 @@ public:
     boost::thread net_xio_thread_;
     vfs::PythonClient client_;
 };
+
+TEST_F(NetworkServerTest, uri)
+{
+    EXPECT_EQ(network_server_uri(local_node_id()),
+              net_xio_server_->uri());
+}
 
 TEST_F(NetworkServerTest, create_destroy_context)
 {

--- a/src/filesystem/test/ObjectRouterTest.cpp
+++ b/src/filesystem/test/ObjectRouterTest.cpp
@@ -182,7 +182,7 @@ public:
                        vfs::MessagePort(local_config().message_port + next_port_off_),
                        vfs::XmlRpcPort(local_config().xmlrpc_port + next_port_off_),
                        vfs::FailoverCachePort(local_config().failovercache_port + next_port_off_),
-                       make_edge_uri_(local_node_id()));
+                       network_server_uri(local_node_id()));
 
         ++next_port_off_;
 

--- a/src/filesystem/test/ObjectRouterTest.cpp
+++ b/src/filesystem/test/ObjectRouterTest.cpp
@@ -181,7 +181,8 @@ public:
                        local_config().host,
                        vfs::MessagePort(local_config().message_port + next_port_off_),
                        vfs::XmlRpcPort(local_config().xmlrpc_port + next_port_off_),
-                       vfs::FailoverCachePort(local_config().failovercache_port + next_port_off_));
+                       vfs::FailoverCachePort(local_config().failovercache_port + next_port_off_),
+                       make_edge_uri_(local_node_id()));
 
         ++next_port_off_;
 
@@ -531,7 +532,8 @@ TEST_F(ObjectRouterTest, no_modification_of_existing_node_config)
                                    remote_config().host,
                                    vfs::MessagePort(remote_config().message_port + 1),
                                    remote_config().xmlrpc_port,
-                                   remote_config().failovercache_port) };
+                                   remote_config().failovercache_port,
+                                   remote_config().network_server_uri) };
 
     registry->erase_node_configs();
     registry->set_node_configs(configs);

--- a/src/youtils/Uri.cpp
+++ b/src/youtils/Uri.cpp
@@ -51,6 +51,12 @@ Uri::operator==(const Uri& other) const
 #undef CMP
 }
 
+bool
+Uri::operator<(const Uri& other) const
+{
+    return boost::lexical_cast<std::string>(*this) < boost::lexical_cast<std::string>(other);
+}
+
 std::string
 Uri::path() const
 {

--- a/src/youtils/Uri.h
+++ b/src/youtils/Uri.h
@@ -56,6 +56,9 @@ public:
         return not operator==(other);
     }
 
+    bool
+    operator<(const Uri& other) const;
+
     using Query = std::unordered_map<std::string, boost::optional<std::string>>;
 
 #define URI_COMPONENT(typ, name)                    \

--- a/src/youtils/Uri.h
+++ b/src/youtils/Uri.h
@@ -18,11 +18,13 @@
 
 #include "Assert.h"
 #include "Logging.h"
+#include "Serialization.h"
 
 #include <iosfwd>
 #include <string>
 #include <unordered_map>
 
+#include <boost/lexical_cast.hpp>
 #include <boost/optional.hpp>
 
 namespace youtils
@@ -103,6 +105,35 @@ public:
 
 private:
     DECLARE_LOGGER("Uri");
+
+    friend class boost::serialization::access;
+
+    BOOST_SERIALIZATION_SPLIT_MEMBER();
+
+    template<typename Archive>
+    void
+    load(Archive& ar,
+         const unsigned version)
+    {
+        CHECK_VERSION(version, 1);
+
+        auto s(boost::lexical_cast<std::string>(*this));
+        ar & boost::serialization::make_nvp("uri",
+                                            s);
+        *this = Uri(s);
+    }
+
+    template<typename Archive>
+    void
+    save(Archive& ar,
+         const unsigned version) const
+    {
+        CHECK_VERSION(version, 1);
+
+        const auto s(boost::lexical_cast<std::string>(*this));
+        ar & boost::serialization::make_nvp("uri",
+                                            s);
+    }
 };
 
 std::ostream&
@@ -114,5 +145,7 @@ operator>>(std::istream&,
            Uri&);
 
 }
+
+BOOST_CLASS_VERSION(youtils::Uri, 1);
 
 #endif // !YT_URI_H_


### PR DESCRIPTION
The `ClusterNodeConfig` now contains the URI of the network (edge) server - this info can be obtained from the `ClusterRegistry`.