### PR TITLE
filesystem::ClusterNodeConfig: introduce XMLRPC and DTL address

### DIFF
--- a/src/filesystem-python-client/test/fs_python_client_test.py.in
+++ b/src/filesystem-python-client/test/fs_python_client_test.py.in
@@ -111,10 +111,13 @@ class TestHelperTest(unittest.TestCase):
 
     def test_cluster_node_config(self):
         cfg = ClusterNodeConfig("ClusterNodeId",
-                                "hostname",
+                                "message_host",
                                 123,
                                 456,
-                                789)
+                                789,
+                                "rdma://edge_host:101",
+                                "xmlrpc_host",
+                                "dtl_host")
         self.assertEqual(
             cfg, PythonTestHelpers.reflect_cluster_node_config(cfg))
 

--- a/src/filesystem/ClusterNodeConfig.cpp
+++ b/src/filesystem/ClusterNodeConfig.cpp
@@ -26,9 +26,11 @@ operator<<(std::ostream& os,
 {
     os << "ClusterNodeConfig { " <<
         "vrouter_id: \"" << cfg.vrouter_id << "\", " <<
-        "host: \"" << cfg.host << "\", " <<
+        "message_host: \"" << cfg.message_host << "\", " <<
         "message_port: " << cfg.message_port << ", " <<
+        "xmlrpc_host: \"" << cfg.xmlrpc_host << "\", " <<
         "xmlrpc_port: " << cfg.xmlrpc_port << ", " <<
+        "failovercache_host: \"" << cfg.failovercache_host << "\", " <<
         "failovercache_port: " << cfg.failovercache_port << " }";
 
     return os;

--- a/src/filesystem/ConfigHelper.h
+++ b/src/filesystem/ConfigHelper.h
@@ -64,6 +64,13 @@ public:
         return localnode_config_->failovercache_port;
     }
 
+    const std::string&
+    failover_cache_host() const
+    {
+        VERIFY(localnode_config_);
+        return localnode_config_->failovercache_host;
+    }
+
     const ClusterNodeConfig&
     localnode_config() const
     {

--- a/src/filesystem/FileSystem.cpp
+++ b/src/filesystem/FileSystem.cpp
@@ -174,7 +174,7 @@ FileSystem::FileSystem(const bpt::ptree& pt,
                UseCache::F)
     , stats_collector_(pt,
                     registerizle)
-    , xmlrpc_svc_(router_.node_config().host,
+    , xmlrpc_svc_(router_.node_config().xmlrpc_host,
                   router_.node_config().xmlrpc_port)
 {
     verify_volume_suffix_(fs_internal_suffix.value());

--- a/src/filesystem/LocalPythonClient.cpp
+++ b/src/filesystem/LocalPythonClient.cpp
@@ -43,7 +43,7 @@ LocalPythonClient::LocalPythonClient(const std::string& config,
     const bpt::ptree pt((*config_fetcher_)(VerifyConfig::F));
     const ConfigHelper argument_helper(pt);
     cluster_id_ = argument_helper.cluster_id();
-    cluster_contacts_.emplace_back(argument_helper.localnode_config().host,
+    cluster_contacts_.emplace_back(argument_helper.localnode_config().xmlrpc_host,
                                    argument_helper.localnode_config().xmlrpc_port);
 }
 

--- a/src/filesystem/ObjectRouter.cpp
+++ b/src/filesystem/ObjectRouter.cpp
@@ -111,7 +111,7 @@ ObjectRouter::ObjectRouter(const bpt::ptree& pt,
 
     const ClusterNodeConfig ncfg(node_config());
     const std::string addr("tcp://" +
-                           ncfg.host +
+                           ncfg.message_host +
                            ":"s +
                            boost::lexical_cast<std::string>(ncfg.message_port));
 
@@ -1737,7 +1737,7 @@ ObjectRouter::failoverconfig_as_it_should_be() const
                     it = node_map_.begin();
                 }
 
-                return vd::FailOverCacheConfig(it->second->config.host,
+                return vd::FailOverCacheConfig(it->second->config.failovercache_host,
                                                it->second->config.failovercache_port,
                                                foc_mode_);
             }
@@ -1812,14 +1812,14 @@ ObjectRouter::xmlrpc_client()
         auto it = node_map_.find(node_id());
         VERIFY(it != node_map_.end());
 
-        contacts.emplace_back(it->second->config.host,
+        contacts.emplace_back(it->second->config.xmlrpc_host,
                               it->second->config.xmlrpc_port);
 
         for (const auto& p : node_map_)
         {
             if (p.first != node_id())
             {
-                contacts.emplace_back(p.second->config.host,
+                contacts.emplace_back(p.second->config.xmlrpc_host,
                                       p.second->config.xmlrpc_port);
             }
         }

--- a/src/filesystem/RemoteNode.cpp
+++ b/src/filesystem/RemoteNode.cpp
@@ -56,7 +56,7 @@ RemoteNode::init_zock_()
     const std::string rport(boost::lexical_cast<std::string>(config.message_port));
     zock_.reset(new zmq::socket_t(*ztx_, ZMQ_REQ));
 
-    const std::string tcp_addr("tcp://" + config.host + std::string(":") + rport);
+    const std::string tcp_addr("tcp://" + config.message_host + std::string(":") + rport);
     ZUtils::socket_no_linger(*zock_);
 
     LOG_INFO("Connecting to " << tcp_addr);

--- a/src/filesystem/XMLRPC.cpp
+++ b/src/filesystem/XMLRPC.cpp
@@ -499,11 +499,11 @@ XMLRPCRedirectWrapper<T>::execute(::XmlRpc::XmlRpcValue& params,
 
     VERIFY(maybe_remote_config);
 
-    LOG_INFO("Redirecting to " << maybe_remote_config->host << ", port " <<
+    LOG_INFO("Redirecting to " << maybe_remote_config->xmlrpc_host << ", port " <<
              maybe_remote_config->xmlrpc_port);
 
     result.clear();
-    result[XMLRPCKeys::xmlrpc_redirect_host] = T::XMLVAL(maybe_remote_config->host);
+    result[XMLRPCKeys::xmlrpc_redirect_host] = T::XMLVAL(maybe_remote_config->xmlrpc_host);
     result[XMLRPCKeys::xmlrpc_redirect_port] = T::XMLVAL(maybe_remote_config->xmlrpc_port);
 }
 

--- a/src/filesystem/failovercache/FailOverCacheHelperMain.cpp
+++ b/src/filesystem/failovercache/FailOverCacheHelperMain.cpp
@@ -114,7 +114,7 @@ main(int argc,
     const std::string
         path_for_failover_cache(argument_helper.failover_cache_path().string());
     const std::string
-        addr(argument_helper.localnode_config().host);
+        addr(argument_helper.failover_cache_host());
     const auto
         port(boost::lexical_cast<std::string>(argument_helper.failover_cache_port()));
     const auto

--- a/src/filesystem/test/FileSystemTestSetup.cpp
+++ b/src/filesystem/test/FileSystemTestSetup.cpp
@@ -108,7 +108,7 @@ FileSystemTestSetup::start_failovercache_for_local_node()
 {
     local_foc_helper_ =
         std::make_unique<FailOverCacheTestHelper>(failovercache_dir(remote_dir(topdir_)),
-                                                  remote_config().host,
+                                                  remote_config().failovercache_host,
                                                   remote_config().failovercache_port,
                                                   failovercache_transport());
 }
@@ -124,7 +124,7 @@ FileSystemTestSetup::start_failovercache_for_remote_node()
 {
     remote_foc_helper_ =
         std::make_unique<FailOverCacheTestHelper>(failovercache_dir(topdir_),
-                                                  local_config().host,
+                                                  local_config().failovercache_host,
                                                   local_config().failovercache_port,
                                                   failovercache_transport());
 }

--- a/src/filesystem/test/ObjectRouterTest.cpp
+++ b/src/filesystem/test/ObjectRouterTest.cpp
@@ -50,7 +50,7 @@ public:
         , next_port_off_(2)
     {
         const std::string addr("tcp://"s +
-                               local_config().host +
+                               local_config().message_host +
                                ":"s +
                                boost::lexical_cast<std::string>(local_config().message_port));
         zock.connect(addr.c_str());
@@ -178,11 +178,13 @@ public:
 
         const vfs::ClusterNodeConfig
             new_config(new_node_id,
-                       local_config().host,
+                       local_config().message_host,
                        vfs::MessagePort(local_config().message_port + next_port_off_),
                        vfs::XmlRpcPort(local_config().xmlrpc_port + next_port_off_),
                        vfs::FailoverCachePort(local_config().failovercache_port + next_port_off_),
-                       network_server_uri(local_node_id()));
+                       network_server_uri(local_node_id()),
+                       local_config().xmlrpc_host,
+                       local_config().failovercache_host);
 
         ++next_port_off_;
 
@@ -529,11 +531,13 @@ TEST_F(ObjectRouterTest, no_modification_of_existing_node_config)
 
     const vfs::ClusterNodeConfigs configs{ local_config(),
             vfs::ClusterNodeConfig(remote_config().vrouter_id,
-                                   remote_config().host,
+                                   remote_config().message_host,
                                    vfs::MessagePort(remote_config().message_port + 1),
                                    remote_config().xmlrpc_port,
                                    remote_config().failovercache_port,
-                                   remote_config().network_server_uri) };
+                                   remote_config().network_server_uri,
+                                   remote_config().xmlrpc_host,
+                                   remote_config().failovercache_host), };
 
     registry->erase_node_configs();
     registry->set_node_configs(configs);

--- a/src/filesystem/test/PythonClientTest.cpp
+++ b/src/filesystem/test/PythonClientTest.cpp
@@ -217,7 +217,7 @@ protected:
     vd::FailOverCacheConfig
     check_initial_foc_config(const std::string& vname)
     {
-        const vd::FailOverCacheConfig cfg(remote_config().host,
+        const vd::FailOverCacheConfig cfg(remote_config().failovercache_host,
                                           remote_config().failovercache_port,
                                           vd::FailOverCacheMode::Asynchronous);
         check_foc_config(vname,
@@ -658,7 +658,7 @@ TEST_F(PythonClientTest, redirection_response)
     }                                                                   \
     catch (vfs::clienterrors::MaxRedirectsExceededException& e)         \
     {                                                                   \
-        EXPECT_EQ(remote_config().host, e.host);                        \
+        EXPECT_EQ(remote_config().xmlrpc_host, e.host);                 \
         EXPECT_EQ(remote_config().xmlrpc_port, e.port);                 \
     }                                                                   \
     CATCH_STD_ALL_EWHAT({                                               \
@@ -1746,7 +1746,7 @@ TEST_F(PythonClientTest, failovercache_config)
 
     //
 
-    const vd::FailOverCacheConfig cfg2(local_config().host,
+    const vd::FailOverCacheConfig cfg2(local_config().failovercache_host,
                                        local_config().failovercache_port,
                                        vd::FailOverCacheMode::Asynchronous);
 


### PR DESCRIPTION
Part of https://github.com/openvstorage/volumedriver/issues/113

CC @khenderick:
This introduces new optional params to the Python APIs `ClusterNodeConfig` ctor and exposes the XMLRPC and DTL port as new properties.