### PR TITLE
Feature/dynamic dtl reconfiguration

### DIFF
--- a/src/filesystem/FileSystem.cpp
+++ b/src/filesystem/FileSystem.cpp
@@ -237,6 +237,36 @@ FileSystem::componentName() const
 }
 
 void
+FileSystem::update_dtl_settings_(const bpt::ptree& pt,
+                                 yt::UpdateReport& rep)
+{
+#define U(var)                                  \
+        (var).update(pt, rep)
+
+    if (fs_dtl_config_mode.value() == FailOverCacheConfigMode::Manual)
+    {
+        const ip::PARAMETER_TYPE(fs_dtl_host) new_host(pt);
+        const ip::PARAMETER_TYPE(fs_dtl_port) new_port(pt);
+        const ip::PARAMETER_TYPE(fs_dtl_mode) new_mode(pt);
+
+        try
+        {
+            router_.set_manual_default_foc_config(make_foc_config(new_host.value(),
+                                                                  new_port.value(),
+                                                                  new_mode.value()));
+        }
+        CATCH_STD_ALL_LOG_IGNORE("Failed to apply new DTL settings");
+    }
+
+    U(fs_dtl_config_mode);
+    U(fs_dtl_host);
+    U(fs_dtl_port);
+    U(fs_dtl_mode);
+
+#undef U
+}
+
+void
 FileSystem::update(const bpt::ptree& pt,
                    yt::UpdateReport& rep)
 {
@@ -255,10 +285,9 @@ FileSystem::update(const bpt::ptree& pt,
     U(fs_metadata_backend_mds_timeout_secs);
     U(fs_cache_dentries);
     U(fs_nullio);
-    U(fs_dtl_config_mode);
-    U(fs_dtl_host);
-    U(fs_dtl_port);
-    U(fs_dtl_mode);
+
+    update_dtl_settings_(pt, rep);
+
     U(fs_enable_shm_interface);
     U(fs_enable_network_interface);
     U(ip::PARAMETER_TYPE(fs_virtual_disk_format)(vdisk_format_->name()));

--- a/src/filesystem/FileSystem.h
+++ b/src/filesystem/FileSystem.h
@@ -614,17 +614,17 @@ private:
     restart_();
 
     void
-    create_volume_(const FrontendPath& path,
-                   volumedriver::VolumeConfig::MetaDataBackendConfigPtr mdb_config,
+    create_volume_(const FrontendPath&,
+                   volumedriver::VolumeConfig::MetaDataBackendConfigPtr,
                    const uint64_t size,
-                   DirectoryEntryPtr dentry);
+                   DirectoryEntryPtr);
 
     void
-    create_clone_(const FrontendPath& path,
-                  volumedriver::VolumeConfig::MetaDataBackendConfigPtr mdb_config,
+    create_clone_(const FrontendPath&,
+                  volumedriver::VolumeConfig::MetaDataBackendConfigPtr,
                   const volumedriver::VolumeId& parent,
                   const MaybeSnapshotName& maybe_parent_snap,
-                  DirectoryEntryPtr dentry);
+                  DirectoryEntryPtr);
 
     typedef std::function<void(const FrontendPath&,
                                DirectoryEntryPtr)> CreateVolumeOrCloneFun;
@@ -632,26 +632,30 @@ private:
     create_volume_or_clone_(const FrontendPath&,
                             CreateVolumeOrCloneFun&&);
 
-    template<typename ...A>
+    template<typename ...Args>
     void
-    do_mknod(const FrontendPath& path,
-             UserId uid,
-             GroupId gid,
-             Permissions pms,
-             A&&... args);
+    do_mknod(const FrontendPath&,
+             UserId,
+             GroupId,
+             Permissions,
+             Args&&...);
 
-    template<typename ...A>
+    template<typename ...Args>
     void
-    do_mkdir(UserId uid,
-             GroupId gid,
-             Permissions pms,
-             A&&... args);
+    do_mkdir(UserId,
+             GroupId,
+             Permissions,
+             Args&&...);
 
-    template<typename ...A>
+    template<typename ...Args>
     void
-    do_unlink(const FrontendPath& path,
-              const DirectoryEntryPtr& dentry,
-              A... args);
+    do_unlink(const FrontendPath&,
+              const DirectoryEntryPtr&,
+              Args...);
+
+    void
+    update_dtl_settings_(const boost::property_tree::ptree&,
+                         youtils::UpdateReport&);
 };
 
 }

--- a/src/filesystem/FileSystemParameters.h
+++ b/src/filesystem/FileSystemParameters.h
@@ -134,14 +134,14 @@ DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(fs_nullio,
 DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(fs_dtl_config_mode,
                                        volumedriverfs::FailOverCacheConfigMode);
 
-DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(fs_dtl_host,
-                                       std::string);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(fs_dtl_host,
+                                                  std::string);
 
-DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(fs_dtl_port,
-                                       uint16_t);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(fs_dtl_port,
+                                                  uint16_t);
 
-DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(fs_dtl_mode,
-                                       volumedriver::FailOverCacheMode);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(fs_dtl_mode,
+                                                  volumedriver::FailOverCacheMode);
 
 DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(fs_enable_shm_interface,
                                        bool);

--- a/src/filesystem/LocalNode.h
+++ b/src/filesystem/LocalNode.h
@@ -197,9 +197,14 @@ public:
     uint64_t
     volume_potential(const ObjectId&);
 
+    using MaybeFailOverCacheConfig = boost::optional<volumedriver::FailOverCacheConfig>;
+
     void
-    set_manual_foc_config(const ObjectId& oid,
-                          const boost::optional<volumedriver::FailOverCacheConfig>& foc_cfg);
+    set_manual_foc_config(const ObjectId&,
+                          const MaybeFailOverCacheConfig&);
+
+    void
+    set_manual_default_foc_config(const MaybeFailOverCacheConfig&);
 
     void
     set_automatic_foc_config(const ObjectId&);
@@ -207,7 +212,7 @@ public:
     FailOverCacheConfigMode
     get_foc_config_mode(const ObjectId& oid);
 
-    boost::optional<volumedriver::FailOverCacheConfig>
+    MaybeFailOverCacheConfig
     get_foc_config(const ObjectId& oid);
 
     void
@@ -342,9 +347,13 @@ private:
              MaybeSyncTimeoutMilliSeconds);
 
     void
+    do_adjust_failovercache_config_(const volumedriver::VolumeId&,
+                                    const MaybeFailOverCacheConfig&);
+
+    void
     adjust_failovercache_config_(const ObjectId& volume_id,
                                  const FailOverCacheConfigMode&,
-                                 const boost::optional<volumedriver::FailOverCacheConfig>&);
+                                 const MaybeFailOverCacheConfig&);
 
     void
     try_adjust_failovercache_config_(const ObjectId& id);

--- a/src/filesystem/test/FileSystemTestSetup.cpp
+++ b/src/filesystem/test/FileSystemTestSetup.cpp
@@ -80,6 +80,8 @@ FileSystemTestSetup::FileSystemTestSetup(const FileSystemTestSetupParameters& pa
     , redirect_timeout_ms_(params.redirect_timeout_ms_)
     , redirect_retries_(params.redirect_retries_)
     , scrub_manager_interval_secs_(params.scrub_manager_interval_secs_)
+    , dtl_config_mode_(params.dtl_config_mode_)
+    , dtl_mode_(params.dtl_mode_)
     , fdriver_namespace_("ovs-fdnspc-fstest-"s + yt::UUID().str())
     , arakoon_test_setup_(std::make_shared<ara::ArakoonTestSetup>(topdir_ / "arakoon"))
     , client_(vrouter_cluster_id(),
@@ -258,6 +260,25 @@ FileSystemTestSetup::make_mdstore_config_(bpt::ptree& pt) const
 }
 
 bpt::ptree&
+FileSystemTestSetup::make_dtl_config_(const vfs::NodeId& vrouter_id,
+                                      bpt::ptree& pt) const
+{
+    ip::PARAMETER_TYPE(fs_dtl_config_mode)(dtl_config_mode_).persist(pt);
+    if (dtl_config_mode_ == vfs::FailOverCacheConfigMode::Manual)
+    {
+        const vfs::ClusterNodeConfig cfg(vrouter_id == local_node_id() ?
+                                         local_config() :
+                                         remote_config());
+
+        ip::PARAMETER_TYPE(fs_dtl_host)(cfg.host).persist(pt);
+        ip::PARAMETER_TYPE(fs_dtl_port)(cfg.failovercache_port).persist(pt);
+        ip::PARAMETER_TYPE(fs_dtl_mode)(dtl_mode_).persist(pt);
+    }
+
+    return pt;
+}
+
+bpt::ptree&
 FileSystemTestSetup::make_config_(bpt::ptree& pt,
                                   const fs::path& topdir,
                                   const vfs::NodeId& vrouter_id) const
@@ -341,6 +362,8 @@ FileSystemTestSetup::make_config_(bpt::ptree& pt,
         ip::PARAMETER_TYPE(fs_enable_network_interface)(true).persist(pt);
 
         make_mdstore_config_(pt);
+        make_dtl_config_(vrouter_id,
+                         pt);
     }
 
     // volume_router

--- a/src/filesystem/test/FileSystemTestSetup.h
+++ b/src/filesystem/test/FileSystemTestSetup.h
@@ -28,6 +28,7 @@
 
 #include <filesystem/ClusterId.h>
 #include <filesystem/ClusterNodeConfig.h>
+#include <filesystem/FailOverCacheConfigMode.h>
 #include <filesystem/NodeId.h>
 #include <filesystem/PythonClient.h>
 #include <filesystem/VirtualDiskFormat.h>
@@ -81,6 +82,10 @@ struct FileSystemTestSetupParameters
     PARAM(uint64_t, redirect_timeout_ms) = 0;
     PARAM(uint64_t, redirect_retries) = 2;
     PARAM(uint64_t, scrub_manager_interval_secs) = 1;
+    PARAM(volumedriverfs::FailOverCacheConfigMode, dtl_config_mode) =
+        volumedriverfs::FailOverCacheConfigMode::Automatic;
+    PARAM(volumedriver::FailOverCacheMode, dtl_mode) =
+        volumedriver::FailOverCacheMode::Asynchronous;
 
 #undef PARAM
 };
@@ -159,12 +164,16 @@ protected:
     TearDown();
 
     boost::property_tree::ptree&
-    make_mdstore_config_(boost::property_tree::ptree& pt) const;
+    make_mdstore_config_(boost::property_tree::ptree&) const;
 
     boost::property_tree::ptree&
-    make_config_(boost::property_tree::ptree& pt,
+    make_dtl_config_(const volumedriverfs::NodeId&,
+                     boost::property_tree::ptree&) const;
+
+    boost::property_tree::ptree&
+    make_config_(boost::property_tree::ptree&,
                  const boost::filesystem::path& topdir,
-                 const volumedriverfs::NodeId& vrouter_id) const;
+                 const volumedriverfs::NodeId&) const;
 
     boost::property_tree::ptree&
     make_registry_config_(boost::property_tree::ptree&) const;
@@ -340,6 +349,9 @@ protected:
     uint64_t redirect_timeout_ms_;
     uint32_t redirect_retries_;
     uint64_t scrub_manager_interval_secs_;
+
+    volumedriverfs::FailOverCacheConfigMode dtl_config_mode_;
+    volumedriver::FailOverCacheMode dtl_mode_;
 
     const backend::Namespace fdriver_namespace_;
 

--- a/src/filesystem/test/Makefile.am
+++ b/src/filesystem/test/Makefile.am
@@ -67,6 +67,7 @@ volumedriver_fs_test_SOURCES = \
 	LocalNodeTest.cpp \
 	LocalPythonClientTest.cpp \
 	Main.cpp \
+	ManualDtlConfigModeTest.cpp \
 	MessageTest.cpp \
 	MetaDataStoreTest.cpp \
 	NetworkServerTest.cpp \

--- a/src/filesystem/test/ManualDtlConfigModeTest.cpp
+++ b/src/filesystem/test/ManualDtlConfigModeTest.cpp
@@ -1,0 +1,114 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#include "FileSystemTestBase.h"
+
+#include <youtils/ConfigurationReport.h>
+#include <youtils/UpdateReport.h>
+
+namespace volumedriverfstest
+{
+
+using namespace volumedriverfs;
+
+namespace bpt = boost::property_tree;
+namespace ip = initialized_params;
+namespace vd = volumedriver;
+namespace yt = youtils;
+
+#define LOCKVD() \
+    fungi::ScopedLock ag__(api::getManagementMutex())
+
+class ManualDtlConfigModeTest
+    : public FileSystemTestBase
+{
+public:
+    ManualDtlConfigModeTest()
+        : FileSystemTestBase(FileSystemTestSetupParameters("ManualDtlConfigModeTest")
+                             .dtl_config_mode(FailOverCacheConfigMode::Manual))
+    {}
+};
+
+TEST_F(ManualDtlConfigModeTest, reconfiguration)
+{
+    const FrontendPath path(make_volume_name("/volume"));
+    const ObjectId oid(create_file(path));
+    const vd::VolumeId vid(oid.str());
+
+    ObjectRouter& router = fs_->object_router();
+
+    EXPECT_EQ(FailOverCacheConfigMode::Manual,
+              router.get_default_foc_config_mode());
+
+    const ClusterNodeConfig ncfg(local_config());
+    const ObjectRouter::MaybeFailOverCacheConfig fcfg(router.failoverconfig_as_it_should_be());
+
+    ASSERT_NE(boost::none,
+              fcfg);
+    EXPECT_EQ(ncfg.host,
+              fcfg->host);
+    EXPECT_EQ(ncfg.failovercache_port,
+              fcfg->port);
+    EXPECT_EQ(dtl_mode_,
+              fcfg->mode);
+
+    {
+        const ObjectRegistrationPtr reg(router.object_registry()->find(oid,
+                                                                       IgnoreCache::F));
+        EXPECT_EQ(FailOverCacheConfigMode::Automatic,
+                  reg->foc_config_mode);
+    }
+
+    {
+        LOCKVD();
+        EXPECT_EQ(fcfg,
+                  api::getFailOverCacheConfig(vd::VolumeId(vid)));
+    }
+
+    auto set_dtl_host([&](const std::string& h)
+                      {
+                          LOCKVD();
+
+                          bpt::ptree pt;
+                          api::persistConfiguration(pt,
+                                                    false);
+                          ip::PARAMETER_TYPE(fs_dtl_host)(h).persist(pt);
+                          api::updateConfiguration(pt);
+                      });
+
+    set_dtl_host("");
+
+    EXPECT_EQ(boost::none,
+              router.failoverconfig_as_it_should_be());
+
+    {
+        LOCKVD();
+        EXPECT_EQ(boost::none,
+                  api::getFailOverCacheConfig(vid));
+    }
+
+    set_dtl_host(fcfg->host);
+
+    EXPECT_EQ(fcfg,
+              router.failoverconfig_as_it_should_be());
+
+    {
+        LOCKVD();
+        EXPECT_EQ(fcfg,
+                  api::getFailOverCacheConfig(vd::VolumeId(vid)));
+    }
+}
+
+}


### PR DESCRIPTION
This makes the following params in the `filesystem` section of the config dynamically reconfigurable:
* `fs_dtl_host`
* `fs_dtl_port`
* `fs_dtl_mode`
.

Part of #113.
CC @khenderick.

NB: the call might return successfully even if there were issues updating volumes to the new DTL (a reliable rollback not being available is the problem here), so after such an update the individual volumes' settings need to be checked.