### PR TITLE
Feature/gcc 5 compile warnings

### DIFF
--- a/src/procon/ProCon.h
+++ b/src/procon/ProCon.h
@@ -531,24 +531,24 @@ public:
 
         Latch theLatch, noLatch(true);
 
+        std::unique_ptr<_ProducerTp> producer;
+        std::unique_ptr<_ConsumerTp> consumer;
 #if defined(_HAS_PUTTABLETAKABLE)
         Puttable<_Tp, _ChannelTp> puttable(chan);
         Takable<_Tp, _ChannelTp>  takable(chan);
 
-        _ProducerTp* producer = bHidePuttableTakable_
-            ? new _ProducerTp(chan, noLatch)
-            : new _ProducerTp(puttable, noLatch) ;
-        _ConsumerTp* consumer = bHidePuttableTakable_
-            ? new _ConsumerTp(chan, syncStart_ ? theLatch : noLatch)
-            : new _ConsumerTp(takable, syncStart_ ? theLatch : noLatch);
+        producer = bHidePuttableTakable_
+            ? std::make_unique<_ProducerTp>(chan, noLatch)
+            : std::make_unique<_ProducerTp>(puttable, noLatch);
+
+        consumer = bHidePuttableTakable_
+            ? std::make_unique<_ConsumerTp>(chan, syncStart_ ? theLatch : noLatch)
+            : std::make_unique<_ConsumerTp>(takable, syncStart_ ? theLatch : noLatch);
 #else
-        _ProducerTp* producer =
-            new _ProducerTp(chan, noLatch);
-        _ConsumerTp* consumer =
-            new _ConsumerTp(chan, syncStart_ ? theLatch : noLatch);
+        producer = std::make_unique<_ProducerTp>(chan, noLatch);
+        consumer = std::make_unique<_ConsumerTp>(chan, syncStart_ ? theLatch : noLatch);
 #endif
-        std::auto_ptr<_ProducerTp> prodClean(producer);
-        std::auto_ptr<_ConsumerTp> consClean(consumer);
+
         consumer->mayStop(false);
 
         pcModelCreated(*producer, *consumer);
@@ -618,18 +618,19 @@ public:
     {
         Latch theLatch, noLatch(true);
 
+        std::unique_ptr<_ConsumerTp> consumer;
+
 #if defined(_HAS_PUTTABLETAKABLE)
         Takable<_Tp, _ChannelTp>  takable(channel_); // valid in this function scope
 
         // consumer is created here, and it is shared by all consumer threads...
         // in a sense the single consumer is the model for a group of threaded live consumers
-        _ConsumerTp* consumer = bHidePuttableTakable_
-            ? new _ConsumerTp(channel_, syncStart_ ? theLatch : noLatch)
-            : new _ConsumerTp(takable, syncStart_ ? theLatch : noLatch);
+        consumer = bHidePuttableTakable_
+            ? std::make_unique<_ConsumerTp>(channel_, syncStart_ ? theLatch : noLatch)
+            : std::make_unique<_ConsumerTp>(takable, syncStart_ ? theLatch : noLatch);
 #else
-        _ConsumerTp* consumer = new _ConsumerTp(channel_, syncStart_ ? theLatch : noLatch);
+        consumer = std::make_unique<_ConsumerTp>(channel_, syncStart_ ? theLatch : noLatch);
 #endif
-        std::auto_ptr<_ConsumerTp> consClean(consumer);
         consumer->mayStop(true);
         consumerModelCreated(*consumer);
 

--- a/src/volumedriver/VolManager.cpp
+++ b/src/volumedriver/VolManager.cpp
@@ -489,12 +489,16 @@ VolManager::getCurrentVolumesTLogRequirements()
         // /opt/vmachines/jenkins_work/workspace/volumedriver-no-dedup-compile-warnings-ubuntu-14.04/volumedriver-core/src/volumedriver/VolManager.cpp:486:18: warning: '*((void*)(& t)+4).volumedriver::TLogMultiplier::t' may be used uninitialized in this function [-Wmaybe-uninitialized]
         //  res += s * ((t == boost::none) ? number_of_scos_in_tlog.value() : t.get());
         //           ^
-#if defined(__GNUC__) && __GNUC__ <= 4 && GNUC_MINOR__ <= 9
+        // NB: still present with g++ 5.4.
+#if defined(__GNUC__) && \
+    (__GNUC__ <= 4 || \
+     (__GNUC__ == 5 && GNUC_MINOR__ <= 4))
         PRAGMA_IGNORE_WARNING_BEGIN("-Wmaybe-uninitialized");
 #endif
         res += s * (t ? *t : number_of_scos_in_tlog.value());
-#if defined(__GNUC__) && __GNUC__ <= 4 && GNUC_MINOR__ <= 9
-        PRAGMA_IGNORE_WARNING_END;
+#if defined(__GNUC__) && \
+    (__GNUC__ <= 4 || \
+     (__GNUC__ == 5 && GNUC_MINOR__ <= 4))
 #endif
     }
 

--- a/src/volumedriver/test/SCOCacheConstructorTest.cpp
+++ b/src/volumedriver/test/SCOCacheConstructorTest.cpp
@@ -38,7 +38,7 @@ protected:
 TEST_F(SCOCacheConstructorTest, invalid)
 {
     MountPointConfigs mpCfgs;
-    std::auto_ptr<SCOCache> scoCache;
+    std::unique_ptr<SCOCache> scoCache;
     boost::property_tree::ptree pt;
 
     PARAMETER_TYPE(datastore_throttle_usecs)(throttling).persist(pt);

--- a/src/volumedriver/test/SCOCacheNamespaceTest.cpp
+++ b/src/volumedriver/test/SCOCacheNamespaceTest.cpp
@@ -28,9 +28,9 @@ TEST(SCOCacheNamespaceConstructorTest, constructor)
     uint64_t max = 1 << 30;
 
     {
-        std::auto_ptr<SCOCacheNamespace> ns(new SCOCacheNamespace(nspace,
-                                                                  max,
-                                                                  min));
+        std::unique_ptr<SCOCacheNamespace> ns(new SCOCacheNamespace(nspace,
+                                                                    max,
+                                                                    min));
 
         EXPECT_EQ(nspace, ns->getName());
         EXPECT_EQ(max, ns->getMinSize());
@@ -38,8 +38,8 @@ TEST(SCOCacheNamespaceConstructorTest, constructor)
     }
     {
         std::unique_ptr<SCOCacheNamespace> ns(new SCOCacheNamespace(nspace,
-                                                                  min,
-                                                                  max));
+                                                                    min,
+                                                                    max));
 
         EXPECT_EQ(nspace, ns->getName());
         EXPECT_EQ(min, ns->getMinSize());
@@ -47,7 +47,8 @@ TEST(SCOCacheNamespaceConstructorTest, constructor)
     }
 }
 
-class SCOCacheNamespaceTest : public testing::TestWithParam<VolumeDriverTestConfig>
+class SCOCacheNamespaceTest
+    : public testing::TestWithParam<VolumeDriverTestConfig>
 {
 protected:
     virtual void


### PR DESCRIPTION
Silence compiler warnings that show up with g++ 5.4 on Ubuntu 16.04.