### PR TITLE
Feature/cluster registry fix backward compat of asserts

### DIFF
--- a/src/filesystem/ClusterRegistry.cpp
+++ b/src/filesystem/ClusterRegistry.cpp
@@ -160,19 +160,23 @@ ClusterRegistry::set_node_configs(const ClusterNodeConfigs& configs)
     LOG_INFO("Registry for cluster " << cluster_id_ << " initialized");
 }
 
-ClusterRegistry::NodeStatusMap
-ClusterRegistry::get_node_status_map()
+ara::buffer
+ClusterRegistry::get_node_status_map_()
 try
 {
     LOG_TRACE("getting the node status map for " << cluster_id_);
-
-    const ara::buffer buf(arakoon_->get(make_key()));
-    return deserialize_node_map(buf);
+    return arakoon_->get(make_key());
 }
 catch (ara::error_not_found&)
 {
     throw ClusterNotRegisteredException("cluster not registered",
                                         cluster_id_.str().c_str());
+}
+
+ClusterRegistry::NodeStatusMap
+ClusterRegistry::get_node_status_map()
+{
+    return deserialize_node_map(get_node_status_map_());
 }
 
 ClusterNodeConfigs
@@ -211,24 +215,23 @@ try
 {
     LOG_TRACE(node_id << ", state " << state);
 
-    // The code could be refactored so we can cling onto the originally returned
-    // ara::buffer instead of serializing the map here.
-    // OTOH this should not be used in a critical path anyway, so let's not
-    // bother for now.
-
-    NodeStatusMap map(get_node_status_map());
-    auto it = find_node_throw_(node_id, map);
-
     arakoon_->run_sequence("set node state",
                            [&](ara::sequence& seq)
                            {
-                               const std::string key(make_key());
-                               seq.add_assert(key, serialize_node_map(map));
+                               const ara::buffer buf(get_node_status_map_());
+                               NodeStatusMap map(deserialize_node_map(buf));
+
+                               auto it = find_node_throw_(node_id, map);
+                               const ClusterNodeStatus::State old_state = it->second.state;
+                               it->second = ClusterNodeStatus(it->second.config, state);
 
                                LOG_INFO("Updating state of node " << node_id <<
-                                        " from " << it->second.state << " to " << state);
+                                        " from " << old_state << " to " << state);
 
-                               it->second = ClusterNodeStatus(it->second.config, state);
+                               const std::string key(make_key());
+                               seq.add_assert(key,
+                                              buf);
+
                                seq.add_set(key, serialize_node_map(map));
                            },
                            yt::RetryOnArakoonAssert::T);
@@ -244,7 +247,8 @@ void
 ClusterRegistry::prepare_node_offline_assertion(arakoon::sequence& seq,
                                                 const NodeId& node_id)
 {
-    const NodeStatusMap map(get_node_status_map());
+    const ara::buffer buf(get_node_status_map_());
+    const NodeStatusMap map(deserialize_node_map(buf));
     const auto it = find_node_throw_(node_id, map);
 
     const ClusterNodeStatus::State state = it->second.state;
@@ -256,7 +260,7 @@ ClusterRegistry::prepare_node_offline_assertion(arakoon::sequence& seq,
     }
 
     seq.add_assert(make_key(),
-                   serialize_node_map(map));
+                   buf);
 }
 
 }

--- a/src/filesystem/ClusterRegistry.h
+++ b/src/filesystem/ClusterRegistry.h
@@ -102,6 +102,9 @@ private:
     const ClusterId cluster_id_;
     std::shared_ptr<youtils::LockedArakoon> arakoon_;
 
+    arakoon::buffer
+    get_node_status_map_();
+
     void
     verify_(const ClusterNodeConfigs& node_configs);
 


### PR DESCRIPTION
When modifying the state of nodes in the registry the code asserts on
the previous state of the registry to detect / deal with concurrent
updates. The previous state of the registry was however deserialized and
serialized again for the assertion, which in case of newly added fields
to the serialized format caused the assertion to fail.

Addresses #129