### PR TITLE
Feature/configurable dtl timeouts

### DIFF
--- a/src/volumedriver/FailOverCacheClientInterface.h
+++ b/src/volumedriver/FailOverCacheClientInterface.h
@@ -62,10 +62,10 @@ public:
     virtual void
     newCache(std::unique_ptr<FailOverCacheProxy>) = 0;
 
-    virtual boost::chrono::seconds
+    virtual boost::chrono::milliseconds
     getDefaultRequestTimeout() const
     {
-        return boost::chrono::seconds(60);
+        return boost::chrono::milliseconds(60000);
     }
 
     virtual void

--- a/src/volumedriver/FailOverCacheProxy.h
+++ b/src/volumedriver/FailOverCacheProxy.h
@@ -40,7 +40,8 @@ public:
                        const Namespace&,
                        const LBASize,
                        const ClusterMultiplier,
-                       const boost::chrono::seconds);
+                       const boost::chrono::milliseconds request_timeout,
+                       const boost::optional<boost::chrono::milliseconds>& connect_timeout = boost::none);
 
     FailOverCacheProxy(const FailOverCacheProxy&) = delete;
 
@@ -72,7 +73,7 @@ public:
     removeUpTo(const SCO) throw ();
 
     void
-    setRequestTimeout(const boost::chrono::seconds);
+    setRequestTimeout(const boost::chrono::milliseconds);
 
     void
     setBusyLoopDuration(const boost::chrono::microseconds);

--- a/src/volumedriver/VolManager.cpp
+++ b/src/volumedriver/VolManager.cpp
@@ -148,6 +148,8 @@ try
           , dtl_queue_depth(pt)
           , dtl_write_trigger(pt)
           , dtl_busy_loop_usecs(pt)
+          , dtl_request_timeout_ms(pt)
+          , dtl_connect_timeout_ms(pt)
           , number_of_scos_in_tlog(pt)
           , non_disposable_scos_factor(pt)
           , default_cluster_size(pt)
@@ -1812,6 +1814,8 @@ VolManager::update(const boost::property_tree::ptree& pt,
     dtl_queue_depth.update(pt, report);
     dtl_write_trigger.update(pt, report);
     dtl_busy_loop_usecs.update(pt, report);
+    dtl_request_timeout_ms.update(pt, report);
+    dtl_connect_timeout_ms.update(pt, report);
 
     freespace_check_interval.update(pt, report);
     dtl_check_interval_in_seconds.update(pt, report);
@@ -1855,6 +1859,8 @@ VolManager::persist(boost::property_tree::ptree& pt,
     dtl_queue_depth.persist(pt, reportDefault);
     dtl_write_trigger.persist(pt, reportDefault);
     dtl_busy_loop_usecs.persist(pt, reportDefault);
+    dtl_request_timeout_ms.persist(pt, reportDefault);
+    dtl_connect_timeout_ms.persist(pt, reportDefault);
 
     number_of_scos_in_tlog.persist(pt, reportDefault);
     non_disposable_scos_factor.persist(pt, reportDefault);

--- a/src/volumedriver/VolManager.h
+++ b/src/volumedriver/VolManager.h
@@ -531,6 +531,8 @@ public:
     DECLARE_PARAMETER(dtl_queue_depth);
     DECLARE_PARAMETER(dtl_write_trigger);
     DECLARE_PARAMETER(dtl_busy_loop_usecs);
+    DECLARE_PARAMETER(dtl_request_timeout_ms);
+    DECLARE_PARAMETER(dtl_connect_timeout_ms);
 
     DECLARE_PARAMETER(number_of_scos_in_tlog);
     DECLARE_PARAMETER(non_disposable_scos_factor);

--- a/src/volumedriver/Volume.cpp
+++ b/src/volumedriver/Volume.cpp
@@ -436,6 +436,31 @@ Volume::localRestartDataStore_(SCONumber last_sco_num_in_backend,
     }
 }
 
+namespace
+{
+
+boost::optional<bc::milliseconds>
+dtl_connect_timeout()
+{
+    const unsigned t = VolManager::get()->dtl_connect_timeout_ms.value();
+    if (t == 0)
+    {
+        return boost::none;
+    }
+    else
+    {
+        return bc::milliseconds(t);
+    }
+}
+
+bc::milliseconds
+dtl_request_timeout()
+{
+    return bc::milliseconds(VolManager::get()->dtl_request_timeout_ms.value());
+}
+
+}
+
 void
 Volume::localRestart()
 {
@@ -472,7 +497,8 @@ Volume::localRestart()
                                                      TODO("AR: fix getLBASize instead")
                                                      LBASize(getLBASize()),
                                                      getClusterMultiplier(),
-                                                     failover_->getDefaultRequestTimeout());
+                                                     dtl_request_timeout(),
+                                                     dtl_connect_timeout());
         }
         CATCH_STD_ALL_EWHAT({
                 LOG_VINFO("Could not start with previous failover settings: " << EWHAT);
@@ -593,7 +619,8 @@ Volume::backend_restart(const CloneTLogs& restartTLogs,
                                                      cfg.getNS(),
                                                      LBASize(getLBASize()),
                                                      getClusterMultiplier(),
-                                                     failover_->getDefaultRequestTimeout());
+                                                     dtl_request_timeout(),
+                                                     dtl_connect_timeout());
         }
         CATCH_STD_ALL_EWHAT({
                 if (ignoreFOCIfUnreachable == IgnoreFOCIfUnreachable::T)
@@ -2278,7 +2305,8 @@ Volume::setFailOverCacheConfig_(const FailOverCacheConfig& config)
                                                              getNamespace(),
                                                              LBASize(getLBASize()),
                                                              getClusterMultiplier(),
-                                                             failover_->getDefaultRequestTimeout()));
+                                                             dtl_request_timeout(),
+                                                             dtl_connect_timeout()));
     failover_->Clear();
 
     MaybeCheckSum cs = dataStore_->finalizeCurrentSCO();

--- a/src/volumedriver/VolumeDriverParameters.cpp
+++ b/src/volumedriver/VolumeDriverParameters.cpp
@@ -83,6 +83,20 @@ DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(dtl_busy_loop_usecs,
                                       ShowDocumentation::T,
                                       0U);
 
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(dtl_request_timeout_ms,
+                                      volmanager_component_name,
+                                      "dtl_request_timeout_ms",
+                                      "Timeout for DTL requests",
+                                      ShowDocumentation::T,
+                                      60000U);
+
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(dtl_connect_timeout_ms,
+                                      volmanager_component_name,
+                                      "dtl_connect_timeout_ms",
+                                      "Timeout for connection attempts to the DTL - 0: wait forever / the OS to signal errors",
+                                      ShowDocumentation::T,
+                                      0U);
+
 DEFINE_INITIALIZED_PARAM(clean_interval,
                          volmanager_component_name,
                          "scocache_cleanup_interval",

--- a/src/volumedriver/VolumeDriverParameters.h
+++ b/src/volumedriver/VolumeDriverParameters.h
@@ -42,6 +42,11 @@ DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(dtl_write_trigger,
                                                   std::atomic<unsigned>);
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(dtl_busy_loop_usecs,
                                                   std::atomic<unsigned>);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(dtl_request_timeout_ms,
+                                                  std::atomic<unsigned>);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(dtl_connect_timeout_ms,
+                                                  std::atomic<unsigned>);
+
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(freespace_check_interval,
                                                   std::atomic<uint64_t>);
 DECLARE_RESETTABLE_INITIALIZED_PARAM(clean_interval,

--- a/src/volumedriver/failovercache/fungilib/IPv4Socket.h
+++ b/src/volumedriver/failovercache/fungilib/IPv4Socket.h
@@ -47,9 +47,6 @@ public:
     virtual Socket
     *accept(bool nonblocking = true) override;
 
-    virtual void
-    connect(const std::string &host, uint16_t port) override;
-
     virtual bool
     connect_nb(const std::string &host, uint16_t port) override;
 
@@ -61,6 +58,11 @@ private:
                int sock_type_,
                const char *remote_ip,
                uint16_t remote_port);
+
+    int
+    poll_(pollfd*,
+          nfds_t,
+          const boost::optional<boost::chrono::milliseconds>&) override;
 };
 
 }

--- a/src/volumedriver/failovercache/fungilib/IPv6Socket.cpp
+++ b/src/volumedriver/failovercache/fungilib/IPv6Socket.cpp
@@ -205,23 +205,6 @@ static void setup_sockaddr_v6_(struct sockaddr_in6 &inaddr6, const std::string &
 	inaddr6.sin6_addr = Socket::resolveIPv6(host);
 }
 
-// TODO: avoid code duplication between ipv4 and ipv6 connect?
-void IPv6Socket::connect(const std::string &host, uint16_t port) {
-    LOG_DEBUG("IPv6Socket::connect "<< host.c_str() << ":" << port << "/" << (use_rs_ ? "RDMA" : "TCP"));
-	struct sockaddr *saddr = 0;
-	struct sockaddr_in6 inaddr6;
-    setup_sockaddr_v6_(inaddr6, host, port);
-	socklen_t len = sizeof(sockaddr_in6);
-	saddr = (struct sockaddr *) &inaddr6;
-
-	if (::connect(sock_, saddr, len) < 0) {
-		std::stringstream ss;
-		ss << host << ":" << port;
-		std::string str = ss.str();
-		throw ConnectionRefusedError("Failure to connect to", str.c_str(), getErrorNumber());
-	};
-}
-
 bool IPv6Socket::connect_nb(const std::string &host, uint16_t port) {
 	LOG_DEBUG("IPv6Socket::connect_nb "<< host.c_str() <<":" << port);
     connectionInProgress_ = true;

--- a/src/volumedriver/failovercache/fungilib/IPv6Socket.h
+++ b/src/volumedriver/failovercache/fungilib/IPv6Socket.h
@@ -46,9 +46,6 @@ public:
     virtual Socket*
     accept(bool nonblocking = true) override;
 
-    virtual void
-    connect(const std::string &host, uint16_t port) override;
-
     virtual bool
     connect_nb(const std::string &host, uint16_t port) override;
 

--- a/src/volumedriver/failovercache/fungilib/Socket.h
+++ b/src/volumedriver/failovercache/fungilib/Socket.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <cassert>
 
+#include <poll.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -47,6 +48,7 @@ public:
     static std::unique_ptr<Socket>
     createClientSocket(const std::string &host,
                        uint16_t port,
+                       const boost::optional<boost::chrono::milliseconds>& connect_timeout = boost::none,
                        int sock_type = SOCK_STREAM);
 
     static std::unique_ptr<Socket>
@@ -65,10 +67,12 @@ public:
                       bool reuseaddr = true) = 0;
 
     /** @exception IOException */
-    virtual Socket *accept(bool nonblocking = true)=0;
+    virtual Socket *accept(bool nonblocking = true) = 0;
 
-    /** @exception IOException */
-    virtual void connect(const std::string &host, uint16_t port) = 0;
+    void
+    connect(const std::string&,
+            uint16_t,
+            const boost::optional<boost::chrono::milliseconds>&);
 
     /** @exception IOException
      * will return false if connection is still pending,
@@ -192,6 +196,11 @@ protected:
     /** @exception IOException */
     void close();
     void closeNoThrow();
+
+    virtual int
+    poll_(pollfd*,
+          nfds_t,
+          const boost::optional<boost::chrono::milliseconds>&);
 
 private:
     DECLARE_LOGGER("Socket");


### PR DESCRIPTION
Introduce / expose timeouts for connecting to the DTL / requests.

Addresses #131 .

CC @khenderick: new configurables: `volume_manager/dtl_{connect,request}_timeout_ms`:
* unsigned, dynamically reconfigurable. Default values:
  * request timeout: 60000 ms
  * connect timeout: 0 ms (-> wait for the OS to report success /
    failure, maintains current behaviour).