### PR TITLE
Feature/export volume location to clients

### DIFF
--- a/src/filesystem/ClusterRegistry.cpp
+++ b/src/filesystem/ClusterRegistry.cpp
@@ -227,8 +227,8 @@ ClusterRegistry::get_node_configs()
     return configs;
 }
 
-ClusterNodeStatus::State
-ClusterRegistry::get_node_state(const NodeId& node_id)
+ClusterNodeStatus
+ClusterRegistry::get_node_status(const NodeId& node_id)
 {
     LOG_TRACE(node_id);
 
@@ -236,7 +236,7 @@ ClusterRegistry::get_node_state(const NodeId& node_id)
     const auto it = find_node_throw_(node_id, map);
     LOG_TRACE(node_id << ", state " << it->second.state);
 
-    return it->second.state;
+    return it->second;
 }
 
 void

--- a/src/filesystem/ClusterRegistry.h
+++ b/src/filesystem/ClusterRegistry.h
@@ -80,8 +80,8 @@ public:
     set_node_state(const NodeId& id,
                    const ClusterNodeStatus::State st);
 
-    ClusterNodeStatus::State
-    get_node_state(const NodeId& id);
+    ClusterNodeStatus
+    get_node_status(const NodeId&);
 
     ClusterId
     cluster_id() const

--- a/src/filesystem/NetworkXioCommon.h
+++ b/src/filesystem/NetworkXioCommon.h
@@ -128,6 +128,8 @@ enum class NetworkXioMsgOpcode
     TruncateRsp,
     ListClusterNodeURIReq,
     ListClusterNodeURIRsp,
+    GetVolumeURIReq,
+    GetVolumeURIRsp,
 };
 
 #endif //__NETWORK_XIO_COMMON_H_

--- a/src/filesystem/NetworkXioIOHandler.h
+++ b/src/filesystem/NetworkXioIOHandler.h
@@ -117,6 +117,9 @@ private:
 
     void handle_list_cluster_node_uri(NetworkXioRequest *req);
 
+    void handle_get_volume_uri(NetworkXioRequest*,
+                               const std::string& volume_name);
+
     void handle_error(NetworkXioRequest *req,
                       NetworkXioMsgOpcode op,
                       int errval);

--- a/src/filesystem/NetworkXioServer.cpp
+++ b/src/filesystem/NetworkXioServer.cpp
@@ -547,7 +547,8 @@ NetworkXioServer::xio_send_reply(NetworkXioRequest *req)
     if ((req->op == NetworkXioMsgOpcode::ReadRsp ||
          req->op == NetworkXioMsgOpcode::ListVolumesRsp ||
          req->op == NetworkXioMsgOpcode::ListSnapshotsRsp ||
-         req->op == NetworkXioMsgOpcode::ListClusterNodeURIRsp) && req->data)
+         req->op == NetworkXioMsgOpcode::ListClusterNodeURIRsp ||
+         req->op == NetworkXioMsgOpcode::GetVolumeURIRsp) && req->data)
     {
         vmsg_sglist_set_nents(&req->xio_reply.out, 1);
         req->xio_reply.out.sgl_type = XIO_SGL_TYPE_IOV;

--- a/src/filesystem/ObjectRouter.cpp
+++ b/src/filesystem/ObjectRouter.cpp
@@ -480,7 +480,7 @@ ObjectRouter::maybe_steal_(R (ClusterNode::*fn)(const Object&,
             VERIFY(remote == IsRemoteNode::T);
             LOG_ERROR(id << ": remote node " << owner_id << " timed out");
 
-            if (cluster_registry_->get_node_state(owner_id) ==
+            if (cluster_registry_->get_node_status(owner_id).state ==
                 ClusterNodeStatus::State::Online)
             {
                 const auto ev(FileSystemEvents::redirect_timeout_while_online(owner_id));

--- a/src/filesystem/c-api/Makefile.am
+++ b/src/filesystem/c-api/Makefile.am
@@ -24,6 +24,7 @@ libovsvolumedriver_la_SOURCES = \
 	NetworkHAContext.cpp \
 	NetworkXioClient.cpp \
 	NetworkXioContext.cpp \
+	PathSelector.cpp \
 	TracePoints_tp.c \
 	Utils.cpp \
 	libovsvolumedriver.cpp

--- a/src/filesystem/c-api/NetworkHAContext.cpp
+++ b/src/filesystem/c-api/NetworkHAContext.cpp
@@ -430,6 +430,14 @@ NetworkHAContext::list_cluster_node_uri(std::vector<std::string>& uris)
 }
 
 int
+NetworkHAContext::get_volume_uri(const char* volume_name,
+                                 std::string& uri)
+{
+    return atomic_get_ctx()->get_volume_uri(volume_name,
+                                            uri);
+}
+
+int
 NetworkHAContext::send_read_request(struct ovs_aiocb *ovs_aiocbp,
                                     ovs_aio_request *request)
 {

--- a/src/filesystem/c-api/NetworkHAContext.h
+++ b/src/filesystem/c-api/NetworkHAContext.h
@@ -43,6 +43,18 @@ public:
 
     ~NetworkHAContext();
 
+    boost::optional<std::string>
+    volume_name() const override final
+    {
+        return atomic_get_ctx()->volume_name();
+    }
+
+    std::string
+    current_uri() const override final
+    {
+        return atomic_get_ctx()->current_uri();
+    }
+
     int
     open_volume(const char *volume_name,
                 int oflag);

--- a/src/filesystem/c-api/NetworkHAContext.h
+++ b/src/filesystem/c-api/NetworkHAContext.h
@@ -34,12 +34,16 @@
 namespace libovsvolumedriver
 {
 
-class NetworkHAContext : public ovs_context_t
+class RequestDispatcherCallback;
+
+class NetworkHAContext
+    : public ovs_context_t
 {
 public:
     NetworkHAContext(const std::string& uri,
                      uint64_t net_client_qdepth,
-                     bool ha_enabled);
+                     bool ha_enabled,
+                     RequestDispatcherCallback&);
 
     ~NetworkHAContext();
 
@@ -194,6 +198,8 @@ private:
     bool opened_;
     bool openning_;
     bool connection_error_;
+
+    RequestDispatcherCallback& callback_;
 
     std::shared_ptr<ovs_context_t>
     atomic_get_ctx() const

--- a/src/filesystem/c-api/NetworkHAContext.h
+++ b/src/filesystem/c-api/NetworkHAContext.h
@@ -159,7 +159,7 @@ private:
      * when g++ > 5.0.0 is used
      */
     std::shared_ptr<ovs_context_t> ctx_;
-    fungi::SpinLock ctx_lock_;
+    mutable fungi::SpinLock ctx_lock_;
     std::string volume_name_;
     int oflag_;
     std::string uri_;
@@ -184,7 +184,7 @@ private:
     bool connection_error_;
 
     std::shared_ptr<ovs_context_t>
-    atomic_get_ctx()
+    atomic_get_ctx() const
     {
         fungi::ScopedSpinLock l_(ctx_lock_);
         return ctx_;

--- a/src/filesystem/c-api/NetworkHAContext.h
+++ b/src/filesystem/c-api/NetworkHAContext.h
@@ -153,6 +153,7 @@ public:
             connection_error_ = true;
         }
     }
+
 private:
     /* cnanakos TODO: use atomic overloads for shared_ptr
      * when g++ > 5.0.0 is used
@@ -182,7 +183,7 @@ private:
     bool openning_;
     bool connection_error_;
 
-    const std::shared_ptr<ovs_context_t>&
+    std::shared_ptr<ovs_context_t>
     atomic_get_ctx()
     {
         fungi::ScopedSpinLock l_(ctx_lock_);
@@ -194,7 +195,6 @@ private:
     {
         fungi::ScopedSpinLock l_(ctx_lock_);
         ctx_.swap(ctx);
-        ctx.reset();
     }
 
     bool

--- a/src/filesystem/c-api/NetworkHAContext.h
+++ b/src/filesystem/c-api/NetworkHAContext.h
@@ -98,15 +98,15 @@ public:
                    std::string& volume_uri) override final;
 
     int
-    send_read_request(struct ovs_aiocb *ovs_aiocbp,
-                      ovs_aio_request *request);
+    send_read_request(ovs_aio_request*,
+                      ovs_aiocb*) override final;
 
     int
-    send_write_request(struct ovs_aiocb *ovs_aiocbp,
-                       ovs_aio_request *request);
+    send_write_request(ovs_aio_request*,
+                       ovs_aiocb*) override final;
 
     int
-    send_flush_request(ovs_aio_request *request);
+    send_flush_request(ovs_aio_request*) override final;
 
     int
     stat_volume(struct stat *st);
@@ -196,6 +196,12 @@ private:
         fungi::ScopedSpinLock l_(ctx_lock_);
         ctx_.swap(ctx);
     }
+
+    template<typename... Args>
+    int
+    wrap_io(int (ovs_context_t::*mem_fun)(ovs_aio_request*, Args...),
+            ovs_aio_request*,
+            Args...);
 
     bool
     is_connection_error() const

--- a/src/filesystem/c-api/NetworkHAContext.h
+++ b/src/filesystem/c-api/NetworkHAContext.h
@@ -94,6 +94,10 @@ public:
     list_cluster_node_uri(std::vector<std::string>& uris);
 
     int
+    get_volume_uri(const char* volume_name,
+                   std::string& volume_uri) override final;
+
+    int
     send_read_request(struct ovs_aiocb *ovs_aiocbp,
                       ovs_aio_request *request);
 

--- a/src/filesystem/c-api/NetworkXioClient.h
+++ b/src/filesystem/c-api/NetworkXioClient.h
@@ -44,7 +44,8 @@ public:
     NetworkXioClient(const std::string& uri,
                      const uint64_t qd,
                      NetworkHAContext& ha_ctx,
-                     bool ha_try_reconnect);
+                     bool ha_try_reconnect,
+                     RequestDispatcherCallback&);
 
     ~NetworkXioClient();
 
@@ -232,6 +233,8 @@ private:
     NetworkHAContext& ha_ctx_;
     bool ha_try_reconnect_;
     bool connection_error_;
+
+    RequestDispatcherCallback& callback_;
 
     void
     xio_run_loop_worker();

--- a/src/filesystem/c-api/NetworkXioClient.h
+++ b/src/filesystem/c-api/NetworkXioClient.h
@@ -158,6 +158,11 @@ public:
                               std::vector<std::string>& uris);
 
     static void
+    xio_get_volume_uri(const std::string& uri,
+                       const char* volume_name,
+                       std::string& volume_uri);
+
+    static void
     xio_list_snapshots(const std::string& uri,
                        const char* volume_name,
                        std::vector<std::string>& snapshots,
@@ -285,6 +290,11 @@ private:
     handle_list_cluster_node_uri(xio_ctl_s *xctl,
                                  xio_iovec_ex *sglist,
                                  int vec_size);
+
+    static void
+    handle_get_volume_uri(xio_ctl_s *xctl,
+                          xio_iovec_ex *sglist,
+                          int vec_size);
 
     static void
     create_vec_from_buf(xio_ctl_s *xctl,

--- a/src/filesystem/c-api/NetworkXioContext.cpp
+++ b/src/filesystem/c-api/NetworkXioContext.cpp
@@ -508,8 +508,8 @@ NetworkXioContext::get_volume_uri(const char* volume_name,
 }
 
 int
-NetworkXioContext::send_read_request(struct ovs_aiocb *ovs_aiocbp,
-                                     ovs_aio_request *request)
+NetworkXioContext::send_read_request(ovs_aio_request* request,
+                                     ovs_aiocb* ovs_aiocbp)
 {
     int r = 0;
     try
@@ -535,8 +535,8 @@ NetworkXioContext::send_read_request(struct ovs_aiocb *ovs_aiocbp,
 }
 
 int
-NetworkXioContext::send_write_request(struct ovs_aiocb *ovs_aiocbp,
-                                      ovs_aio_request *request)
+NetworkXioContext::send_write_request(ovs_aio_request* request,
+                                      ovs_aiocb* ovs_aiocbp)
 {
     int r = 0;
     try
@@ -562,7 +562,7 @@ NetworkXioContext::send_write_request(struct ovs_aiocb *ovs_aiocbp,
 }
 
 int
-NetworkXioContext::send_flush_request(ovs_aio_request *request)
+NetworkXioContext::send_flush_request(ovs_aio_request* request)
 {
     int r = 0;
     try

--- a/src/filesystem/c-api/NetworkXioContext.cpp
+++ b/src/filesystem/c-api/NetworkXioContext.cpp
@@ -22,12 +22,14 @@ namespace libovsvolumedriver
 NetworkXioContext::NetworkXioContext(const std::string& uri,
                                      uint64_t net_client_qdepth,
                                      NetworkHAContext& ha_ctx,
-                                     bool ha_try_reconnect)
+                                     bool ha_try_reconnect,
+                                     RequestDispatcherCallback& callback)
     : net_client_(nullptr)
     , uri_(uri)
     , net_client_qdepth_(net_client_qdepth)
     , ha_ctx_(ha_ctx)
     , ha_try_reconnect_(ha_try_reconnect)
+    , callback_(callback)
 {
     LIBLOGID_DEBUG("uri: " << uri <<
                    ",queue depth: " << net_client_qdepth);
@@ -102,7 +104,8 @@ NetworkXioContext::open_volume_(const char *volume_name,
             std::make_shared<NetworkXioClient>(uri_,
                                                net_client_qdepth_,
                                                ha_ctx_,
-                                               ha_try_reconnect_);
+                                               ha_try_reconnect_,
+                                               callback_);
         if (should_insert_request)
         {
             ha_ctx_.insert_inflight_request(

--- a/src/filesystem/c-api/NetworkXioContext.cpp
+++ b/src/filesystem/c-api/NetworkXioContext.cpp
@@ -488,6 +488,26 @@ NetworkXioContext::list_cluster_node_uri(std::vector<std::string>& uris)
 }
 
 int
+NetworkXioContext::get_volume_uri(const char* volume_name,
+                                  std::string& volume_uri)
+{
+    try
+    {
+        NetworkXioClient::xio_get_volume_uri(uri_, volume_name, volume_uri);
+        return 0;
+    }
+    catch (const std::bad_alloc&)
+    {
+        errno = ENOMEM;
+    }
+    catch (...)
+    {
+        errno = EIO;
+    }
+    return -1;
+}
+
+int
 NetworkXioContext::send_read_request(struct ovs_aiocb *ovs_aiocbp,
                                      ovs_aio_request *request)
 {

--- a/src/filesystem/c-api/NetworkXioContext.h
+++ b/src/filesystem/c-api/NetworkXioContext.h
@@ -99,15 +99,15 @@ public:
                    std::string& uri) override final;
 
     int
-    send_read_request(struct ovs_aiocb *ovs_aiocbp,
-                      ovs_aio_request *request);
+    send_read_request(ovs_aio_request*,
+                      ovs_aiocb*) override final;
 
     int
-    send_write_request(struct ovs_aiocb *ovs_aiocbp,
-                       ovs_aio_request *request);
+    send_write_request(ovs_aio_request*,
+                       ovs_aiocb*) override final;
 
     int
-    send_flush_request(ovs_aio_request *request);
+    send_flush_request(ovs_aio_request*) override final;
 
     int
     stat_volume(struct stat *st);

--- a/src/filesystem/c-api/NetworkXioContext.h
+++ b/src/filesystem/c-api/NetworkXioContext.h
@@ -95,6 +95,10 @@ public:
     list_cluster_node_uri(std::vector<std::string>& uris);
 
     int
+    get_volume_uri(const char* volume_name,
+                   std::string& uri) override final;
+
+    int
     send_read_request(struct ovs_aiocb *ovs_aiocbp,
                       ovs_aio_request *request);
 

--- a/src/filesystem/c-api/NetworkXioContext.h
+++ b/src/filesystem/c-api/NetworkXioContext.h
@@ -29,7 +29,8 @@ public:
     NetworkXioContext(const std::string& uri,
                       uint64_t net_client_qdepth,
                       NetworkHAContext& ha_ctx,
-                      bool ha_try_reconnect);
+                      bool ha_try_reconnect,
+                      RequestDispatcherCallback&);
 
     ~NetworkXioContext();
 
@@ -144,6 +145,7 @@ private:
     std::string volname_;
     NetworkHAContext& ha_ctx_;
     bool ha_try_reconnect_;
+    RequestDispatcherCallback& callback_;
 };
 
 } //namespace libovsvolumedriver

--- a/src/filesystem/c-api/NetworkXioContext.h
+++ b/src/filesystem/c-api/NetworkXioContext.h
@@ -117,6 +117,26 @@ public:
 
     int
     deallocate(ovs_buffer_t *ptr);
+
+    boost::optional<std::string>
+    volume_name() const override final
+    {
+        if (not volname_.empty())
+        {
+            return volname_;
+        }
+        else
+        {
+            return boost::none;
+        }
+    }
+
+    std::string
+    current_uri() const override final
+    {
+        return uri_;
+    }
+
 private:
     libovsvolumedriver::NetworkXioClientPtr net_client_;
     std::string uri_;

--- a/src/filesystem/c-api/PathSelector.cpp
+++ b/src/filesystem/c-api/PathSelector.cpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#include "Logger.h"
+#include "PathSelector.h"
+
+#include <chrono>
+
+#include <boost/optional/optional_io.hpp>
+
+#include <youtils/IOException.h>
+
+namespace libovsvolumedriver
+{
+
+#define LOCK_CTX()                              \
+    std::lock_guard<decltype(ctx_lock_)> clg__(ctx_lock_)
+
+#define LOCK_MAP()                              \
+    std::lock_guard<decltype(map_lock_)> mlg__(map_lock_)
+
+PathSelector::PathSelector(const std::string& uri,
+                           ContextFactoryFun make_context,
+                           RequestDispatcherCallback& callback)
+    : ctx_(make_context(uri, *this))
+    , make_context_(std::move(make_context))
+    , callback_(callback)
+    , period_secs_(30)
+    , checker_("PathChecker",
+               [&]
+               {
+                   update_();
+               },
+               period_secs_)
+{}
+
+void
+PathSelector::update_()
+{
+    const boost::optional<std::string> vname(volume_name());
+    if (vname)
+    {
+        ContextPtr ctx = get_ctx_();
+        std::string uri;
+        int ret = ctx->get_volume_uri(vname->c_str(),
+                                      uri);
+        if (ret)
+        {
+            LIBLOG_ERROR(*vname << ": failed to get volume URI");
+            throw fungi::IOException("failed to get volume URI");
+        }
+
+        const std::string cur_uri(current_uri());
+        if (uri != cur_uri)
+        {
+            LIBLOG_INFO(*vname << ": URI has changed from " << cur_uri << " to " << uri <<
+                        " - attempting to follow");
+
+            ContextPtr ctx(make_context_(uri,
+                                         *this));
+
+            LOCK_CTX();
+            std::swap(ctx, ctx_);
+        }
+    }
+}
+
+template<typename... Args>
+int
+PathSelector::wrap_io_(int (ovs_context_t::*mem_fun)(ovs_aio_request*,
+                                                     Args...),
+                       ovs_aio_request* req,
+                       Args... args)
+{
+    ContextPtr ctx(get_ctx_());
+    auto key = reinterpret_cast<uint64_t>(req);
+
+    {
+        LOCK_MAP();
+        auto ret(map_.emplace(key, ctx));
+    }
+
+    int ret = (ctx.get()->*mem_fun)(req,
+                                    std::forward<Args>(args)...);
+    if (ret < 0)
+    {
+        map_.erase(key);
+    }
+
+    return ret;
+}
+
+int
+PathSelector::send_read_request(ovs_aio_request* req,
+                                ovs_aiocb* aiocb)
+{
+    return wrap_io_(&ovs_context_t::send_read_request,
+                    req,
+                    aiocb);
+}
+
+int
+PathSelector::send_write_request(ovs_aio_request* req,
+                                 ovs_aiocb* aiocb)
+{
+    return wrap_io_(&ovs_context_t::send_write_request,
+                    req,
+                    aiocb);
+}
+
+int
+PathSelector::send_flush_request(ovs_aio_request* req)
+{
+    return wrap_io_(&ovs_context_t::send_flush_request,
+                    req);
+}
+
+void
+PathSelector::complete_request(ovs_aio_request& req,
+                               ssize_t ret,
+                               int err,
+                               bool schedule)
+{
+    {
+        LOCK_MAP();
+        map_.erase(reinterpret_cast<uint64_t>(&req));
+    }
+
+    callback_.complete_request(req, ret, err, schedule);
+}
+
+}

--- a/src/filesystem/c-api/PathSelector.h
+++ b/src/filesystem/c-api/PathSelector.h
@@ -1,0 +1,228 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#ifndef LIB_OVS_VOLUMEDRIVER_PATH_SELECTOR_H_
+#define LIB_OVS_VOLUMEDRIVER_PATH_SELECTOR_H_
+
+#include "context.h"
+#include "RequestDispatcherCallback.h"
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#include <youtils/PeriodicAction.h>
+#include <youtils/SpinLock.h>
+
+namespace libovsvolumedriver
+{
+
+class PathSelector
+    : public ovs_context_t
+    , public RequestDispatcherCallback
+{
+public:
+    using ContextPtr = std::shared_ptr<ovs_context_t>;
+    using ContextFactoryFun = std::function<ContextPtr(const std::string& uri,
+                                                       RequestDispatcherCallback&)>;
+
+    PathSelector(const std::string& uri,
+                 ContextFactoryFun,
+                 RequestDispatcherCallback&);
+
+    ~PathSelector() = default;
+
+    PathSelector(const PathSelector&) = delete;
+
+    PathSelector&
+    operator=(const PathSelector&) = delete;
+
+    int
+    open_volume(const char *volume_name,
+                int oflag) override final
+    {
+        return get_ctx_()->open_volume(volume_name, oflag);
+    }
+
+    void
+    close_volume() override final
+    {
+        return get_ctx_()->close_volume();
+    }
+
+    int
+    create_volume(const char *volume_name,
+                  uint64_t size) override final
+    {
+        return get_ctx_()->create_volume(volume_name, size);
+    }
+
+    int
+    remove_volume(const char *volume_name) override final
+    {
+        return get_ctx_()->remove_volume(volume_name);
+    }
+
+    int
+    snapshot_create(const char *volume_name,
+                    const char *snapshot_name,
+                    const uint64_t timeout) override final
+    {
+        return get_ctx_()->snapshot_create(volume_name, snapshot_name, timeout);
+    }
+
+    int
+    snapshot_rollback(const char *volume_name,
+                      const char *snapshot_name) override final
+    {
+        return get_ctx_()->snapshot_rollback(volume_name, snapshot_name);
+    }
+
+    int
+    snapshot_remove(const char *volume_name,
+                    const char *snapshot_name) override final
+    {
+        return get_ctx_()->snapshot_remove(volume_name, snapshot_name);
+    }
+    void
+    list_snapshots(std::vector<std::string>& snaps,
+                   const char *volume_name,
+                   uint64_t *size,
+                   int *saved_errno) override final
+    {
+        return get_ctx_()->list_snapshots(snaps, volume_name, size, saved_errno);
+    }
+
+    int
+    is_snapshot_synced(const char *volume_name,
+                       const char *snapshot_name) override final
+    {
+        return get_ctx_()->is_snapshot_synced(volume_name, snapshot_name);
+    }
+
+    int
+    list_volumes(std::vector<std::string>& vols) override final
+    {
+        return get_ctx_()->list_volumes(vols);
+    }
+
+    int
+    list_cluster_node_uri(std::vector<std::string>& uris) override final
+    {
+        return get_ctx_()->list_cluster_node_uri(uris);
+    }
+
+    int
+    get_volume_uri(const char* volume_name,
+                   std::string& uri) override final
+    {
+        return get_ctx_()->get_volume_uri(volume_name, uri);
+    }
+
+    int
+    send_read_request(ovs_aio_request*,
+                      ovs_aiocb*) override final;
+
+    int
+    send_write_request(ovs_aio_request*,
+                       ovs_aiocb*) override final;
+
+    int
+    send_flush_request(ovs_aio_request*) override final;
+
+    int
+    stat_volume(struct stat *st) override final
+    {
+        return get_ctx_()->stat_volume(st);
+    }
+
+    ovs_buffer*
+    allocate(size_t size) override final
+    {
+        return get_ctx_()->allocate(size);
+    }
+
+    int
+    deallocate(ovs_buffer* buf) override final
+    {
+        return get_ctx_()->deallocate(buf);
+    }
+
+    int
+    truncate_volume(const char *volume_name,
+                    uint64_t size) override final
+    {
+        return get_ctx_()->truncate_volume(volume_name, size);
+    }
+
+    int
+    truncate(uint64_t size) override final
+    {
+        return get_ctx_()->truncate(size);
+    }
+
+    std::string
+    current_uri() const override final
+    {
+        return get_ctx_()->current_uri();
+    }
+
+    boost::optional<std::string>
+    volume_name() const override final
+    {
+        return get_ctx_()->volume_name();
+    }
+
+    void
+    complete_request(ovs_aio_request&,
+                     ssize_t ret,
+                     int err,
+                     bool schedule) override final;
+
+private:
+    ContextPtr ctx_;
+    mutable fungi::SpinLock ctx_lock_;
+
+    // consider using a custom - boost::pool based? - allocator,
+    // especially since the map is protected by a spinlock.
+    std::unordered_map<uint64_t, ContextPtr> map_;
+    mutable fungi::SpinLock map_lock_;
+
+    ContextFactoryFun make_context_;
+    RequestDispatcherCallback& callback_;
+    std::atomic<uint64_t> period_secs_;
+    youtils::PeriodicAction checker_;
+
+    ContextPtr
+    get_ctx_() const
+    {
+        std::lock_guard<decltype(ctx_lock_)> g(ctx_lock_);
+        return ctx_;
+    }
+
+    template<typename... Args>
+    int
+    wrap_io_(int (ovs_context_t::*mem_fun)(ovs_aio_request*,
+                                           Args...),
+             ovs_aio_request*,
+             Args...);
+
+    void
+    update_();
+};
+
+}
+
+#endif // !LIB_OVS_VOLUMEDRIVER_PATH_SELECTOR_H_

--- a/src/filesystem/c-api/RequestDispatcherCallback.h
+++ b/src/filesystem/c-api/RequestDispatcherCallback.h
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#ifndef REQUEST_DISPATCHER_CALLBACK_H_
+#define REQUEST_DISPATCHER_CALLBACK_H_
+
+struct ovs_aio_request;
+
+namespace libovsvolumedriver
+{
+
+struct RequestDispatcherCallback
+{
+    virtual ~RequestDispatcherCallback() = default;
+
+    virtual void
+    complete_request(ovs_aio_request&,
+                     ssize_t ret,
+                     int err,
+                     bool schedule) = 0;
+};
+
+}
+
+#endif // !REQUEST_DISPATCHER_CALLBACK_H_

--- a/src/filesystem/c-api/ShmContext.cpp
+++ b/src/filesystem/c-api/ShmContext.cpp
@@ -294,8 +294,8 @@ ShmContext::get_volume_uri(const char* /* volume_name */,
 }
 
 int
-ShmContext::send_read_request(struct ovs_aiocb *ovs_aiocbp,
-                              ovs_aio_request *request)
+ShmContext::send_read_request(ovs_aio_request* request,
+                              ovs_aiocb* ovs_aiocbp)
 {
     return shm_ctx_->shm_client_->send_read_request(ovs_aiocbp->aio_buf,
                                                     ovs_aiocbp->aio_nbytes,
@@ -304,8 +304,8 @@ ShmContext::send_read_request(struct ovs_aiocb *ovs_aiocbp,
 }
 
 int
-ShmContext::send_write_request(struct ovs_aiocb *ovs_aiocbp,
-                               ovs_aio_request *request)
+ShmContext::send_write_request(ovs_aio_request* request,
+                               ovs_aiocb* ovs_aiocbp)
 {
     return shm_ctx_->shm_client_->send_write_request(ovs_aiocbp->aio_buf,
                                                      ovs_aiocbp->aio_nbytes,
@@ -314,7 +314,7 @@ ShmContext::send_write_request(struct ovs_aiocb *ovs_aiocbp,
 }
 
 int
-ShmContext::send_flush_request(ovs_aio_request *request)
+ShmContext::send_flush_request(ovs_aio_request* request)
 {
     struct ovs_aiocb *ovs_aiocbp = request->ovs_aiocbp;
     return shm_ctx_->shm_client_->send_write_request(ovs_aiocbp->aio_buf,

--- a/src/filesystem/c-api/ShmContext.cpp
+++ b/src/filesystem/c-api/ShmContext.cpp
@@ -286,6 +286,14 @@ ShmContext::list_cluster_node_uri(std::vector<std::string>& /*uris*/)
 }
 
 int
+ShmContext::get_volume_uri(const char* /* volume_name */,
+                           std::string& /*uri*/)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
 ShmContext::send_read_request(struct ovs_aiocb *ovs_aiocbp,
                               ovs_aio_request *request)
 {

--- a/src/filesystem/c-api/ShmContext.cpp
+++ b/src/filesystem/c-api/ShmContext.cpp
@@ -358,3 +358,15 @@ ShmContext::deallocate(ovs_buffer_t *ptr)
     }
     return r;
 }
+
+std::string
+ShmContext::current_uri() const
+{
+    throw std::logic_error("ShmContext::current_uri is not implemented yet");
+}
+
+boost::optional<std::string>
+ShmContext::volume_name() const
+{
+    throw std::logic_error("ShmContext::volume_name is not implemented yet");
+}

--- a/src/filesystem/c-api/ShmContext.h
+++ b/src/filesystem/c-api/ShmContext.h
@@ -85,15 +85,15 @@ struct ShmContext : public ovs_context_t
                    std::string& uri) override final;
 
     int
-    send_read_request(struct ovs_aiocb *ovs_aiocbp,
-                      ovs_aio_request *request);
+    send_read_request(ovs_aio_request*,
+                      ovs_aiocb*) override final;
 
     int
-    send_write_request(struct ovs_aiocb *ovs_aiocbp,
-                       ovs_aio_request *request);
+    send_write_request(ovs_aio_request*,
+                       ovs_aiocb*) override final;
 
     int
-    send_flush_request(ovs_aio_request *request);
+    send_flush_request(ovs_aio_request*) override final;
 
     int
     stat_volume(struct stat *st);

--- a/src/filesystem/c-api/ShmContext.h
+++ b/src/filesystem/c-api/ShmContext.h
@@ -81,6 +81,10 @@ struct ShmContext : public ovs_context_t
     list_cluster_node_uri(std::vector<std::string>& uris);
 
     int
+    get_volume_uri(const char* volume_name,
+                   std::string& uri) override final;
+
+    int
     send_read_request(struct ovs_aiocb *ovs_aiocbp,
                       ovs_aio_request *request);
 

--- a/src/filesystem/c-api/ShmContext.h
+++ b/src/filesystem/c-api/ShmContext.h
@@ -103,6 +103,12 @@ struct ShmContext : public ovs_context_t
 
     int
     deallocate(ovs_buffer_t *ptr);
+
+    std::string
+    current_uri() const override final;
+
+    boost::optional<std::string>
+    volume_name() const override final;
 };
 
 #endif //__SHM_CONTEXT_H

--- a/src/filesystem/c-api/common.h
+++ b/src/filesystem/c-api/common.h
@@ -18,6 +18,8 @@
 
 #define ATTRIBUTE_UNUSED __attribute__((unused))
 
+#include "volumedriver.h"
+
 #include <string>
 #include <libxio.h>
 

--- a/src/filesystem/c-api/context.h
+++ b/src/filesystem/c-api/context.h
@@ -65,13 +65,13 @@ struct ovs_context_t
     virtual int get_volume_uri(const char* volume_name,
                                std::string& uri) = 0;
 
-    virtual int send_read_request(struct ovs_aiocb *ovs_aiocbp,
-                                  ovs_aio_request *request) = 0;
+    virtual int send_read_request(ovs_aio_request*,
+                                  ovs_aiocb*) = 0;
 
-    virtual int send_write_request(struct ovs_aiocb *ovs_aiocbp,
-                                   ovs_aio_request *request) = 0;
+    virtual int send_write_request(ovs_aio_request*,
+                                   ovs_aiocb*) = 0;
 
-    virtual int send_flush_request(ovs_aio_request *request) = 0;
+    virtual int send_flush_request(ovs_aio_request*) = 0;
 
     virtual int stat_volume(struct stat *st) = 0;
 

--- a/src/filesystem/c-api/context.h
+++ b/src/filesystem/c-api/context.h
@@ -20,6 +20,9 @@
 
 #include <vector>
 
+struct ovs_aio_request;
+struct ovs_aiocb;
+
 struct ovs_context_t
 {
     TransportType transport;
@@ -69,9 +72,9 @@ struct ovs_context_t
 
     virtual int stat_volume(struct stat *st) = 0;
 
-    virtual ovs_buffer_t* allocate(size_t size) = 0;
+    virtual ovs_buffer* allocate(size_t size) = 0;
 
-    virtual int deallocate(ovs_buffer_t *ptr) = 0;
+    virtual int deallocate(ovs_buffer *ptr) = 0;
 
     virtual int truncate_volume(const char *volume_name,
                                 uint64_t length) = 0;

--- a/src/filesystem/c-api/context.h
+++ b/src/filesystem/c-api/context.h
@@ -62,6 +62,9 @@ struct ovs_context_t
 
     virtual int list_cluster_node_uri(std::vector<std::string>& uris) = 0;
 
+    virtual int get_volume_uri(const char* volume_name,
+                               std::string& uri) = 0;
+
     virtual int send_read_request(struct ovs_aiocb *ovs_aiocbp,
                                   ovs_aio_request *request) = 0;
 

--- a/src/filesystem/c-api/context.h
+++ b/src/filesystem/c-api/context.h
@@ -20,6 +20,8 @@
 
 #include <vector>
 
+#include <boost/optional.hpp>
+
 struct ovs_aio_request;
 struct ovs_aiocb;
 
@@ -83,6 +85,12 @@ struct ovs_context_t
                                 uint64_t length) = 0;
 
     virtual int truncate(uint64_t length) = 0;
+
+    virtual std::string
+    current_uri() const = 0;
+
+    virtual boost::optional<std::string>
+    volume_name() const = 0;
 };
 
 #endif // __CONTEXT_H

--- a/src/filesystem/c-api/libovsvolumedriver.cpp
+++ b/src/filesystem/c-api/libovsvolumedriver.cpp
@@ -768,15 +768,15 @@ _ovs_submit_aio_request(ovs_ctx_t *ctx,
     case RequestOp::Read:
     {
         /* on error returns -1, errno is already set */
-        r = ctx->send_read_request(ovs_aiocbp,
-                                   request);
+        r = ctx->send_read_request(request,
+                                   ovs_aiocbp);
     }
         break;
     case RequestOp::Write:
     {
         /* on error returns -1, errno is already set */
-        r = ctx->send_write_request(ovs_aiocbp,
-                                    request);
+        r = ctx->send_write_request(request,
+                                    ovs_aiocbp);
     }
         break;
     case RequestOp::Flush:

--- a/src/filesystem/c-api/libovsvolumedriver.cpp
+++ b/src/filesystem/c-api/libovsvolumedriver.cpp
@@ -44,6 +44,13 @@
 
 namespace libvoldrv = libovsvolumedriver;
 
+namespace
+{
+
+libvoldrv::DefaultRequestDispatcherCallback default_request_callback;
+
+}
+
 ovs_ctx_attr_t*
 ovs_ctx_attr_new()
 {
@@ -186,7 +193,8 @@ ovs_ctx_new(const ovs_ctx_attr_t *attr)
         case TransportType::RDMA:
             ctx = new libvoldrv::NetworkHAContext(uri,
                                                   attr->network_qdepth,
-                                                  attr->enable_ha);
+                                                  attr->enable_ha,
+                                                  default_request_callback);
             break;
         case TransportType::SharedMemory:
             ctx = new ShmContext;

--- a/src/filesystem/test/ClusterRegistryTest.cpp
+++ b/src/filesystem/test/ClusterRegistryTest.cpp
@@ -80,7 +80,7 @@ TEST_F(ClusterRegistryTest, empty_registry)
     EXPECT_THROW(cluster_registry_->get_node_status_map(),
                  vfs::ClusterNotRegisteredException);
 
-    EXPECT_THROW(cluster_registry_->get_node_state(vfs::NodeId("some-node")),
+    EXPECT_THROW(cluster_registry_->get_node_status(vfs::NodeId("some-node")),
                  vfs::ClusterNotRegisteredException);
 
     EXPECT_THROW(cluster_registry_->set_node_state(vfs::NodeId("some-node"),
@@ -174,13 +174,13 @@ TEST_F(ClusterRegistryTest, node_states)
     cluster_registry_->set_node_configs(configs);
 
     EXPECT_EQ(vfs::ClusterNodeStatus::State::Online,
-              cluster_registry_->get_node_state(configs[0].vrouter_id));
+              cluster_registry_->get_node_status(configs[0].vrouter_id).state);
 
     cluster_registry_->set_node_state(configs[0].vrouter_id,
                                       vfs::ClusterNodeStatus::State::Offline);
 
     EXPECT_EQ(vfs::ClusterNodeStatus::State::Offline,
-              cluster_registry_->get_node_state(configs[0].vrouter_id));
+              cluster_registry_->get_node_status(configs[0].vrouter_id).state);
 
     const vfs::ClusterRegistry::NodeStatusMap
         status_map(cluster_registry_->get_node_status_map());
@@ -188,7 +188,7 @@ TEST_F(ClusterRegistryTest, node_states)
     EXPECT_EQ(vfs::ClusterNodeStatus::State::Offline,
               status_map.begin()->second.state);
 
-    EXPECT_THROW(cluster_registry_->get_node_state(vfs::NodeId("InexistentNode")),
+    EXPECT_THROW(cluster_registry_->get_node_status(vfs::NodeId("InexistentNode")),
                  vfs::ClusterNodeNotRegisteredException);
 
     EXPECT_THROW(cluster_registry_->set_node_state(vfs::NodeId("InexistentNode"),

--- a/src/filesystem/test/NetworkServerTest.cpp
+++ b/src/filesystem/test/NetworkServerTest.cpp
@@ -35,6 +35,8 @@
 
 #include <filesystem/ObjectRouter.h>
 #include <filesystem/Registry.h>
+
+#include <filesystem/c-api/context.h>
 #include <filesystem/c-api/volumedriver.h>
 
 namespace volumedriverfstest
@@ -1548,6 +1550,32 @@ TEST_F(NetworkServerTest, high_availability_fail_remote_automated)
     test_high_availability(true,
                            false,
                            true);
+}
+
+TEST_F(NetworkServerTest, get_volume_uri)
+{
+    CtxAttrPtr attrs(make_ctx_attr(1024,
+                                   false,
+                                   FileSystemTestSetup::local_edge_port()));
+    CtxPtr ctx(ovs_ctx_new(attrs.get()));
+    ASSERT_TRUE(ctx != nullptr);
+
+    const std::string vname("volume");
+    const size_t vsize = 1ULL << 20;
+
+    ASSERT_EQ(0,
+              ovs_create_volume(ctx.get(),
+                                vname.c_str(),
+                                vsize));
+
+    auto& ctx_iface = dynamic_cast<ovs_context_t&>(*ctx);
+
+    std::string uri;
+    ctx_iface.get_volume_uri(vname.c_str(),
+                             uri);
+
+    EXPECT_EQ(network_server_uri(local_node_id()),
+              yt::Uri(uri));
 }
 
 } //namespace

--- a/src/filesystem/test/RemoteTest.cpp
+++ b/src/filesystem/test/RemoteTest.cpp
@@ -1590,7 +1590,7 @@ TEST_F(RemoteTest, only_steal_from_offlined_node)
 
     std::shared_ptr<vfs::ClusterRegistry> reg(cluster_registry(fs_->object_router()));
     EXPECT_EQ(vfs::ClusterNodeStatus::State::Online,
-              reg->get_node_state(remote_node_id()));
+              reg->get_node_status(remote_node_id()).state);
 
     std::vector<char> buf(pattern.size());
     EXPECT_GT(0,
@@ -1599,7 +1599,7 @@ TEST_F(RemoteTest, only_steal_from_offlined_node)
                              buf.size(),
                              off));
     EXPECT_EQ(vfs::ClusterNodeStatus::State::Online,
-              reg->get_node_state(remote_node_id()));
+              reg->get_node_status(remote_node_id()).state);
 }
 
 TEST_F(RemoteTest, stealing_and_fencing)

--- a/src/filesystem/test/RestartTest.cpp
+++ b/src/filesystem/test/RestartTest.cpp
@@ -91,12 +91,12 @@ TEST_F(RestartTest, offlined_node)
                         vfs::ClusterNodeStatus::State::Offline);
 
     EXPECT_EQ(vfs::ClusterNodeStatus::State::Offline,
-              reg->get_node_state(local_node_id()));
+              reg->get_node_status(local_node_id()).state);
 
     ASSERT_NO_THROW(start_fs());
 
     EXPECT_EQ(vfs::ClusterNodeStatus::State::Online,
-              reg->get_node_state(local_node_id()));
+              reg->get_node_status(local_node_id()).state);
 }
 
 TEST_F(RestartTest, owner_tag)


### PR DESCRIPTION
Building blocks:
- `c-api`: `ovs_context::get_volume_uri`: allows to retrieve the location (Edge URI) of a given volume
- `filesystem`: `volumedriverfs::Handle::is_local`: can be used after I/O requests to check if a volume is living on the local instance or elsewhere (only supports volumes atm, not filedriver objects). This information could be piggy-backed in I/O responses to clients.

NB: there's more to come, opening the PR to allow early review feedback
