### PR TITLE
Feature/cluster topology awareness

### DIFF
--- a/src/filesystem-python-client/DictConverter.h
+++ b/src/filesystem-python-client/DictConverter.h
@@ -1,0 +1,102 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#ifndef VFS_DICT_CONVERTER_H_
+#define VFS_DICT_CONVERTER_H_
+
+#include "PairConverter.h"
+
+#include <type_traits>
+
+#include <boost/python.hpp>
+#include <boost/python/dict.hpp>
+#include <boost/python/object.hpp>
+#include <boost/python/stl_iterator.hpp>
+#include <boost/python/to_python_converter.hpp>
+
+namespace volumedriverfs
+{
+
+namespace python
+{
+
+template<typename Map>
+struct DictConverter
+{
+    using K = typename Map::key_type;
+    using V = typename Map::mapped_type;
+
+    static PyObject*
+    convert(const Map& map)
+    {
+        namespace bpy = boost::python;
+        bpy::dict dict;
+
+        for (const auto& p : map)
+        {
+            dict[p.first] = p.second;
+        }
+        return bpy::incref(dict.ptr());
+    }
+
+    static void*
+    convertible(PyObject* o)
+    {
+        return PyDict_Check(o) ? o : nullptr;
+    }
+
+    static void
+    from_python(PyObject* obj,
+                boost::python::converter::rvalue_from_python_stage1_data* data)
+    {
+        namespace bpy = boost::python;
+
+        bpy::handle<> handle(bpy::borrowed(obj));
+
+        using Storage = bpy::converter::rvalue_from_python_storage<Map>;
+        void* storage = reinterpret_cast<Storage*>(data)->storage.bytes;
+
+        const bpy::dict dict = bpy::extract<bpy::dict>(handle.get());
+
+        using Iterator = bpy::stl_input_iterator<typename Map::value_type>;
+        data->convertible = new(storage) Map(Iterator(dict.iteritems()),
+                                             Iterator());
+    }
+
+    static void
+    registerize()
+    {
+        namespace bpy = boost::python;
+
+        bpy::converter::registry::push_back(&DictConverter<Map>::convertible,
+                                            &DictConverter<Map>::from_python,
+                                            bpy::type_id<Map>());
+
+        bpy::to_python_converter<Map , DictConverter<Map>>();
+    }
+};
+
+}
+
+}
+
+#define REGISTER_DICT_CONVERTER_(Map)                           \
+    volumedriverfs::python::DictConverter<Map>::registerize()
+
+#define REGISTER_DICT_CONVERTER(Map)                                    \
+    REGISTER_PAIR_CONVERTER(std::add_const<Map::key_type>::type, Map::mapped_type); \
+    REGISTER_DICT_CONVERTER_(Map)
+
+#endif // !VFS_DICT_CONVERTER_H_

--- a/src/filesystem-python-client/PythonTestHelpers.cpp
+++ b/src/filesystem-python-client/PythonTestHelpers.cpp
@@ -132,6 +132,9 @@ PythonTestHelpers::registerize()
         .def("reflect_uri",
              &PythonTestHelpers::reflect<youtils::Uri>)
         .staticmethod("reflect_uri")
+        .def("reflect_maybe_node_distance_map",
+             &PythonTestHelpers::reflect<ClusterNodeConfig::MaybeNodeDistanceMap>)
+        .staticmethod("reflect_maybe_node_distance_map")
         ;
 }
 

--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -15,6 +15,7 @@
 
 #include "ArakoonClient.h"
 #include "ChronoDurationConverter.h"
+#include "DictConverter.h"
 #include "FileSystemMetaDataClient.h"
 #include "IterableConverter.h"
 #include "LocalClient.h"
@@ -22,6 +23,7 @@
 #include "MDSClient.h"
 #include "ObjectRegistryClient.h"
 #include "OptionalConverter.h"
+#include "PairConverter.h"
 #include "Piccalilli.h"
 #include "PythonTestHelpers.h"
 #include "ScrubManagerClient.h"
@@ -173,21 +175,6 @@ reminder(vfs::XMLRPCErrorCode code)
         break;
     }
 }
-
-template <typename M>
-struct MapToDictConverter
-{
-    static PyObject*
-    convert(const M& map)
-    {
-        bpy::dict d;
-        for (const auto& e : map)
-        {
-            d[e.first] = e.second;
-        }
-        return bpy::incref(d.ptr());
-    }
-};
 
 struct UpdateReportConverter
 {
@@ -1159,8 +1146,8 @@ BOOST_PYTHON_MODULE(storagerouterclient)
 
     bpy::to_python_converter<yt::UpdateReport, UpdateReportConverter>();
 
-    typedef std::map<vfs::NodeId, vfs::ClusterNodeStatus::State> NodeStatusMap;
-    bpy::to_python_converter<NodeStatusMap, MapToDictConverter<NodeStatusMap>>();
+    using NodeStatusMap = std::map<vfs::NodeId, vfs::ClusterNodeStatus::State>;
+    REGISTER_DICT_CONVERTER(NodeStatusMap);
 
     REGISTER_ITERABLE_CONVERTER(std::vector<vfs::ClusterContact>);
 

--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -879,6 +879,9 @@ BOOST_PYTHON_MODULE(storagerouterclient)
 
     REGISTER_OPTIONAL_CONVERTER(youtils::Uri);
 
+    REGISTER_DICT_CONVERTER(vfs::ClusterNodeConfig::NodeDistanceMap);
+    REGISTER_OPTIONAL_CONVERTER(vfs::ClusterNodeConfig::NodeDistanceMap);
+
     bpy::class_<vfs::ClusterNodeConfig>
         ("ClusterNodeConfig",
          "configuration of a single volumedriverfs cluster node",
@@ -887,9 +890,10 @@ BOOST_PYTHON_MODULE(storagerouterclient)
                    vfs::MessagePort,
                    vfs::XmlRpcPort,
                    vfs::FailoverCachePort,
-         const MaybeUri&,
-         const MaybeString&,
-         const MaybeString&>
+                   const MaybeUri&,
+                   const MaybeString&,
+                   const MaybeString&,
+                   const vfs::ClusterNodeConfig::MaybeNodeDistanceMap&>
          ((bpy::args("vrouter_id"),
            bpy::args("host"),
            bpy::args("message_port"),
@@ -897,7 +901,8 @@ BOOST_PYTHON_MODULE(storagerouterclient)
            bpy::args("failovercache_port"),
            bpy::args("network_server_uri") = MaybeUri(),
            bpy::args("xmlrpc_host") = MaybeString(),
-           bpy::args("failovercache_host") = MaybeString()),
+           bpy::args("failovercache_host") = MaybeString(),
+           bpy::args("node_distance_map") = vfs::ClusterNodeConfig::MaybeNodeDistanceMap()),
           "Create a cluster node configuration\n"
           "@param vrouter_id: string, node ID\n"
           "@param host: string, hostname or IP address to be used for communication between nodes\n"
@@ -906,7 +911,8 @@ BOOST_PYTHON_MODULE(storagerouterclient)
           "@param failovercache_port: uint16_t, TCP port of the FailoverCache for this node\n"
           "@param network_server_uri: optional string (URI), URI the network server shall listen on\n"
           "@param xmlrpc_host: optional string, address the XMLRPC server shall use, falls back to 'host' if unspecified\n"
-          "@param failovercache_host: optional string, address the DTL shall use, falls back to 'host' if unspecified\n"))
+          "@param failovercache_host: optional string, address the DTL shall use, falls back to 'host' if unspecified\n"
+          "@param node_distance_map: optional dict str -> uint32, distance of other NodeIds from this node\n"))
         .def("__str__",
              &vfs::ClusterNodeConfig::str)
         .def("__repr__",
@@ -931,7 +937,7 @@ BOOST_PYTHON_MODULE(storagerouterclient)
         DEF_READONLY_PROP_(failovercache_host)
         DEF_READONLY_PROP_(failovercache_port)
         DEF_READONLY_PROP_(network_server_uri)
-
+        DEF_READONLY_PROP_(node_distance_map)
 #undef DEF_READONLY_PROP_
         ;
 
@@ -993,6 +999,9 @@ BOOST_PYTHON_MODULE(storagerouterclient)
         .def("erase_node_configs",
              &vfs::ClusterRegistry::erase_node_configs,
              "Erase the cluster node configurations for this cluster from the registry\n")
+        .def("get_node_status_map",
+             &vfs::ClusterRegistry::get_node_status_map,
+             "Get the node status map\n")
         ;
 
     bpy::enum_<vfs::ObjectType>("ObjectType")

--- a/src/filesystem-python-client/test/fs_python_client_test.py.in
+++ b/src/filesystem-python-client/test/fs_python_client_test.py.in
@@ -168,6 +168,14 @@ class TestHelperTest(unittest.TestCase):
         s = "tcp://127.0.0.1:1234"
         self.assertEqual(s, PythonTestHelpers.reflect_uri(s))
 
+    def test_maybe_node_distance_map(self):
+        d = {}
+        self.assertEqual(d, PythonTestHelpers.reflect_maybe_node_distance_map(d))
+        d["node_1"] = 1
+        d["node_2"] = 1
+        d["node_3"] = 2
+        self.assertEqual(d, PythonTestHelpers.reflect_maybe_node_distance_map(d))
+
     def test_cluster_node_config(self):
         node_id = "node_X"
         host = "192.168.1.1"

--- a/src/filesystem/ClusterNodeConfig.cpp
+++ b/src/filesystem/ClusterNodeConfig.cpp
@@ -24,7 +24,7 @@ std::ostream&
 operator<<(std::ostream& os,
            const ClusterNodeConfig& cfg)
 {
-    os << "ClusterNodeConfig { " <<
+    os << "ClusterNodeConfig{" <<
         "vrouter_id: \"" << cfg.vrouter_id << "\", " <<
         "message_host: \"" << cfg.message_host << "\", " <<
         "message_port: " << cfg.message_port << ", " <<
@@ -35,9 +35,33 @@ operator<<(std::ostream& os,
         "network_server_uri: \"" <<
         (cfg.network_server_uri ?
          boost::lexical_cast<std::string>(*cfg.network_server_uri) :
-         "") << "\"}";
+         "") << "\", " <<
+        "node_distance_map: ";
 
-    return os;
+    if (cfg.node_distance_map)
+    {
+        os << "{";
+        bool fst = true;
+        for (const auto& e : *cfg.node_distance_map)
+        {
+            if (fst)
+            {
+                fst = false;
+            }
+            else
+            {
+                os << ", ";
+            }
+            os << "\"" << e.first << "\": " << e.second;
+        }
+        os << "}";
+    }
+    else
+    {
+        os << " ";
+    }
+
+    return os << "}";
 }
 
 std::string

--- a/src/filesystem/ClusterNodeConfig.h
+++ b/src/filesystem/ClusterNodeConfig.h
@@ -41,6 +41,8 @@ namespace volumedriverfs
 struct ClusterNodeConfig
 {
     using MaybeUri = boost::optional<youtils::Uri>;
+    using NodeDistanceMap = std::map<NodeId, uint32_t>;
+    using MaybeNodeDistanceMap = boost::optional<NodeDistanceMap>;
 
     ClusterNodeConfig(const NodeId& id,
                       const std::string& mhost,
@@ -49,7 +51,8 @@ struct ClusterNodeConfig
                       FailoverCachePort fport,
                       const MaybeUri& nw_uri,
                       const boost::optional<std::string>& xhost = boost::none,
-                      const boost::optional<std::string>& fhost = boost::none)
+                      const boost::optional<std::string>& fhost = boost::none,
+                      const MaybeNodeDistanceMap& node_dist_map = boost::none)
         : vrouter_id(id)
         , message_host(mhost)
         , message_port(mport)
@@ -58,6 +61,7 @@ struct ClusterNodeConfig
         , failovercache_host(fhost ? *fhost : mhost)
         , failovercache_port(fport)
         , network_server_uri(nw_uri)
+        , node_distance_map(node_dist_map)
     {
         //we don't allow empty node_id's as the empty string is
         //used in our python API as "don't care"
@@ -75,6 +79,7 @@ struct ClusterNodeConfig
         , failovercache_host(other.failovercache_host)
         , failovercache_port(other.failovercache_port)
         , network_server_uri(other.network_server_uri)
+        , node_distance_map(other.node_distance_map)
     {}
 
     ClusterNodeConfig&
@@ -82,14 +87,15 @@ struct ClusterNodeConfig
     {
         if (this != &other)
         {
-            const_cast<NodeId&>(vrouter_id) = other.vrouter_id;
-            const_cast<std::string&>(message_host) = other.message_host;
-            const_cast<MessagePort&>(message_port) = other.message_port;
-            const_cast<std::string&>(xmlrpc_host) = other.xmlrpc_host;
-            const_cast<XmlRpcPort&>(xmlrpc_port) = other.xmlrpc_port;
-            const_cast<std::string&>(failovercache_host) = other.failovercache_host;
-            const_cast<FailoverCachePort&>(failovercache_port) = other.failovercache_port;
-            const_cast<MaybeUri&>(network_server_uri) = other.network_server_uri;
+            vrouter_id = other.vrouter_id;
+            message_host = other.message_host;
+            message_port = other.message_port;
+            xmlrpc_host = other.xmlrpc_host;
+            xmlrpc_port = other.xmlrpc_port;
+            failovercache_host = other.failovercache_host;
+            failovercache_port = other.failovercache_port;
+            network_server_uri = other.network_server_uri;
+            node_distance_map = other.node_distance_map;
         }
 
         return *this;
@@ -106,7 +112,8 @@ struct ClusterNodeConfig
             (xmlrpc_port == other.xmlrpc_port) and
             (failovercache_host == other.failovercache_host) and
             (failovercache_port == other.failovercache_port) and
-            (network_server_uri == other.network_server_uri);
+            (network_server_uri == other.network_server_uri) and
+            (node_distance_map == other.node_distance_map);
     }
 
     bool
@@ -121,35 +128,44 @@ struct ClusterNodeConfig
     void
     load(Archive& ar, const unsigned version)
     {
-        if (version > 3)
+        if (version > 4)
         {
-            THROW_SERIALIZATION_ERROR(version, 3, 1);
+            THROW_SERIALIZATION_ERROR(version, 4, 1);
         }
 
-        ar & const_cast<NodeId&>(vrouter_id);
-        ar & const_cast<std::string&>(message_host);
-        ar & static_cast<uint16_t&>(const_cast<MessagePort&>(message_port));
-        ar & static_cast<uint16_t&>(const_cast<XmlRpcPort&>(xmlrpc_port));
-        ar & static_cast<uint16_t&>(const_cast<FailoverCachePort&>(failovercache_port));
+        ar & vrouter_id;
+        ar & message_host;
+        ar & static_cast<uint16_t&>(message_port);
+        ar & static_cast<uint16_t&>(xmlrpc_port);
+        ar & static_cast<uint16_t&>(failovercache_port);
 
         if (version > 1)
         {
-            ar & const_cast<MaybeUri&>(network_server_uri);
+            ar & network_server_uri;
         }
         else
         {
-            const_cast<MaybeUri&>(network_server_uri) = boost::none;
+            network_server_uri = boost::none;
         }
 
         if (version > 2)
         {
-            ar & const_cast<std::string&>(xmlrpc_host);
-            ar & const_cast<std::string&>(failovercache_host);
+            ar & xmlrpc_host;
+            ar & failovercache_host;
         }
         else
         {
-            const_cast<std::string&>(xmlrpc_host) = message_host;
-            const_cast<std::string&>(failovercache_host) = message_host;
+            xmlrpc_host = message_host;
+            failovercache_host = message_host;
+        }
+
+        if (version > 3)
+        {
+            ar & node_distance_map;
+        }
+        else
+        {
+            node_distance_map = boost::none;
         }
     }
 
@@ -157,7 +173,7 @@ struct ClusterNodeConfig
     void
     save(Archive& ar, const unsigned version) const
     {
-        CHECK_VERSION(version, 3);
+        CHECK_VERSION(version, 4);
 
         ar & vrouter_id;
         ar & message_host;
@@ -167,20 +183,22 @@ struct ClusterNodeConfig
         ar & network_server_uri;
         ar & xmlrpc_host;
         ar & failovercache_host;
+        ar & node_distance_map;
     }
 
     // for python consumption
     std::string
     str() const;
 
-    const NodeId vrouter_id;
-    const std::string message_host;
-    const MessagePort message_port;
-    const std::string xmlrpc_host;
-    const XmlRpcPort xmlrpc_port;
-    const std::string failovercache_host;
-    const FailoverCachePort failovercache_port;
-    const MaybeUri network_server_uri;
+    NodeId vrouter_id;
+    std::string message_host;
+    MessagePort message_port;
+    std::string xmlrpc_host;
+    XmlRpcPort xmlrpc_port;
+    std::string failovercache_host;
+    FailoverCachePort failovercache_port;
+    MaybeUri network_server_uri;
+    MaybeNodeDistanceMap node_distance_map;
 };
 
 std::ostream&
@@ -191,7 +209,7 @@ using ClusterNodeConfigs = std::vector<ClusterNodeConfig>;
 
 }
 
-BOOST_CLASS_VERSION(volumedriverfs::ClusterNodeConfig, 3);
+BOOST_CLASS_VERSION(volumedriverfs::ClusterNodeConfig, 4);
 
 namespace boost
 {

--- a/src/filesystem/ClusterRegistry.cpp
+++ b/src/filesystem/ClusterRegistry.cpp
@@ -321,4 +321,42 @@ ClusterRegistry::prepare_node_offline_assertion(arakoon::sequence& seq,
                    buf);
 }
 
+ClusterRegistry::NeighbourMap
+ClusterRegistry::get_neighbour_map(const NodeId& node_id)
+{
+    const NodeStatusMap status_map(get_node_status_map());
+    auto it = find_node_throw_(node_id,
+                               status_map);
+
+    const ClusterNodeConfig& cfg = it->second.config;
+    ClusterRegistry::NeighbourMap neigh_map;
+
+    if (cfg.node_distance_map)
+    {
+        for (const auto& p : *cfg.node_distance_map)
+        {
+            auto it = status_map.find(p.first);
+            if (it == status_map.end())
+            {
+                // throw instead?
+                LOG_WARN(p.first << " present in NodeDistanceMap of " <<
+                         node_id << " but absent from NodeStatusMap - skipping it");
+            }
+            else
+            {
+                neigh_map.emplace(p.second, it->second.config);
+            }
+        }
+    }
+    else
+    {
+        for (const auto& p : status_map)
+        {
+            neigh_map.emplace(0, p.second.config);
+        }
+    }
+
+    return neigh_map;
+}
+
 }

--- a/src/filesystem/ClusterRegistry.h
+++ b/src/filesystem/ClusterRegistry.h
@@ -41,7 +41,8 @@ MAKE_EXCEPTION(InvalidConfigurationException, fungi::IOException);
 class ClusterRegistry
 {
 public:
-    typedef std::map<NodeId, ClusterNodeStatus> NodeStatusMap;
+    using NodeStatusMap = std::map<NodeId, ClusterNodeStatus>;
+    using NeighbourMap = std::multimap<uint32_t, ClusterNodeConfig>;
 
     ClusterRegistry(const ClusterId& cluster_id,
                     std::shared_ptr<youtils::LockedArakoon> arakoon);
@@ -65,7 +66,7 @@ public:
     operator=(const ClusterRegistry&) = delete;
 
     void
-    set_node_configs(const ClusterNodeConfigs& configs);
+    set_node_configs(const ClusterNodeConfigs&);
 
     ClusterNodeConfigs
     get_node_configs();
@@ -76,9 +77,12 @@ public:
     NodeStatusMap
     get_node_status_map();
 
+    NeighbourMap
+    get_neighbour_map(const NodeId&);
+
     void
-    set_node_state(const NodeId& id,
-                   const ClusterNodeStatus::State st);
+    set_node_state(const NodeId&,
+                   const ClusterNodeStatus::State);
 
     ClusterNodeStatus
     get_node_status(const NodeId&);
@@ -90,8 +94,8 @@ public:
     }
 
     void
-    prepare_node_offline_assertion(arakoon::sequence& seq,
-                                   const NodeId& node_id);
+    prepare_node_offline_assertion(arakoon::sequence&,
+                                   const NodeId&);
 
     std::string
     make_key() const;
@@ -109,12 +113,12 @@ private:
     verify_(const ClusterNodeConfigs& node_configs);
 
     NodeStatusMap::iterator
-    find_node_throw_(const NodeId& node_id,
-                     ClusterRegistry::NodeStatusMap& map);
+    find_node_throw_(const NodeId&,
+                     ClusterRegistry::NodeStatusMap&);
 
     NodeStatusMap::const_iterator
-    find_node_throw_(const NodeId& node_id,
-                     const NodeStatusMap& map);
+    find_node_throw_(const NodeId&,
+                     const NodeStatusMap&);
 };
 
 }

--- a/src/filesystem/FileSystemParameters.cpp
+++ b/src/filesystem/FileSystemParameters.cpp
@@ -246,6 +246,13 @@ DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(network_workqueue_ctrl_max_threads,
                                       ShowDocumentation::T,
                                       128);
 
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(network_max_neighbour_distance,
+                                      network_interface_component_name,
+                                      "network_max_neighbour_distance",
+                                      "Hide nodes that have a distance >= this value from network clients",
+                                      ShowDocumentation::T,
+                                      std::numeric_limits<uint32_t>::max());
+
 // FileSystem:
 const char filesystem_component_name[] = "filesystem";
 

--- a/src/filesystem/FileSystemParameters.h
+++ b/src/filesystem/FileSystemParameters.h
@@ -76,6 +76,10 @@ DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_use_fencing,
                                                   bool);
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_send_sync_response,
                                                   bool);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_min_workers,
+                                                  uint16_t);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_max_workers,
+                                                  uint16_t);
 
 DECLARE_INITIALIZED_PARAM(vrouter_id,
                           std::string);
@@ -89,9 +93,6 @@ DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_registry_cache_capacity,
 extern const char volumeroutercluster_component_name[];
 
 DECLARE_INITIALIZED_PARAM(vrouter_cluster_id, std::string);
-
-DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_min_workers, uint16_t);
-DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_max_workers, uint16_t);
 
 // FileSystem:
 extern const char filesystem_component_name[];
@@ -181,6 +182,9 @@ DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(network_workqueue_max_threads,
 
 DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(network_workqueue_ctrl_max_threads,
                                        unsigned int);
+
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(network_max_neighbour_distance,
+                                                  std::atomic<uint32_t>);
 
 // EventPublisher:
 extern const char events_component_name[];

--- a/src/filesystem/NetworkXioIOHandler.cpp
+++ b/src/filesystem/NetworkXioIOHandler.cpp
@@ -18,10 +18,12 @@
 #include "ObjectRouter.h"
 #include "PythonClient.h" // clienterrors
 
-#include <volumedriver/DtlInSync.h>
 #include <youtils/Assert.h>
 #include <youtils/Catchers.h>
 #include <youtils/SocketAddress.h>
+#include <youtils/SourceOfUncertainty.h>
+
+#include <volumedriver/DtlInSync.h>
 
 namespace volumedriverfs
 {
@@ -763,6 +765,61 @@ NetworkXioIOHandler::handle_is_snapshot_synced(NetworkXioRequest *req,
     pack_ctrl_msg(req);
 }
 
+namespace
+{
+
+std::pair<std::vector<std::string>, size_t>
+get_neighbours(const ClusterRegistry::NeighbourMap& nmap,
+               const uint32_t max_neighbour_distance)
+{
+    using Set = std::set<std::string>;
+    std::vector<Set> sets;
+    sets.reserve(nmap.size());
+
+    uint32_t distance = 0;
+    size_t count = 0;
+
+    for (auto it = nmap.begin(); it != nmap.lower_bound(max_neighbour_distance); ++it)
+    {
+        const ClusterNodeConfig& c = it->second;
+        auto uri(boost::lexical_cast<std::string>(*c.network_server_uri));
+
+        if (sets.empty() or distance != it->first)
+        {
+            ASSERT(it->first >= distance);
+            distance = it->first;
+            sets.push_back(Set{});
+        }
+
+        auto res(sets.back().emplace(std::move(uri)));
+        ASSERT(res.second);
+
+        ++count;
+    }
+
+    yt::SourceOfUncertainty rand;
+    std::vector<std::string> uris;
+    uris.reserve(count);
+
+    size_t total_size = 0;
+    for (auto& set : sets)
+    {
+        while (not set.empty())
+        {
+            auto it = set.begin();
+            std::advance(it, rand(set.size() - 1));
+            ASSERT(it != set.end());
+            total_size += it->size() + 1;
+            uris.push_back(std::move(*it));
+            set.erase(it);
+        }
+    }
+
+    return std::make_pair(std::move(uris), total_size);
+}
+
+}
+
 void
 NetworkXioIOHandler::handle_list_cluster_node_uri(NetworkXioRequest *req)
 {
@@ -778,18 +835,8 @@ NetworkXioIOHandler::handle_list_cluster_node_uri(NetworkXioRequest *req)
         ObjectRouter& router = fs_.object_router();
         const ClusterRegistry::NeighbourMap
             nmap(router.cluster_registry()->get_neighbour_map(router.node_id()));
-        uris.reserve(nmap.size());
-
-        for (auto it = nmap.begin(); it != nmap.lower_bound(max_neighbour_distance_); ++it)
-        {
-            const ClusterNodeConfig& c = it->second;
-            if (c.network_server_uri)
-            {
-                auto uri(boost::lexical_cast<std::string>(*c.network_server_uri));
-                total_size += uri.length() + 1;
-                uris.push_back(std::move(uri));
-            }
-        }
+        std::tie(uris, total_size) = get_neighbours(nmap,
+                                                    max_neighbour_distance_);
     }
     CATCH_STD_ALL_EWHAT({
         LOG_ERROR("Problem listing cluster nodes URI: " << EWHAT);

--- a/src/filesystem/NetworkXioIOHandler.h
+++ b/src/filesystem/NetworkXioIOHandler.h
@@ -30,11 +30,13 @@ public:
     NetworkXioIOHandler(FileSystem& fs,
                         NetworkXioWorkQueuePtr wq,
                         NetworkXioWorkQueuePtr wq_ctrl,
-                        NetworkXioClientData* cd)
+                        NetworkXioClientData* cd,
+                        const std::atomic<uint32_t>& max_neighbour_distance)
     : fs_(fs)
     , wq_(wq)
     , wq_ctrl_(wq_ctrl)
     , cd_(cd)
+    , max_neighbour_distance_(max_neighbour_distance)
     {}
 
     ~NetworkXioIOHandler()
@@ -141,6 +143,7 @@ private:
     NetworkXioWorkQueuePtr wq_;
     NetworkXioWorkQueuePtr wq_ctrl_;
     NetworkXioClientData *cd_;
+    const std::atomic<uint32_t>& max_neighbour_distance_;
 
     std::string volume_name_;
     Handle::Ptr handle_;

--- a/src/filesystem/NetworkXioInterface.cpp
+++ b/src/filesystem/NetworkXioInterface.cpp
@@ -60,6 +60,7 @@ NetworkXioInterface::update(const bpt::ptree& pt,
     U(network_snd_rcv_queue_depth);
     U(network_workqueue_max_threads);
     U(network_workqueue_ctrl_max_threads);
+    U(network_max_neighbour_distance);
 #undef U
 }
 
@@ -73,6 +74,7 @@ NetworkXioInterface::persist(bpt::ptree& pt,
     P(network_snd_rcv_queue_depth);
     P(network_workqueue_max_threads);
     P(network_workqueue_ctrl_max_threads);
+    P(network_max_neighbour_distance);
 #undef P
 }
 

--- a/src/filesystem/NetworkXioInterface.h
+++ b/src/filesystem/NetworkXioInterface.h
@@ -40,12 +40,14 @@ public:
     , network_snd_rcv_queue_depth(pt)
     , network_workqueue_max_threads(pt)
     , network_workqueue_ctrl_max_threads(pt)
+    , network_max_neighbour_distance(pt)
     , fs_(fs)
     , xio_server_(fs_,
                   uri(),
                   snd_rcv_queue_depth(),
                   wq_max_threads(),
-                  wq_ctrl_max_threads())
+                  wq_ctrl_max_threads(),
+                  max_neighbour_distance())
     {}
 
     ~NetworkXioInterface()
@@ -99,6 +101,13 @@ public:
     {
         return network_workqueue_ctrl_max_threads.value();
     }
+
+    const std::atomic<uint32_t>&
+    max_neighbour_distance() const
+    {
+        return network_max_neighbour_distance.value();
+    }
+
 private:
     DECLARE_LOGGER("NetworkXioInterface");
 
@@ -106,6 +115,7 @@ private:
     DECLARE_PARAMETER(network_snd_rcv_queue_depth);
     DECLARE_PARAMETER(network_workqueue_max_threads);
     DECLARE_PARAMETER(network_workqueue_ctrl_max_threads);
+    DECLARE_PARAMETER(network_max_neighbour_distance);
 
     FileSystem& fs_;
     NetworkXioServer xio_server_;

--- a/src/filesystem/NetworkXioServer.cpp
+++ b/src/filesystem/NetworkXioServer.cpp
@@ -130,7 +130,8 @@ NetworkXioServer::NetworkXioServer(FileSystem& fs,
                                    const yt::Uri& uri,
                                    size_t snd_rcv_queue_depth,
                                    unsigned int workqueue_max_threads,
-                                   unsigned int workqueue_ctrl_max_threads)
+                                   unsigned int workqueue_ctrl_max_threads,
+                                   const std::atomic<uint32_t>& max_neigh_dist)
     : fs_(fs)
     , uri_(uri)
     , stopping(false)
@@ -139,6 +140,7 @@ NetworkXioServer::NetworkXioServer(FileSystem& fs,
     , queue_depth(snd_rcv_queue_depth)
     , wq_max_threads(workqueue_max_threads)
     , wq_ctrl_max_threads(workqueue_ctrl_max_threads)
+    , max_neighbour_distance(max_neigh_dist)
 {}
 
 NetworkXioServer::~NetworkXioServer()
@@ -388,7 +390,8 @@ NetworkXioServer::create_session_connection(xio_session *session,
             NetworkXioIOHandler *ioh_ptr = new NetworkXioIOHandler(fs_,
                                                                    wq_,
                                                                    wq_ctrl_,
-                                                                   cd);
+                                                                   cd,
+                                                                   max_neighbour_distance);
             cd->ioh = ioh_ptr;
             cd->session = session;
             cd->conn = evdata->conn;

--- a/src/filesystem/NetworkXioServer.h
+++ b/src/filesystem/NetworkXioServer.h
@@ -45,7 +45,8 @@ public:
                      const youtils::Uri&,
                      size_t snd_rcv_queue_depth,
                      unsigned int workqueue_max_threads,
-                     unsigned int workqueue_ctrl_max_threads);
+                     unsigned int workqueue_ctrl_max_threads,
+                     const std::atomic<uint32_t>& max_neighbour_distance);
 
     ~NetworkXioServer();
 
@@ -104,6 +105,7 @@ private:
     size_t queue_depth;
     unsigned int wq_max_threads;
     unsigned int wq_ctrl_max_threads;
+    const std::atomic<uint32_t>& max_neighbour_distance;
 
     NetworkXioWorkQueuePtr wq_;
     NetworkXioWorkQueuePtr wq_ctrl_;

--- a/src/filesystem/c-api/NetworkHAContext.h
+++ b/src/filesystem/c-api/NetworkHAContext.h
@@ -187,6 +187,7 @@ private:
 
     std::atomic<uint64_t> request_id_;
 
+    // Order: preferred/nearest ones at the end
     std::vector<std::string> cluster_nw_uris_;
 
     IOThread ha_ctx_thread_;
@@ -249,7 +250,7 @@ private:
     do_reconnect(const std::string& uri);
 
     std::string
-    get_rand_cluster_uri();
+    get_next_cluster_uri();
 
     void
     maybe_update_volume_location();

--- a/src/filesystem/test/ClusterRegistryTest.cpp
+++ b/src/filesystem/test/ClusterRegistryTest.cpp
@@ -15,19 +15,21 @@
 
 #include "RegistryTestSetup.h"
 
-#include <boost/lexical_cast.hpp>
-
-#include <youtils/InitializedParam.h>
-#include <gtest/gtest.h>
-#include <youtils/UUID.h>
-
 #include "../ClusterRegistry.h"
 #include "../Registry.h"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/optional/optional_io.hpp>
+
+#include <gtest/gtest.h>
+
+#include <youtils/InitializedParam.h>
+#include <youtils/UUID.h>
 
 namespace volumedriverfstest
 {
 
-namespace vfs = volumedriverfs;
+using namespace volumedriverfs;
 namespace yt = youtils;
 
 // TODO: factor out the code that is shared with {Cached,}VolumeRegistryTest
@@ -44,80 +46,80 @@ protected:
     SetUp()
     {
         RegistryTestSetup::SetUp();
-        cluster_registry_ = std::make_shared<vfs::ClusterRegistry>(cluster_id_,
-                                                                   registry_);
+        cluster_registry_ = std::make_shared<ClusterRegistry>(cluster_id_,
+                                                              registry_);
     }
 
-    vfs::ClusterNodeConfigs
+    ClusterNodeConfigs
     make_cluster_node_configs(unsigned count)
     {
-        vfs::ClusterNodeConfigs configs;
+        ClusterNodeConfigs configs;
         configs.reserve(count);
 
         for (unsigned i = 0; i < count; ++i)
         {
             const std::string n("node" + boost::lexical_cast<std::string>(i));
-            configs.push_back(vfs::ClusterNodeConfig(vfs::NodeId(n),
-                                                     n,
-                                                     vfs::MessagePort(i + 1),
-                                                     vfs::XmlRpcPort(i + 1),
-                                                     vfs::FailoverCachePort(i + 1),
-                                                     boost::none));
+            configs.push_back(ClusterNodeConfig(NodeId(n),
+                                                n,
+                                                MessagePort(i + 1),
+                                                XmlRpcPort(i + 1),
+                                                FailoverCachePort(i + 1),
+                                                boost::none));
         }
 
         return configs;
     }
 
-    const vfs::ClusterId cluster_id_;
-    std::shared_ptr<vfs::ClusterRegistry> cluster_registry_;
+    const ClusterId cluster_id_;
+    std::shared_ptr<ClusterRegistry> cluster_registry_;
 };
 
 TEST_F(ClusterRegistryTest, empty_registry)
 {
     EXPECT_THROW(cluster_registry_->get_node_configs(),
-                 vfs::ClusterNotRegisteredException);
+                 ClusterNotRegisteredException);
 
     EXPECT_THROW(cluster_registry_->get_node_status_map(),
-                 vfs::ClusterNotRegisteredException);
+                 ClusterNotRegisteredException);
 
-    EXPECT_THROW(cluster_registry_->get_node_status(vfs::NodeId("some-node")),
-                 vfs::ClusterNotRegisteredException);
+    EXPECT_THROW(cluster_registry_->get_node_status(NodeId("some-node")),
+                 ClusterNotRegisteredException);
 
-    EXPECT_THROW(cluster_registry_->set_node_state(vfs::NodeId("some-node"),
-                                                   vfs::ClusterNodeStatus::State::Offline),
-                 vfs::ClusterNotRegisteredException);
+    EXPECT_THROW(cluster_registry_->set_node_state(NodeId("some-node"),
+                                                   ClusterNodeStatus::State::Offline),
+                 ClusterNotRegisteredException);
 
     EXPECT_NO_THROW(cluster_registry_->erase_node_configs());
 }
 
 TEST_F(ClusterRegistryTest, empty_configs)
 {
-    vfs::ClusterNodeConfigs configs;
+    ClusterNodeConfigs configs;
     EXPECT_THROW(cluster_registry_->set_node_configs(configs),
-                 vfs::InvalidConfigurationException);
+                 InvalidConfigurationException);
 }
 
 TEST_F(ClusterRegistryTest, config_with_duplicates)
 {
-    vfs::ClusterNodeConfigs configs = make_cluster_node_configs(1);
+    ClusterNodeConfigs configs = make_cluster_node_configs(1);
     configs.push_back(configs[0]);
 
     EXPECT_THROW(cluster_registry_->set_node_configs(configs),
-                 vfs::InvalidConfigurationException);
+                 InvalidConfigurationException);
 }
 
 TEST_F(ClusterRegistryTest, happy_path)
 {
     const unsigned count = 3;
-    const vfs::ClusterNodeConfigs configs(make_cluster_node_configs(count));
+    const ClusterNodeConfigs configs(make_cluster_node_configs(count));
 
     cluster_registry_->set_node_configs(configs);
 
-    const vfs::ClusterNodeConfigs
+    const ClusterNodeConfigs
         retrieved_configs(cluster_registry_->get_node_configs());
     EXPECT_TRUE(configs == retrieved_configs);
 
-    vfs::ClusterRegistry::NodeStatusMap
+    ClusterRegistry::NodeStatusMap
         status_map(cluster_registry_->get_node_status_map());
 
     EXPECT_EQ(configs.size(), status_map.size());
@@ -127,7 +129,7 @@ TEST_F(ClusterRegistryTest, happy_path)
         auto it = status_map.find(cfg.vrouter_id);
         ASSERT_TRUE(it != status_map.end());
         EXPECT_TRUE(cfg == it->second.config);
-        EXPECT_EQ(vfs::ClusterNodeStatus::State::Online, it->second.state);
+        EXPECT_EQ(ClusterNodeStatus::State::Online, it->second.state);
 
         status_map.erase(it);
     }
@@ -137,12 +139,12 @@ TEST_F(ClusterRegistryTest, happy_path)
 
 TEST_F(ClusterRegistryTest, update_configs)
 {
-    const vfs::ClusterNodeConfigs configs(make_cluster_node_configs(3));
+    const ClusterNodeConfigs configs(make_cluster_node_configs(3));
 
     cluster_registry_->set_node_configs(configs);
     EXPECT_TRUE(configs == cluster_registry_->get_node_configs());
 
-    const vfs::ClusterNodeConfigs updated_configs(++configs.begin(), configs.end());
+    const ClusterNodeConfigs updated_configs(++configs.begin(), configs.end());
     ASSERT_EQ(configs.size() - 1, updated_configs.size());
     ASSERT_FALSE(updated_configs.empty());
 
@@ -155,54 +157,137 @@ TEST_F(ClusterRegistryTest, update_configs)
 
 TEST_F(ClusterRegistryTest, erasure)
 {
-    const vfs::ClusterNodeConfigs configs(make_cluster_node_configs(1));
+    const ClusterNodeConfigs configs(make_cluster_node_configs(1));
     cluster_registry_->set_node_configs(configs);
 
-    const vfs::ClusterNodeConfigs
+    const ClusterNodeConfigs
         retrieved_configs(cluster_registry_->get_node_configs());
     EXPECT_TRUE(configs == retrieved_configs);
 
     cluster_registry_->erase_node_configs();
 
     EXPECT_THROW(cluster_registry_->get_node_configs(),
-                 vfs::ClusterNotRegisteredException);
+                 ClusterNotRegisteredException);
 }
 
 TEST_F(ClusterRegistryTest, node_states)
 {
-    const vfs::ClusterNodeConfigs configs(make_cluster_node_configs(1));
+    const ClusterNodeConfigs configs(make_cluster_node_configs(1));
     cluster_registry_->set_node_configs(configs);
 
-    EXPECT_EQ(vfs::ClusterNodeStatus::State::Online,
+    EXPECT_EQ(ClusterNodeStatus::State::Online,
               cluster_registry_->get_node_status(configs[0].vrouter_id).state);
 
     cluster_registry_->set_node_state(configs[0].vrouter_id,
-                                      vfs::ClusterNodeStatus::State::Offline);
+                                      ClusterNodeStatus::State::Offline);
 
-    EXPECT_EQ(vfs::ClusterNodeStatus::State::Offline,
+    EXPECT_EQ(ClusterNodeStatus::State::Offline,
               cluster_registry_->get_node_status(configs[0].vrouter_id).state);
 
-    const vfs::ClusterRegistry::NodeStatusMap
+    const ClusterRegistry::NodeStatusMap
         status_map(cluster_registry_->get_node_status_map());
     ASSERT_EQ(1U, status_map.size());
-    EXPECT_EQ(vfs::ClusterNodeStatus::State::Offline,
+    EXPECT_EQ(ClusterNodeStatus::State::Offline,
               status_map.begin()->second.state);
 
-    EXPECT_THROW(cluster_registry_->get_node_status(vfs::NodeId("InexistentNode")),
-                 vfs::ClusterNodeNotRegisteredException);
+    EXPECT_THROW(cluster_registry_->get_node_status(NodeId("InexistentNode")),
+                 ClusterNodeNotRegisteredException);
 
-    EXPECT_THROW(cluster_registry_->set_node_state(vfs::NodeId("InexistentNode"),
-                                                   vfs::ClusterNodeStatus::State::Offline),
-                 vfs::ClusterNodeNotRegisteredException);
+    EXPECT_THROW(cluster_registry_->set_node_state(NodeId("InexistentNode"),
+                                                   ClusterNodeStatus::State::Offline),
+                 ClusterNodeNotRegisteredException);
 }
 
 TEST_F(ClusterRegistryTest, unique_key)
 {
-    const vfs::ClusterId cluster_id(yt::UUID().str());
-    vfs::ClusterRegistry cregistry(cluster_id,
-                                   registry_);
+    const ClusterId cluster_id(yt::UUID().str());
+    ClusterRegistry cregistry(cluster_id,
+                              registry_);
 
     EXPECT_NE(cregistry.make_key(), cluster_registry_->make_key());
+}
+
+TEST_F(ClusterRegistryTest, neighbours_default)
+{
+    const ClusterNodeConfigs configs(make_cluster_node_configs(7));
+    cluster_registry_->set_node_configs(configs);
+
+    for (const auto& cfg : configs)
+    {
+        EXPECT_FALSE(cfg.node_distance_map);
+
+        const ClusterRegistry::NeighbourMap
+            nmap(cluster_registry_->get_neighbour_map(cfg.vrouter_id));
+        EXPECT_EQ(configs.size(),
+                  nmap.size());
+        for (const auto& p : nmap)
+        {
+            EXPECT_EQ(0, p.first);
+        }
+    }
+}
+
+TEST_F(ClusterRegistryTest, invalid_neighbour_config)
+{
+    const ClusterNodeConfigs configs(make_cluster_node_configs(2));
+    cluster_registry_->set_node_configs(configs);
+
+    ClusterNodeConfigs invalid_configs = { configs[0] };
+    invalid_configs[0].node_distance_map = {{ configs[1].vrouter_id, 10 }};
+
+    EXPECT_THROW(cluster_registry_->set_node_configs(invalid_configs),
+                 InvalidConfigurationException);
+
+    EXPECT_EQ(configs,
+              cluster_registry_->get_node_configs());
+}
+
+TEST_F(ClusterRegistryTest, explicit_neighbours)
+{
+    ClusterNodeConfigs configs(make_cluster_node_configs(3));
+
+    for (auto& cfg : configs)
+    {
+        bool found = false;
+        ClusterNodeConfig::NodeDistanceMap map;
+
+        for (size_t i = 0; i < configs.size(); ++i)
+        {
+            if (found)
+            {
+                map[configs[i].vrouter_id] = i;
+            }
+            else if (configs[i].vrouter_id == cfg.vrouter_id)
+            {
+                found = true;
+            }
+        }
+
+        cfg.node_distance_map = std::move(map);
+    }
+
+    cluster_registry_->set_node_configs(configs);
+
+    for (size_t i = 0; i < configs.size(); ++i)
+    {
+        const ClusterRegistry::NeighbourMap
+            nmap(cluster_registry_->get_neighbour_map(configs[i].vrouter_id));
+        EXPECT_EQ(configs.size() - i - 1,
+                  nmap.size());
+
+        size_t j = i + 1;
+
+        for (const auto& p : nmap)
+        {
+            EXPECT_EQ(j,
+                      p.first);
+            ASSERT_GT(configs.size(),
+                      j);
+            EXPECT_EQ(configs[j],
+                      p.second);
+            ++j;
+        }
+    }
 }
 
 }

--- a/src/filesystem/test/NetworkServerTest.cpp
+++ b/src/filesystem/test/NetworkServerTest.cpp
@@ -47,11 +47,13 @@ namespace bc = boost::chrono;
 namespace bpt = boost::property_tree;
 namespace bpy = boost::python;
 namespace fs = boost::filesystem;
+namespace ip = initialized_params;
 namespace vd = volumedriver;
 namespace vfs = volumedriverfs;
 namespace yt = youtils;
 namespace libovs = libovsvolumedriver;
 
+using namespace std::literals::string_literals;
 using namespace volumedriverfs;
 
 namespace
@@ -626,6 +628,17 @@ public:
                   ovs_ctx_destroy(ctx));
         EXPECT_EQ(0,
                   ovs_ctx_attr_destroy(ctx_attr));
+    }
+
+    void
+    set_max_neighbour_distance(uint32_t dist)
+    {
+        bpt::ptree pt;
+        net_xio_server_->persist(pt, ReportDefault::F);
+        ip::PARAMETER_TYPE(network_max_neighbour_distance)(dist).persist(pt);
+        yt::UpdateReport urep;
+        net_xio_server_->update(pt, urep);
+        ASSERT_EQ(1, urep.update_size());
     }
 
     std::unique_ptr<NetworkXioInterface> net_xio_server_;
@@ -1766,6 +1779,107 @@ TEST_F(NetworkServerTest, ha_stress)
 
                     umount_remote(hard_kill);
                 });
+}
+
+TEST_F(NetworkServerTest, list_uris)
+{
+    std::shared_ptr<ClusterRegistry> creg(fs_->object_router().cluster_registry());
+    const ClusterNodeConfigs configs(creg->get_node_configs());
+    ASSERT_LT(0, configs.size());
+
+    CtxAttrPtr attrs(make_ctx_attr(1024,
+                                   false,
+                                   FileSystemTestSetup::local_edge_port()));
+    CtxPtr ctx(ovs_ctx_new(attrs.get()));
+    ASSERT_TRUE(ctx != nullptr);
+
+    auto& ctx_iface = dynamic_cast<ovs_context_t&>(*ctx);
+
+    std::vector<std::string> uris;
+    uris.reserve(configs.size());
+
+    EXPECT_EQ(0,
+              ctx_iface.list_cluster_node_uri(uris));
+    EXPECT_EQ(configs.size(),
+              uris.size());
+
+    for (const auto& u : uris)
+    {
+        bool found = false;
+        for (const auto& c : configs)
+        {
+            ASSERT_NE(boost::none,
+                      c.network_server_uri);
+            if (u == boost::lexical_cast<std::string>(*c.network_server_uri))
+            {
+                found = true;
+            }
+        }
+
+        EXPECT_TRUE(found);
+    }
+}
+
+TEST_F(NetworkServerTest, list_uris_filter)
+{
+    std::shared_ptr<ClusterRegistry> creg(fs_->object_router().cluster_registry());
+    ClusterNodeConfigs configs(creg->get_node_configs());
+
+    ASSERT_FALSE(configs.empty());
+    const size_t ghost_nodes = 3;
+    configs.reserve(configs.size() + ghost_nodes);
+
+    for (size_t i = 0; i < ghost_nodes; ++i)
+    {
+        ClusterNodeConfig ghost(configs[0]);
+        const std::string n("ghost-node-"s + boost::lexical_cast<std::string>(i));
+        ghost.vrouter_id = NodeId(n);
+        ghost.network_server_uri = yt::Uri("tcp://"s + n + ":1234"s);
+        configs.push_back(ghost);
+    }
+
+    for (auto& cfg : configs)
+    {
+        ClusterNodeConfig::NodeDistanceMap map;
+        uint32_t distance = 0;
+        for (const auto& c : configs)
+        {
+            const auto res(map.emplace(c.vrouter_id, distance++));
+            ASSERT_TRUE(res.second);
+        }
+        cfg.node_distance_map = std::move(map);
+    }
+
+    creg->set_node_configs(configs);
+
+    CtxAttrPtr attrs(make_ctx_attr(1024,
+                                   false,
+                                   FileSystemTestSetup::local_edge_port()));
+    CtxPtr ctx(ovs_ctx_new(attrs.get()));
+    ASSERT_TRUE(ctx != nullptr);
+
+    auto& ctx_iface = dynamic_cast<ovs_context_t&>(*ctx);
+
+    for (size_t i = 0; i <= configs.size(); ++i)
+    {
+        set_max_neighbour_distance(i);
+
+        std::vector<std::string> uris;
+        uris.reserve(i);
+
+        EXPECT_EQ(0,
+                  ctx_iface.list_cluster_node_uri(uris));
+        EXPECT_EQ(i,
+                  uris.size());
+
+        for (size_t j = 0; j < uris.size(); ++j)
+        {
+            ASSERT_NE(boost::none,
+                      configs[j].network_server_uri);
+            EXPECT_EQ(boost::lexical_cast<std::string>(*configs[j].network_server_uri),
+                      uris[j]);
+        }
+    }
 }
 
 } //namespace


### PR DESCRIPTION
Addresses https://github.com/openvstorage/volumedriver/issues/179 :
it allows to model the cluster topology based on a graph with weighted edges: each `ClusterNodeConfig` in the `ClusterRegistry` can be configured with a `NodeId -> uint32_t` mapping, modelling the distance of that node from the one the config belongs to. Absence of the map maintains the current behaviour (all nodes are assumed to be equidistant), absence of a node from the map is interpreted as no connection / infinite distance.
The list of cluster nodes returned to clients is now in order (closest nodes first) and filtered based on a newly introduced `network_interface/network_max_neighbour_distance` configurable:
* `uint32_t`
* dynamically reconfigurable
* default value: `std::numeric_limits<uint32_t>::max() == 2**32-1`
.
Nodes with a distance >= this value are not presented to clients.

The Python API is changed in the following way:
* `the ClusterNodeConfig` ctor grows a new `node_distance_map` parameter (optional dict from `NodeId` -> `uint32_t`), default: `None` -> maintain current behaviour
```
In [12]: cfg0 = src.ClusterNodeConfig("node_0", "127.0.0.1", 12322, 12324, 12326, node_distance_map = { 'node_0' : 0, 'node_1' : 10 })

In [13]: cfg1 = src.ClusterNodeConfig("node_1", "127.0.0.1", 12323, 12325, 12327, node_distance_map = { 'node_0' : 10, 'node_1' : 0 })

In [14]: creg.set_node_configs([cfg0, cfg1])

In [15]: cfgs = creg.get_node_configs()

In [16]: cfgs[0] == cfg0
Out[16]: True

In [17]: cfgs[1] == cfg1
Out[17]: True

In [18]: cfgs[0].node_distance_map
Out[18]: {'node_0': 0, 'node_1': 10}

In [19]: type(cfgs[0].node_distance_map)
Out[19]: dict

In [20]: cfgs[1].node_distance_map
Out[20]: {'node_0': 10, 'node_1': 0}
```

NB: I'm opening this PR early to allow feedback / integration (CC @khenderick). Still TBD: randomize order in which cluster nodes with equal distance are reported to clients.