### PR TITLE
Feature/refresh cluster uris fixes

### DIFF
--- a/src/filesystem/c-api/NetworkHAContext.cpp
+++ b/src/filesystem/c-api/NetworkHAContext.cpp
@@ -356,7 +356,8 @@ NetworkHAContext::try_to_reconnect()
 void
 NetworkHAContext::update_cluster_node_uri()
 {
-    int rl = list_cluster_node_uri(cluster_nw_uris_);
+    std::vector<std::string> uris;
+    int rl = list_cluster_node_uri(uris);
     if (rl < 0)
     {
         LIBLOGID_ERROR("failed to update cluster node URI list: "
@@ -364,7 +365,14 @@ NetworkHAContext::update_cluster_node_uri()
     }
     else
     {
-        std::reverse(cluster_nw_uris_.begin(), cluster_nw_uris_.end());
+        LIBLOGID_INFO("cluster node URIs for " << volume_name() << ":");
+        for (const auto& u : uris)
+        {
+            LIBLOGID_INFO("\t" << u);
+        }
+
+        std::reverse(uris.begin(), uris.end());
+        std::swap(uris, cluster_nw_uris_);
     }
 }
 

--- a/src/filesystem/c-api/NetworkHAContext.cpp
+++ b/src/filesystem/c-api/NetworkHAContext.cpp
@@ -286,6 +286,7 @@ NetworkHAContext::do_reconnect(const std::string& uri)
         {
             atomic_xchg_ctx(tmp_ctx);
             current_uri(uri);
+            update_cluster_node_uri();
         }
     }
     catch (std::exception& e)
@@ -329,7 +330,6 @@ NetworkHAContext::reconnect()
         }
         else
         {
-            update_cluster_node_uri();
             LIBLOGID_INFO("reconnection to URI '" << uri << "' succeeded");
             break;
         }


### PR DESCRIPTION
Addendum to #187 :
* refresh the cluster node URIs after the volume location has changed instead of having to wait until the topology refresh timer takes care of it
* fix refreshing the URI vector: replace it with a new version instead of appending to the old version