### PR TITLE
NetworkXioRequest: initialize all members in ctor

### DIFF
--- a/src/filesystem/NetworkXioRequest.h
+++ b/src/filesystem/NetworkXioRequest.h
@@ -34,18 +34,23 @@ struct NetworkXioRequest
 {
     explicit NetworkXioRequest(NetworkXioClientData *cdata,
                                xio_msg *xreq)
-    : data(nullptr)
-    , data_len(0)
-    , dtl_in_sync(true)
-    , retval(0)
-    , errval(0)
-    , xio_req(xreq)
-    , from_pool(true)
-    , cd(cdata)
+        : op(NetworkXioMsgOpcode::Noop)
+        , data(nullptr)
+        , data_len(0)
+        , size(0)
+        , offset(0)
+        , dtl_in_sync(true)
+        , retval(0)
+        , errval(0)
+        , opaque(0)
+        , xio_req(xreq)
+        , mem_block(nullptr)
+        , from_pool(true)
+        , cd(cdata)
     {
-        work.func = work.func_ctrl = work.dispatch_ctrl_request = nullptr;
-        work.is_ctrl = false;
+        memset(&xio_reply, 0, sizeof(xio_reply));
     }
+
     NetworkXioMsgOpcode op;
 
     void *data;

--- a/src/filesystem/NetworkXioServer.cpp
+++ b/src/filesystem/NetworkXioServer.cpp
@@ -555,8 +555,6 @@ NetworkXioServer::prepare_msg_reply(NetworkXioRequest *req)
 {
     xio_msg *xio_req = req->xio_req;
 
-    memset(&req->xio_reply, 0, sizeof(xio_msg));
-
     vmsg_sglist_set_nents(&req->xio_req->in, 0);
     xio_req->in.header.iov_base = NULL;
     xio_req->in.header.iov_len = 0;

--- a/src/filesystem/NetworkXioWork.h
+++ b/src/filesystem/NetworkXioWork.h
@@ -28,10 +28,10 @@ typedef std::function<void(Work*)> workitem_func_t;
 
 struct Work
 {
-    workitem_func_t func;
-    workitem_func_t func_ctrl;
-    workitem_func_t dispatch_ctrl_request;
-    bool is_ctrl;
+    workitem_func_t func = nullptr;
+    workitem_func_t func_ctrl = nullptr;
+    workitem_func_t dispatch_ctrl_request = nullptr;
+    bool is_ctrl = false;
 };
 
 } //namespace


### PR DESCRIPTION
valgrind points out use of uninitialized memory, e.g. in
`NetworkServerTest.create_rollback_list_remove_snapshot_remote` due to the
`size` member not being initialized:
```
==17791== Conditional jump or move depends on uninitialised value(s)
==17791==    at 0x78C7BD: void msgpack::v1::packer<msgpack::v1::sbuffer>::pack_imp_uint64<unsigned long>(unsigned long) (pack.hpp:1414)
==17791==    by 0x78B702: msgpack::v1::packer<msgpack::v1::sbuffer>::pack_unsigned_long(unsigned long) (pack.hpp:1045)
[...]
==17791==  Uninitialised value was created by a heap allocation
==17791==    at 0x4C2B0C5: operator new(unsigned long) (vg_replace_malloc.c:324)
==17791==    by 0x674014: volumedriverfs::NetworkXioServer::allocate_request(volumedriverfs::NetworkXioClientData*, xio_msg*) (NetworkXioServer.cpp:480)
==17791==    by 0x674799: volumedriverfs::NetworkXioServer::on_request(xio_session*, xio_msg*, int, void*) (NetworkXioServer.cpp:615)
==17791==    by 0x674B83: int volumedriverfs::static_on_request<volumedriverfs::NetworkXioClientData>(xio_session*, xio_msg*, int, void*) (NetworkXioServer.cpp:47)
==17791==    by 0x52EF25A: xio_on_req_recv (xio_session.c:673)
[...]
```
and
```
==17363== Syscall param sendmsg(msg.msg_iov[0]) points to uninitialised byte(s)
==17363==    at 0x568E9BD: ??? (syscall-template.S:81)
[...]
==17363==    by 0xA5290BB: xio_send_response (xio_connection.c:1248)
==17363==    by 0xA58EFF: volumedriverfs::NetworkXioServer::xio_send_reply(volumedriverfs::NetworkXioRequest*) (NetworkXioServer.cpp:600)
==17363==    by 0xA57602: volumedriverfs::NetworkXioServer::run(std::promise<void>) (NetworkXioServer.cpp:349)
==17363==    by 0xA62C0C: volumedriverfs::NetworkXioInterface::run(std::promise<void>) (NetworkXioInterface.cpp:38)
==17363==    by 0x7762DD: volumedriverfstest::NetworkServerTest::SetUp()::{lambda()#1}::operator()() const (NetworkServerTest.cpp:121)
==17363==  Address 0x47082465 is 9,317 bytes inside a block of size 3,833,856 alloc'd
==17363==    at 0x4C2CCEC: memalign (vg_replace_malloc.c:760)
==17363==    by 0x4C2CDB1: posix_memalign (vg_replace_malloc.c:913)
==17363==    by 0xA4F7F17: xio_memalign (xio_env.h:94)
==17363==    by 0xA4F7F17: umemalign (xio_mem.h:104)
==17363==    by 0xA4F7F17: xio_mem_alloc_no_dev (xio_rdma_verbs.c:121)
==17363==    by 0xA4F7F17: xio_mem_alloc (xio_rdma_verbs.c:529)
==17363==    by 0xA50B406: xio_tcp_primary_pool_slab_pre_create (xio_tcp_management.c:2163)
==17363==    by 0xA4F20B0: xio_tasks_pool_alloc_slab (xio_task.c:125)
==17363==    by 0xA4F2612: xio_tasks_pool_create (xio_task.c:232)
==17363==    by 0xA4F4360: xio_ctx_pool_create (xio_context.c:800)
==17363==    by 0xA520B5E: xio_nexus_primary_pool_create (xio_nexus.c:994)
==17363==    by 0xA523F5B: xio_nexus_on_recv_setup_req (xio_nexus.c:607)
==17363==    by 0xA523F5B: xio_nexus_on_new_message (xio_nexus.c:1485)
==17363==    by 0xA523F5B: xio_nexus_on_transport_event (xio_nexus.c:1652)
==17363==    by 0xA52049F: xio_observable_notify_all_observers (xio_observer.c:223)
==17363==    by 0xA512C65: xio_transport_notify_observer (xio_transport.h:303)
==17363==    by 0xA512C65: xio_tcp_on_setup_msg (xio_tcp_datapath.c:368)
==17363==    by 0xA512C65: xio_tcp_rx_ctl_handler (xio_tcp_datapath.c:3444)
==17363==    by 0xA5091F0: xio_tcp_consume_ctl_rx (xio_tcp_management.c:554)
==17363==  Uninitialised value was created by a heap allocation
==17363==    at 0x4C2B0C5: operator new(unsigned long) (vg_replace_malloc.c:324)
==17363==    by 0xA58922: volumedriverfs::NetworkXioServer::allocate_request(volumedriverfs::NetworkXioClientData*, xio_msg*) (NetworkXioServer.cpp:480)
==17363==    by 0xA590A7: volumedriverfs::NetworkXioServer::on_request(xio_session*, xio_msg*, int, void*) (NetworkXioServer.cpp:615)
==17363==    by 0xA59491: int volumedriverfs::static_on_request<volumedriverfs::NetworkXioClientData>(xio_session*, xio_msg*, int, void*) (NetworkXioServer.cpp:47)
==17363==    by 0xA51B25A: xio_on_req_recv (xio_session.c:673)
[...]
```