### PR TITLE
filesystem: split ClusterNodeConfig from ClusterNode

### DIFF
--- a/src/filesystem/ClusterNode.cpp
+++ b/src/filesystem/ClusterNode.cpp
@@ -14,15 +14,16 @@
 // but WITHOUT ANY WARRANTY of any kind.
 
 #include "ClusterNode.h"
-#include "ObjectRouter.h"
 
 namespace volumedriverfs
 {
 
 ClusterNode::ClusterNode(ObjectRouter& vrouter,
-                         const ClusterNodeConfig& cfg)
-    : config(cfg)
-    , vrouter_(vrouter)
+                         const NodeId& node_id,
+                         const youtils::Uri& uri)
+    : vrouter_(vrouter)
+    , node_id_(node_id)
+    , uri_(uri)
 {}
 
 }

--- a/src/filesystem/ClusterNode.h
+++ b/src/filesystem/ClusterNode.h
@@ -16,11 +16,10 @@
 #ifndef VFS_CLUSTER_NODE_H_
 #define VFS_CLUSTER_NODE_H_
 
-#include "ClusterNodeConfig.h"
-#include "Object.h"
 #include "NodeId.h"
 
 #include <youtils/Logging.h>
+#include <youtils/Uri.h>
 
 #include <volumedriver/DtlInSync.h>
 #include <volumedriver/Types.h>
@@ -28,13 +27,13 @@
 namespace volumedriverfs
 {
 
+class Object;
 class ObjectRouter;
 
 class ClusterNode
 {
 public:
-    virtual ~ClusterNode()
-    {}
+    virtual ~ClusterNode() = default;
 
     // XXX: we have to pass the size by a ptr instead of a reference since
     // our use of variadic templates in ObjectRouter leads to
@@ -67,16 +66,30 @@ public:
     virtual void
     unlink(const Object& obj) = 0;
 
-    const ClusterNodeConfig config;
+    const NodeId&
+    node_id() const
+    {
+        return node_id_;
+    }
+
+    const youtils::Uri&
+    uri() const
+    {
+        return uri_;
+    }
 
 protected:
-    ClusterNode(ObjectRouter& vrouter_,
-                const ClusterNodeConfig& cfg);
+    ClusterNode(ObjectRouter&_,
+                const NodeId&,
+                const youtils::Uri&);
 
     ObjectRouter& vrouter_;
 
 private:
     DECLARE_LOGGER("VFSClusterNode");
+
+    const NodeId node_id_;
+    const youtils::Uri uri_;
 };
 
 }

--- a/src/filesystem/ClusterNodeConfig.h
+++ b/src/filesystem/ClusterNodeConfig.h
@@ -122,6 +122,15 @@ struct ClusterNodeConfig
         return not (*this == other);
     }
 
+    youtils::Uri
+    message_uri() const
+    {
+        return youtils::Uri()
+            .scheme(std::string("tcp"))
+            .host(message_host)
+            .port(static_cast<const uint16_t>(message_port));
+    }
+
     BOOST_SERIALIZATION_SPLIT_MEMBER();
 
     template<class Archive>

--- a/src/filesystem/LocalNode.cpp
+++ b/src/filesystem/LocalNode.cpp
@@ -98,7 +98,8 @@ LocalNode::LocalNode(ObjectRouter& router,
                      const ClusterNodeConfig& cfg,
                      const bpt::ptree& pt)
     : ClusterNode(router,
-                  cfg)
+                  cfg.vrouter_id,
+                  cfg.message_uri())
     , vrouter_local_io_sleep_before_retry_usecs(pt)
     , vrouter_local_io_retries(pt)
     , vrouter_sco_multiplier(pt)

--- a/src/filesystem/LocalNode.h
+++ b/src/filesystem/LocalNode.h
@@ -23,6 +23,7 @@
 #include "FileSystemParameters.h"
 #include "ForceRestart.h"
 #include "NodeId.h"
+#include "Object.h"
 
 #include <boost/property_tree/ptree_fwd.hpp>
 

--- a/src/filesystem/ObjectRouter.h
+++ b/src/filesystem/ObjectRouter.h
@@ -407,7 +407,10 @@ private:
     mutable fungi::RWLock node_map_lock_;
 
     using NodeMap = std::unordered_map<NodeId, std::shared_ptr<ClusterNode>>;
+    using ConfigMap = std::unordered_map<NodeId, ClusterNodeConfig>;
+
     NodeMap node_map_;
+    ConfigMap config_map_;
 
     DECLARE_PARAMETER(vrouter_volume_read_threshold);
     DECLARE_PARAMETER(vrouter_volume_write_threshold);
@@ -457,10 +460,10 @@ private:
     mutable std::mutex redirects_lock_;
 
     void
-    update_node_map_(const boost::optional<const boost::property_tree::ptree&>& pt);
+    update_config_(const boost::optional<const boost::property_tree::ptree&>& pt);
 
-    NodeMap
-    build_node_map_(const boost::optional<const boost::property_tree::ptree&>& pt);
+    std::pair<NodeMap, ConfigMap>
+    build_config_(const boost::optional<const boost::property_tree::ptree&>& pt);
 
     ZWorkerPool::MessageParts
     redirected_work_(ZWorkerPool::MessageParts parts_in);

--- a/src/filesystem/RemoteNode.h
+++ b/src/filesystem/RemoteNode.h
@@ -44,8 +44,9 @@ class RemoteNode final
     friend class volumedriverfstest::FileSystemTestBase;
 
 public:
-    RemoteNode(ObjectRouter& vrouter,
-               const ClusterNodeConfig& cfg,
+    RemoteNode(ObjectRouter&,
+               const NodeId&,
+               const youtils::Uri&,
                std::shared_ptr<zmq::context_t> ztx);
 
     ~RemoteNode();
@@ -56,13 +57,13 @@ public:
     operator=(const RemoteNode&) = delete;
 
     virtual void
-    read(const Object& obj,
+    read(const Object&,
          uint8_t* buf,
          size_t* size,
          off_t off) override final;
 
     virtual void
-    write(const Object& obj,
+    write(const Object&,
           const uint8_t* buf,
           size_t* size,
           off_t off,
@@ -73,17 +74,17 @@ public:
          volumedriver::DtlInSync&) override final;
 
     virtual uint64_t
-    get_size(const Object& obj) override final;
+    get_size(const Object&) override final;
 
     virtual void
-    resize(const Object& obj,
+    resize(const Object&,
            uint64_t newsize) override final;
 
     virtual void
-    unlink(const Object& id) override final;
+    unlink(const Object&) override final;
 
     void
-    transfer(const Object& obj);
+    transfer(const Object&);
 
     void
     ping();

--- a/src/filesystem/ZWorkerPool.cpp
+++ b/src/filesystem/ZWorkerPool.cpp
@@ -26,6 +26,8 @@
 namespace volumedriverfs
 {
 
+namespace yt = youtils;
+
 namespace
 {
 
@@ -283,7 +285,7 @@ private:
 
 ZWorkerPool::ZWorkerPool(const std::string& name,
                          zmq::context_t& ztx,
-                         const std::string& pub_addr,
+                         const yt::Uri& pub_uri,
                          WorkerFun worker_fun,
                          uint16_t min_workers,
                          uint16_t max_workers)
@@ -292,7 +294,7 @@ ZWorkerPool::ZWorkerPool(const std::string& name,
     , worker_fun_(std::move(worker_fun))
     , ztx_(ztx)
     , name_(name)
-    , pub_addr_(pub_addr)
+    , pub_uri_(pub_uri)
 {
     validate_settings(min_, max_);
 
@@ -367,12 +369,12 @@ ZWorkerPool::route_()
         zmq::socket_t front_sock(ztx_, ZMQ_ROUTER);
         ZUtils::socket_no_linger(front_sock);
 
-        LOG_INFO("Binding public interface to " << pub_addr_);
-        front_sock.bind(pub_addr_.c_str());
-        LOG_TRACE("Listening for requests from clients on " << pub_addr_);
+        const auto pub_addr(boost::lexical_cast<std::string>(pub_uri_));
+        LOG_INFO("Binding public interface to " << pub_addr);
+        front_sock.bind(pub_addr.c_str());
+        LOG_TRACE("Listening for requests from clients on " << pub_addr);
 
         zmq::socket_t back_sock(ztx_, ZMQ_ROUTER);
-
         ZUtils::socket_no_linger(back_sock);
 
         LOG_INFO("Binding interface to workers to " << back_address_());

--- a/src/filesystem/ZWorkerPool.h
+++ b/src/filesystem/ZWorkerPool.h
@@ -17,8 +17,10 @@
 #define VFS_ZWORKER_POOL_H_
 
 #include <deque>
+#include <functional>
 #include <future>
 #include <map>
+#include <vector>
 
 #include <boost/thread.hpp>
 
@@ -26,6 +28,7 @@
 
 #include <youtils/BooleanEnum.h>
 #include <youtils/Logging.h>
+#include <youtils/Uri.h>
 
 // Design:
 // * ZWorkerPool binds to a public address
@@ -77,7 +80,7 @@ public:
 
     ZWorkerPool(const std::string& name,
                 zmq::context_t& ztx,
-                const std::string& pub_addr,
+                const youtils::Uri& pub_uri,
                 WorkerFun worker_fun,
                 uint16_t min_workers,
                 uint16_t max_workers = 128);
@@ -123,7 +126,7 @@ private:
     std::map<ZWorkerId, ZWorkerPtr> busy_ones_;
 
     const std::string name_;
-    const std::string pub_addr_;
+    const youtils::Uri pub_uri_;
 
     boost::thread router_thread_;
 

--- a/src/filesystem/test/ZWorkerPoolTest.cpp
+++ b/src/filesystem/test/ZWorkerPoolTest.cpp
@@ -32,6 +32,7 @@ namespace volumedriverfstest
 
 namespace vfs = volumedriverfs;
 namespace yt = youtils;
+using namespace std::literals::string_literals;
 
 class ZWorkerPoolTest
     : public testing::Test
@@ -39,7 +40,7 @@ class ZWorkerPoolTest
 protected:
     ZWorkerPoolTest()
         : ztx_(0)
-        , addr_("inproc://" + yt::UUID().str())
+        , uri_(yt::Uri().scheme("inproc"s).host(yt::UUID().str()))
     {}
 
     vfs::ZWorkerPool::MessageParts
@@ -67,7 +68,7 @@ protected:
     {
         zmq::socket_t zock(ztx_, ZMQ_REQ);
         vfs::ZUtils::socket_no_linger(zock);
-        zock.connect(addr_.c_str());
+        zock.connect(boost::lexical_cast<std::string>(uri_).c_str());
 
         return zock;
     }
@@ -75,14 +76,14 @@ protected:
     DECLARE_LOGGER("ZWorkerPoolTest");
 
     zmq::context_t ztx_;
-    const std::string addr_;
+    const youtils::Uri uri_;
 };
 
 TEST_F(ZWorkerPoolTest, construction)
 {
     EXPECT_THROW(vfs::ZWorkerPool("MinSizeZero",
                                   ztx_,
-                                  addr_,
+                                  uri_,
                                   [&](std::vector<zmq::message_t>&& parts)
                                   -> std::vector<zmq::message_t>
                                   {
@@ -94,7 +95,7 @@ TEST_F(ZWorkerPoolTest, construction)
 
     EXPECT_THROW(vfs::ZWorkerPool("MaxLessThanMin",
                                   ztx_,
-                                  addr_,
+                                  uri_,
                                   [&](std::vector<zmq::message_t>&& parts)
                                   -> std::vector<zmq::message_t>
                                   {
@@ -106,7 +107,7 @@ TEST_F(ZWorkerPoolTest, construction)
 
     vfs::ZWorkerPool zwpool("TestZWorkerPool1",
                             ztx_,
-                            addr_,
+                            uri_,
                             [&](std::vector<zmq::message_t>&& parts)
                             -> std::vector<zmq::message_t>
                             {
@@ -124,7 +125,7 @@ TEST_F(ZWorkerPoolTest, address_conflict)
 
     vfs::ZWorkerPool zwpool("TestZWorkerPool1",
                             ztx_,
-                            addr_,
+                            uri_,
                             [&](std::vector<zmq::message_t>&& parts)
                             -> std::vector<zmq::message_t>
                             {
@@ -142,7 +143,7 @@ TEST_F(ZWorkerPoolTest, address_conflict)
 
         EXPECT_THROW(vfs::ZWorkerPool("TestZWorkerPool2",
                                       ztx_,
-                                      addr_,
+                                      uri_,
                                       [&](std::vector<zmq::message_t>&& parts)
                                       -> std::vector<zmq::message_t>
                                       {
@@ -166,7 +167,7 @@ TEST_F(ZWorkerPoolTest, basics)
 
     vfs::ZWorkerPool zwpool("TestZWorkerPool",
                             ztx_,
-                            addr_,
+                            uri_,
                             std::move(fun),
                             min_workers,
                             max_workers);
@@ -227,7 +228,7 @@ TEST_F(ZWorkerPoolTest, maxed_out)
 
     vfs::ZWorkerPool zwpool("TestZWorkerPool",
                             ztx_,
-                            addr_,
+                            uri_,
                             std::move(fun),
                             min_workers,
                             max_workers);
@@ -297,7 +298,7 @@ TEST_F(ZWorkerPoolTest, exceptional_work)
 
     vfs::ZWorkerPool zwpool("TestZWorkerPool",
                             ztx_,
-                            addr_,
+                            uri_,
                             std::move(fun),
                             min_workers,
                             max_workers);
@@ -355,7 +356,7 @@ TEST_F(ZWorkerPoolTest, stress)
 
     vfs::ZWorkerPool zwpool("TestZWorkerPool",
                             ztx_,
-                            addr_,
+                            uri_,
                             std::move(fun),
                             min_workers,
                             max_workers);


### PR DESCRIPTION
With the introduction of the NodeDistanceMap a node's config is now
allowed to change, which conflicts with the code in ClusterNode /
ObjectRouter's node_map_ which actively prevents (network) config changes.

Because of this now only the immutable network config (`NodeId` and `Uri`) is
passed to `ClusterNode`.

Addendum to https://github.com/openvstorage/volumedriver/issues/179