### PR TITLE
Python API: add `req_timeout_secs` arg to API calls

### DIFF
--- a/src/filesystem-python-client/LocalClient.cpp
+++ b/src/filesystem-python-client/LocalClient.cpp
@@ -110,70 +110,96 @@ LocalClient::registerize()
           "@param client_timeout_secs: unsigned, optional client timeout (seconds)"))
         .def("destroy_filesystem",
              &vfs::LocalPythonClient::destroy,
+             (bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Request that the filesystem is destroyed.\n"
              "All data and metadata in Arakoon and the backend will be removed.\n"
-             "Local data (caches) will not be removed.\n")
+             "Local data (caches) will not be removed.\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("get_running_configuration",
              &vfs::LocalPythonClient::get_running_configuration,
-             (bpy::args("report_defaults") = false),
+             (bpy::args("report_defaults") = false,
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Return a string containing the current configuration (JSON format)\n"
              "@param: report_defaults: bool, report default values (default: False)\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: string, configuration data (JSON)\n")
         .def("update_configuration",
              &vfs::LocalPythonClient::update_configuration,
-             (bpy::args("config")),
+             (bpy::args("config"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Request volumedriverfs to update its configuration from the given file\n"
              "@param: config: string, path to the config file (JSON) / etcd URL\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: a list of successfully applied updates - throws in case of error\n")
         .def("get_general_logging_level",
              &vfs::LocalPythonClient::get_general_logging_level,
+             (bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Get the currently active global loglevel\n"
              "Note that logging needs to be enabled, otherwise this call will throw\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: Severity enum value\n")
         .def("set_general_logging_level",
              &vfs::LocalPythonClient::set_general_logging_level,
-             (bpy::args("severity")),
+             (bpy::args("severity"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Set the global loglevel\n"
              "Note that logging needs to be enabled, otherwise this call will throw\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@param severity: Severity enum value\n")
         .def("list_logging_filters",
              &vfs::LocalPythonClient::get_logging_filters,
+             (bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Get a list of all active logging filters\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: a list of (string, Severity) pairs\n")
         .def("add_logging_filter",
              &vfs::LocalPythonClient::add_logging_filter,
              (bpy::args("filter_match"),
-              bpy::args("severity")),
+              bpy::args("severity"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Add a logging filter\n"
              "@param filter_match: string\n"
-             "@param severity: Severity enum value\n")
+             "@param severity: Severity enum value\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("remove_logging_filter",
              &vfs::LocalPythonClient::remove_logging_filter,
-             (bpy::args("filter_match")),
+             (bpy::args("filter_match"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Remove a specific logging filter\n"
-             "@param filter_match: string")
+             "@param filter_match: string"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("remove_logging_filters",
              &vfs::LocalPythonClient::remove_logging_filters,
-             "Remove *all* logging filters\n")
+             (bpy::args("req_timeout_secs") = MaybeSeconds()),
+             "Remove *all* logging filters\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("malloc_info",
              &vfs::LocalPythonClient::malloc_info,
+             (bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Retrieve allocator info from the filesystem instance for debugging purposes\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: a string containing the allocator's malloc_info\n")
         .def("list_cluster_cache_handles",
              &vfs::LocalPythonClient::list_cluster_cache_handles,
+             (bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Get a list of ClusterCacheHandles\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: a list containing ClusterCacheHandles\n")
         .def("get_cluster_cache_handle_info",
              &vfs::LocalPythonClient::get_cluster_cache_handle_info,
-             (bpy::args("handle")),
+             (bpy::args("handle"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Obtain detailed information about a ClusterCacheHandle\n"
              "@param handle, ClusterCacheHandle\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: a ClusterCacheHandleInfo object\n")
         .def("remove_cluster_cache_handle",
              &vfs::LocalPythonClient::remove_cluster_cache_handle,
-             (bpy::args("handle")),
+             (bpy::args("handle"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Remove a ClusterCacheHandle (and its entries) from the ClusterCache\n"
              "@param handle, ClusterCacheHandle\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: a ClusterCacheHandleInfo object\n");
         ;
 }

--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -417,56 +417,70 @@ BOOST_PYTHON_MODULE(storagerouterclient)
              (bpy::args("target_path"),
               bpy::args("metadata_backend_config"),
               bpy::args("volume_size"),
-              bpy::args("node_id") = ""),
+              bpy::args("node_id") = "",
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Creates a new volume under the specified path.\n"
              "@param target_path: string, volume location\n"
              "@param metadata_backend_config: MetaDataBackendConfig\n"
              "@param volume_size: string (DimensionedValue), size of the volume\n"
              "@param node_id: string, on which storagerouter to create the clone, if empty (default) the clone is created on the node receiving this call\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      InsufficientResourcesException\n"
              "      FileExistsException\n")
         .def("truncate",
              &vfs::PythonClient::resize,
              (bpy::args("object_id"),
-              bpy::args("new_size")),
+              bpy::args("new_size"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Resize an object\n"
              "@param object_id, string, ObjectId\n"
-             "@param new_size, string (DimensionedValue), new size of the object")
+             "@param new_size, string (DimensionedValue), new size of the object"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("unlink",
              &vfs::PythonClient::unlink,
-             (bpy::args("target_path")),
+             (bpy::args("target_path"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Unlink directory entry.\n",
              "@param target_path: string, volume location\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      RuntimeError\n")
         .def("update_metadata_backend_config",
              &vfs::PythonClient::update_metadata_backend_config,
              (bpy::args("volume_id"),
-              bpy::args("metadata_backend_config")),
+              bpy::args("metadata_backend_config"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Update the volume's metadata backend config, possibly triggering a failover\n"
              "@param volume_id: string, volume identifier\n"
              "@param metadata_backend_config: MetaDataBackendConfig\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises\n"
              "      InvalidOperationException (config invalid / metadatastore doesn't support update)\n"
              "      PythonClientException\n")
         .def("list_volumes",
              &vfs::PythonClient::list_volumes,
-             (bpy::arg("node_id") = bpy::object()),
+             (bpy::arg("node_id") = bpy::object(),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "List the running volumes.\n"
              "@param node_id: optional string, list volumes on a particular node)\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: a list of volume IDs\n")
         .def("list_volumes_by_path",
              &vfs::PythonClient::list_volumes_by_path,
-             "List the running volumes by path.")
+             (bpy::args("req_timeout_secs") = MaybeSeconds()),
+             "List the running volumes by path.\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("rollback_volume",
              &vfs::PythonClient::rollback_volume,
              (bpy::args("volume_id"),
-              bpy::args("snapshot_id") = ""),
+              bpy::args("snapshot_id") = "",
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Rollback a volume to a snapshot.\n"
              "This only succeeds if the snapshot has arrived on the backend.\n"
              "@param volume_id: string, volume identifier\n"
              "@param snapshot_id: string, snapshot identifier (optional)\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      ObjectNotFoundException\n"
              "      SnapshotNotFoundException\n"
@@ -478,13 +492,15 @@ BOOST_PYTHON_MODULE(storagerouterclient)
               bpy::args("metadata_backend_config"),
               bpy::args("parent_volume_id"),
               bpy::args("parent_snapshot_id"),
-              bpy::args("node_id") = ""),
+              bpy::args("node_id") = "",
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Creates a clone from a snapshot of a volume.\n"
              "@param target_path: string, volume location\n"
              "@param metadata_backend_config: MetaDataBackendConfig\n"
              "@param parent_volume_id: string, parent volume identifier\n"
              "@param parent_snapshot_id: string, parent snapshot identifier\n"
              "@param node_id: string, on which storagerouter to create the clone, if empty (default) the clone is created on the node receiving this call\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      ObjectNotFoundException\n"
              "      InvalidOperationException (parent is not a template) \n"
@@ -495,12 +511,14 @@ BOOST_PYTHON_MODULE(storagerouterclient)
              (bpy::args("target_path"),
               bpy::args("metadata_backend_config"),
               bpy::args("parent_volume_id"),
-              bpy::args("node_id") = ""),
+              bpy::args("node_id") = "",
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Creates a clone from a template volume.\n"
              "@param target_path: string, volume location\n"
              "@param metadata_backend_config: MetaDataBackendConfig\n"
              "@param parent_volume_id: string, parent volume identifier\n"
              "@param node_id: string, on which storagerouter to create the clone, if empty (default) the clone is created on the node receiving this call\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      ObjectNotFoundException\n"
              "      InvalidOperationException (parent is not a template) \n"
@@ -508,64 +526,78 @@ BOOST_PYTHON_MODULE(storagerouterclient)
              "      FileExistsException\n")
         .def("list_snapshots",
              &vfs::PythonClient::list_snapshots,
-             (bpy::args("volume_id")),
+             (bpy::args("volume_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "List the snapshots of a volume.\n"
              "@param volume_id: string, volume identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      ObjectNotFoundException\n")
         .def("info_snapshot",
              &vfs::PythonClient::info_snapshot,
-             (bpy::args("volume_id",
-                        "snapshot_id")),
+             (bpy::args("volume_id"),
+              bpy::args("snapshot_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Show information about a particular snapshot of a volume.\n"
              "@param volume_id: string, volume_identifier\n"
              "@param snapshot_id: string, snapshot identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: SnapshotInfo object\n"
              "@raises \n"
              "      ObjectNotFoundException\n"
              "      SnapshotNotFoundException\n")
         .def("info_volume",
              &vfs::PythonClient::info_volume,
-             (bpy::args("volume_id")),
+             (bpy::args("volume_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Show information about a volume.\n"
              "@param volume_id: string, volume_identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: VolumeInfo object\n"
              "@raises \n"
              "      ObjectNotFoundException\n")
         .def("statistics_volume",
              &vfs::PythonClient::statistics_volume,
              (bpy::args("volume_id"),
-              bpy::args("reset") = false),
+              bpy::args("reset") = false,
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Show detailed performance statistics about a volume.\n"
              "@param volume_id: string, volume_identifier\n"
              "@param reset: boolean, whether to reset the performance_counters\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: Statistics object\n"
              "@raises \n"
              "      ObjectNotFoundException\n")
         .def("list_client_connections",
              &vfs::PythonClient::list_client_connections,
-             (bpy::args("node_id")),
+             (bpy::args("node_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "List client connections per node.\n"
              "@param node_id: string, Node ID\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: ClientInfo object\n")
         .def("statistics_node",
              &vfs::PythonClient::statistics_node,
              (bpy::args("node_id"),
-              bpy::args("reset") = false),
+              bpy::args("reset") = false,
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Show volume performance statistics aggregated per node.\n"
              "@param node_id: string, Node ID\n"
              "@param reset: boolean, whether to reset the performance_counters\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: Statistics object\n")
         .def("create_snapshot",
              &vfs::PythonClient::create_snapshot,
              (bpy::args("volume_id"),
               bpy::args("snapshot_id") = "",
-              bpy::args("metadata") = ""),
+              bpy::args("metadata") = "",
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Create a snapshot.\n"
              "This only succeeds if the previous snapshot (if any) has been written to the backend.\n"
              "@param volume_id: string, volume identifier\n"
              "@param snapshot_id: string, snapshot identifier (optional)\n"
              "@param metadata: string, up to 4096 bytes of metadata (optional)\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: string, snapshot identifier\n"
              "@raises \n"
              "      ObjectNotFoundException\n"
@@ -574,11 +606,13 @@ BOOST_PYTHON_MODULE(storagerouterclient)
              )
         .def("delete_snapshot",
              &vfs::PythonClient::delete_snapshot,
-             bpy::args("volume_id",
-                       "snapshot_id"),
+             (bpy::args("volume_id"),
+              bpy::args("snapshot_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Delete a snapshot.\n"
              "@param volume_id: string, volume identifier\n"
              "@param snapshot_id: string, snapshot identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      ObjectNotFoundException\n"
              "      SnapshotNotFoundException\n"
@@ -586,10 +620,12 @@ BOOST_PYTHON_MODULE(storagerouterclient)
              "      ObjectStillHasChildrenException\n")
         .def("set_volume_as_template",
              &vfs::PythonClient::set_volume_as_template,
-             (bpy::args("volume_id")),
+             (bpy::args("volume_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Convert a volume into a template.\n"
              "Templates are read-only.\n"
              "@param volume_id: string, volume identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      ObjectNotFoundException\n"
              "      InvalidOperationException (on clone)\n")
@@ -613,32 +649,41 @@ BOOST_PYTHON_MODULE(storagerouterclient)
         //      "      InvalidOperationException (on template)\n")
         .def("get_volume_id",
              &vfs::PythonClient::get_volume_id,
-             (bpy::args("path")),
+             (bpy::args("path"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Look up the volume ID behind path (if any)\n"
              "@param path: string, path to check\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: string (volume ID) or None\n")
         .def("get_object_id",
              &vfs::PythonClient::get_object_id,
-             (bpy::args("path")),
+             (bpy::args("path"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Look up the object ID behind path (if any)\n"
              "@param path: string, path to check\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: string (object ID) or None\n")
         .def("server_revision",
              &vfs::PythonClient::server_revision,
-             "Get server revision information")
+             (bpy::args("req_timeout_secs") = MaybeSeconds()),
+             "Get server revision information\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("client_revision",
              &vfs::PythonClient::client_revision,
              "Get client revision information")
         .def("volume_potential",
              &vfs::PythonClient::volume_potential,
-             (bpy::args("node_id")),
-              "Check how many more volumes this node is capable of running"
-              "@param node_id: string, target node"
-              "@returns: int, the number of volumes the node can host")
+             (bpy::args("node_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
+             "Check how many more volumes this node is capable of running\n"
+             "@param node_id: string, target node\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
+             "@returns: int, the number of volumes the node can host")
         .def("stop_object",
              &vfs::PythonClient::stop_object,
              (bpy::args("object_id"),
-              bpy::args("delete_local_data")),
+              bpy::args("delete_local_data"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Request that an object (volume or file) is stopped.\n"
              "\n"
              "NOTE: This does not remove the associated file - any I/O to it will lead to an error.\n"
@@ -647,170 +692,218 @@ BOOST_PYTHON_MODULE(storagerouterclient)
              "@returns: eventually\n")
         .def("migrate",
              &vfs::PythonClient::migrate,
-             (bpy::args("object_id",
-                        "node_id",
-                        "force_restart")),
+             (bpy::args("object_id"),
+              bpy::args("node_id"),
+              bpy::args("force_restart"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Migrate an object (volume or file) to another node.\n"
              "@param volume_id: string, object identifier\n"
              "@param node_id: string, node to move the object to\n"
-             "@param force_restart: boolean, whether to forcibly restart on the new node even if that means data loss (e.g. if the FOC is not available)\n")
+             "@param force_restart: boolean, whether to forcibly restart on the new node even if that means data loss (e.g. if the FOC is not available)\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("restart_object",
              &vfs::PythonClient::restart_object,
              (bpy::args("object_id"),
-              bpy::args("force_restart")),
+              bpy::args("force_restart"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Request that an object (volume or file) is restarted.\n"
              "@param: object_id: string, ID of the object to be restarted\n"
              "@param: force: boolean, whether to force the restart even at the expense of data loss\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: eventually\n")
         .def("mark_node_offline",
              &vfs::PythonClient::mark_node_offline,
-             (bpy::args("node_id")),
+             (bpy::args("node_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Mark a node as offline.\n"
              "This allows volumes currently registered on that node to failover to other nodes in the cluster.\n"
              "Use with caution: only mark a node as offline if it's really not running anymore.\n"
              "If the node being offlined is still running this can lead to split-brain behavior and dataloss.\n"
              "@param node_id: string, node to set mark as offline\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      InvalidOperationException (if executed on node to be offlined)")
         .def("mark_node_online",
              &vfs::PythonClient::mark_node_online,
-             (bpy::args("node_id")),
+             (bpy::args("node_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Mark a previously offlined node as online again.\n"
              "Only nodes marked as online can be started again.\n"
-             "@param node_id: string, node to set mark as offline\n")
+             "@param node_id: string, node to set mark as offline\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("info_cluster",
              &vfs::PythonClient::info_cluster,
+             (bpy::args("req_timeout_secs") = MaybeSeconds()),
              "get an overview of configured nodes in this cluster and their status (online/offline)\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: a dictionary")
         .def("set_sync_ignore",
              &vfs::PythonClient::set_sync_ignore,
              (bpy::args("volume_id"),
               bpy::args("number_of_syncs_to_ignore"),
-              bpy::args("maximum_time_to_ignore_syncs_in_seconds")),
+              bpy::args("maximum_time_to_ignore_syncs_in_seconds"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Set the sync ignore settings.\n"
              "@param volume_id: string, volume identifier\n"
              "@param number_of_syncs_to_ignore: uint64, the number of syncs to ignore\n"
-             "@param maximum_time_to_ignore_syncs_in_seconds: uint64, maximum time to ignore syncs in seconds\n")
+             "@param maximum_time_to_ignore_syncs_in_seconds: uint64, maximum time to ignore syncs in seconds\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("get_sync_ignore",
              &vfs::PythonClient::get_sync_ignore,
-             (bpy::args("volume_id")),
+             (bpy::args("volume_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "get the sync ignore settings.\n"
              "@param volume_id: string, volume identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns a dict with the relevant settings")
          .def("set_sco_multiplier",
               &vfs::PythonClient::set_sco_multiplier,
               (bpy::args("volume_id"),
-               bpy::args("sco_multiplier")),
+               bpy::args("sco_multiplier"),
+               bpy::args("req_timeout_secs") = MaybeSeconds()),
               "Set the number of clusters in a SCO.\n"
               "@param volume_id: string, volume identifier\n"
               "@param sco_multiplier: uint32, the number of clusters in a SCO\n"
+              "@param req_timeout_secs: optional timeout in seconds for this request\n"
               "@raises \n"
               "      InvalidOperationException (if SCO size would become invalid)")
          .def("get_sco_multiplier",
               &vfs::PythonClient::get_sco_multiplier,
-              (bpy::args("volume_id")),
+              (bpy::args("volume_id"),
+               bpy::args("req_timeout_secs") = MaybeSeconds()),
               "Get the number of clusters in a SCO.\n"
               "@param volume_id: string, volume identifier\n"
+              "@param req_timeout_secs: optional timeout in seconds for this request\n"
               "@returns a uint32")
          .def("set_tlog_multiplier",
               &vfs::PythonClient::set_tlog_multiplier,
               (bpy::args("volume_id"),
-               bpy::args("tlog_multiplier")),
+               bpy::args("tlog_multiplier"),
+               bpy::args("req_timeout_secs") = MaybeSeconds()),
               "Set the number of SCO's in a TLOG.\n"
               "@param volume_id: string, volume identifier\n"
               "@param tlog_multiplier: None (= volumedriver global value is used) or uint32, the number of SCO's in a TLOG\n"
+              "@param req_timeout_secs: optional timeout in seconds for this request\n"
               "@raises \n"
               "      InvalidOperationException (if TLOG size would become invalid)")
          .def("get_tlog_multiplier",
               &vfs::PythonClient::get_tlog_multiplier,
-              (bpy::args("volume_id")),
+              (bpy::args("volume_id"),
+               bpy::args("req_timeout_secs") = MaybeSeconds()),
               "Get the number of SCO's in a TLOG.\n"
               "@param volume_id: string, volume identifier\n"
+              "@param req_timeout_secs: optional timeout in seconds for this request\n"
               "@returns a (optional) uint32")
          .def("set_sco_cache_max_non_disposable_factor",
               &vfs::PythonClient::set_sco_cache_max_non_disposable_factor,
               (bpy::args("volume_id"),
-               bpy::args("max_non_disposable_factor")),
+               bpy::args("max_non_disposable_factor"),
+               bpy::args("req_timeout_secs") = MaybeSeconds()),
               "Set the factor of non-disposable data.\n"
               "@param volume_id: string, volume identifier\n"
-              "@param max_non_disposable_factor: None (= volumedriver global value is used) or float, the factor of non-disposable data\n")
+              "@param max_non_disposable_factor: None (= volumedriver global value is used) or float, the factor of non-disposable data\n"
+              "@param req_timeout_secs: optional timeout in seconds for this request\n")
          .def("get_sco_cache_max_non_disposable_factor",
               &vfs::PythonClient::get_sco_cache_max_non_disposable_factor,
-              (bpy::args("volume_id")),
+              (bpy::args("volume_id"),
+               bpy::args("req_timeout_secs") = MaybeSeconds()),
               "Get the factor of non-disposable data.\n"
               "@param volume_id: string, volume identifier\n"
+              "@param req_timeout_secs: optional timeout in seconds for this request\n"
               "@returns a (optional) float")
           .def("get_dtl_config_mode",
                &vfs::PythonClient::get_failover_cache_config_mode,
-               (bpy::args("volume_id")),
+               (bpy::args("volume_id"),
+                bpy::args("req_timeout_secs") = MaybeSeconds()),
                "get a node's DTL configuration mode\n"
                "@param volume_id: string, volume identifier\n"
+               "@param req_timeout_secs: optional timeout in seconds for this request\n"
                "@returns the DTL configuration mode of the node of the volume: Automatic | Manual\n")
           .def("get_dtl_config",
                &vfs::PythonClient::get_failover_cache_config,
-               (bpy::args("volume_id")),
+               (bpy::args("volume_id"),
+                bpy::args("req_timeout_secs") = MaybeSeconds()),
                "get a volume's DTL configuration\n"
                "@param volume_id: string, volume identifier\n"
+               "@param req_timeout_secs: optional timeout in seconds for this request\n"
                "@returns the DTL configuration of the volume\n")
           .def("set_manual_dtl_config",
                &vfs::PythonClient::set_manual_failover_cache_config,
                (bpy::args("node_id"),
-                bpy::args("config")),
+                bpy::args("config"),
+                bpy::args("req_timeout_secs") = MaybeSeconds()),
                "set a volume's DTL configuration\n"
                "@param volume_id: string, volume identifier\n"
-               "@param config: a DTLConfig, or 'None' for no DTL")
+               "@param config: a DTLConfig, or 'None' for no DTL"
+               "@param req_timeout_secs: optional timeout in seconds for this request\n")
           .def("set_automatic_dtl_config",
                &vfs::PythonClient::set_automatic_failover_cache_config,
-               (bpy::args("node_id")),
+               (bpy::args("node_id"),
+                bpy::args("req_timeout_secs") = MaybeSeconds()),
                "set a volume's DTL configuration to Automatic\n"
-               "@param volume_id: string, volume identifier\n")
+               "@param volume_id: string, volume identifier\n"
+               "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("get_readcache_behaviour",
              &vfs::PythonClient::get_cluster_cache_behaviour,
-             (bpy::args("volume_id")),
+             (bpy::args("volume_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "get a volume's readcache behaviour\n"
              "@param volume_id: string, volume identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns None (= volumedriver global value is used) or a ReadCacheBehaviour value\n")
         .def("set_readcache_behaviour",
              &vfs::PythonClient::set_cluster_cache_behaviour,
              (bpy::args("volume_id"),
-              bpy::args("behaviour")),
+              bpy::args("behaviour"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "set a volume's readcache behaviour\n"
              "@param volume_id: string, volume identifier\n"
              "@param behaviour: None (= volumedriver global value is used) or a ReadCacheBehaviour value\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: nothing, eventually\n")
         .def("get_readcache_mode",
              &vfs::PythonClient::get_cluster_cache_mode,
-             (bpy::args("volume_id")),
+             (bpy::args("volume_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "get a volume's readcache mode\n"
              "@param volume_id: string, volume identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns None (= volumedriver global value is used) or a ReadCacheMode value\n")
         .def("set_readcache_mode",
              &vfs::PythonClient::set_cluster_cache_mode,
              (bpy::args("volume_id"),
-              bpy::args("mode")),
+              bpy::args("mode"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "set a volume's readcache mode\n"
              "@param volume_id: string, volume identifier\n"
              "@param mode: None (= volumedriver global value is used) or a ReadCacheMode value\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: nothing, eventually\n")
         .def("get_readcache_limit",
              &vfs::PythonClient::get_cluster_cache_limit,
-             (bpy::args("volume_id")),
+             (bpy::args("volume_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "get a volume's readcache limit (when in LocationBased mode)\n"
              "@param volume_id: string, volume identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns None (= no limit) or the maximum number of clusters the volume can cache\n")
         .def("set_readcache_limit",
              &vfs::PythonClient::set_cluster_cache_limit,
              (bpy::args("volume_id"),
-              bpy::args("limit")),
+              bpy::args("limit"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "set a volume's readcache limit (when in LocationBased mode)\n"
              "@param volume_id: string, volume identifier\n"
              "@param limit: None (= no limit) or an integer specifying the maximum number of clusters\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: nothing, eventually\n")
         .def("update_cluster_node_configs",
              &vfs::PythonClient::update_cluster_node_configs,
-             (bpy::args("node_id") = ""),
+             (bpy::args("node_id") = "",
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Re-read the cluster configuration from the ClusterRegistry.\n"
-             "@param node_id: string, on which storagerouter to re-read the configuration\n")
+             "@param node_id: string, on which storagerouter to re-read the configuration\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n")
         .def("make_locked_client",
              &vfs::PythonClient::make_locked_client,
              (bpy::args("nspace"),
@@ -823,38 +916,48 @@ BOOST_PYTHON_MODULE(storagerouterclient)
              "@returns: LockedClient context manager\n")
         .def("schedule_backend_sync",
              &vfs::PythonClient::schedule_backend_sync,
-             (bpy::args("volume_id")),
+             (bpy::args("volume_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Schedule a backend sync of the given Volume\n"
              "@param volume_id: string, volume identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: string, name of the TLog covering the data written out\n")
         .def("is_volume_synced_up_to_tlog",
              &vfs::PythonClient::is_volume_synced_up_to_tlog,
              (bpy::args("volume_id"),
-              bpy::args("tlog_name")),
+              bpy::args("tlog_name"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Check whether a volume is synced to the backend up to a given TLog\n"
              "@param volume_id: string, volume identifier\n"
              "@param tlog_name: string, TLog name\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: boolean\n")
         .def("is_volume_synced_up_to_snapshot",
              &vfs::PythonClient::is_volume_synced_up_to_snapshot,
              (bpy::args("volume_id"),
-              bpy::args("snapshot_name")),
+              bpy::args("snapshot_name"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Check whether a volume is synced to the backend up to a given snapshot\n"
              "@param volume_id: string, volume identifier\n"
              "@param snapshot_name: string, snapshot name\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: boolean\n")
         .def("set_metadata_cache_capacity",
              &vfs::PythonClient::set_metadata_cache_capacity,
              (bpy::args("volume_id"),
-              bpy::args("num_pages")),
+              bpy::args("num_pages"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Set the volume's metadata cache capacity\n"
              "@param volume_id: string, volume identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@param num_pages, unsigned, number of metadata pages\n")
         .def("get_metadata_cache_capacity",
              &vfs::PythonClient::get_metadata_cache_capacity,
-             (bpy::args("volume_id")),
+             (bpy::args("volume_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
              "Get the volume's metadata cache capacity\n"
              "@param volume_id: string, volume identifier\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns num_pages, unsigned, number of metadata pages or None\n")
         .def("client_timeout_secs",
              &vfs::PythonClient::timeout,

--- a/src/filesystem/LocalPythonClient.h
+++ b/src/filesystem/LocalPythonClient.h
@@ -35,8 +35,10 @@ class LocalPythonClient final
     : public PythonClient
 {
 public:
+    using MaybeSeconds = PythonClient::MaybeSeconds;
+
     explicit LocalPythonClient(const std::string& config,
-                               const boost::optional<boost::chrono::seconds>& = boost::none);
+                               const MaybeSeconds& = boost::none);
 
     ~LocalPythonClient() = default;
 
@@ -49,41 +51,48 @@ public:
     destroy();
 
     std::string
-    get_running_configuration(bool report_defaults = false);
+    get_running_configuration(bool report_defaults = false,
+                              const MaybeSeconds& = boost::none);
 
     youtils::UpdateReport
-    update_configuration(const std::string& path);
+    update_configuration(const std::string& path,
+                         const MaybeSeconds& = boost::none);
 
     void
-    set_general_logging_level(youtils::Severity sev);
+    set_general_logging_level(youtils::Severity,
+                              const MaybeSeconds& = boost::none);
 
     youtils::Severity
-    get_general_logging_level();
+    get_general_logging_level(const MaybeSeconds& = boost::none);
 
     std::vector<youtils::Logger::filter_t>
-    get_logging_filters();
+    get_logging_filters(const MaybeSeconds& = boost::none);
 
     void
     add_logging_filter(const std::string& match,
-                       youtils::Severity sev);
+                       youtils::Severity sev,
+                       const MaybeSeconds& = boost::none);
 
     void
-    remove_logging_filter(const std::string& match);
+    remove_logging_filter(const std::string& match,
+                          const MaybeSeconds& = boost::none);
 
     void
-    remove_logging_filters();
+    remove_logging_filters(const MaybeSeconds& = boost::none);
 
     std::string
-    malloc_info();
+    malloc_info(const MaybeSeconds& = boost::none);
 
     std::vector<volumedriver::ClusterCacheHandle>
-    list_cluster_cache_handles();
+    list_cluster_cache_handles(const MaybeSeconds& = boost::none);
 
     XMLRPCClusterCacheHandleInfo
-    get_cluster_cache_handle_info(const volumedriver::ClusterCacheHandle);
+    get_cluster_cache_handle_info(const volumedriver::ClusterCacheHandle,
+                                  const MaybeSeconds& = boost::none);
 
     void
-    remove_cluster_cache_handle(const volumedriver::ClusterCacheHandle);
+    remove_cluster_cache_handle(const volumedriver::ClusterCacheHandle,
+                                const MaybeSeconds& = boost::none);
 
 private:
     DECLARE_LOGGER("LocalPythonClient");

--- a/src/filesystem/LockedPythonClient.cpp
+++ b/src/filesystem/LockedPythonClient.cpp
@@ -96,7 +96,8 @@ try
     req[XMLRPCKeys::vrouter_id] = vinfo.vrouter_id;
 
     const std::string s(call(PersistConfigurationToString::method_name(),
-                             req)[XMLRPCKeys::configuration]);
+                             req,
+                             boost::none)[XMLRPCKeys::configuration]);
     std::stringstream ss;
     ss << s;
 

--- a/src/filesystem/PythonClient.h
+++ b/src/filesystem/PythonClient.h
@@ -112,87 +112,106 @@ public:
     virtual ~PythonClient() = default;
 
     std::vector<std::string>
-    list_volumes(const boost::optional<std::string>& node_id = boost::none);
+    list_volumes(const boost::optional<std::string>& node_id = boost::none,
+                 const MaybeSeconds& = boost::none);
 
     std::vector<std::string>
-    list_volumes_by_path();
+    list_volumes_by_path(const MaybeSeconds& = boost::none);
 
     std::vector<std::string>
-    list_snapshots(const std::string& volume_id);
+    list_snapshots(const std::string& volume_id,
+                   const MaybeSeconds& = boost::none);
 
     XMLRPCSnapshotInfo
     info_snapshot(const std::string& volume_id,
-                  const std::string& snapshot_id);
+                  const std::string& snapshot_id,
+                  const MaybeSeconds& = boost::none);
 
     XMLRPCVolumeInfo
-    info_volume(const std::string& volume_id);
+    info_volume(const std::string& volume_id,
+                const MaybeSeconds& = boost::none);
 
     XMLRPCStatistics
     statistics_volume(const std::string& volume_id,
-                      bool reset = false);
+                      bool reset = false,
+                      const MaybeSeconds& = boost::none);
 
     XMLRPCStatistics
     statistics_node(const std::string& node_id,
-                    bool reset = false);
+                    bool reset = false,
+                    const MaybeSeconds& = boost::none);
 
     std::string
     create_snapshot(const std::string& volume_id,
                     const std::string& snapshot_id = "",
-                    const std::string& metadata = "");
+                    const std::string& metadata = "",
+                    const MaybeSeconds& = boost::none);
 
     std::string
     create_volume(const std::string& target_path,
                   boost::shared_ptr<volumedriver::MetaDataBackendConfig> mdb_config = nullptr,
                   const youtils::DimensionedValue& = youtils::DimensionedValue(),
-                  const std::string& node_id = "");
+                  const std::string& node_id = "",
+                  const MaybeSeconds& = boost::none);
 
     std::string
     create_clone(const std::string& target_path,
                  boost::shared_ptr<volumedriver::MetaDataBackendConfig> mdb_config,
                  const std::string& parent_volume_id,
                  const std::string& parent_snap_id,
-                 const std::string& node_id = "");
+                 const std::string& node_id = "",
+                 const MaybeSeconds& = boost::none);
 
     void
     resize(const std::string& object_id,
-           const youtils::DimensionedValue&);
+           const youtils::DimensionedValue&,
+           const MaybeSeconds& = boost::none);
 
     void
-    unlink(const std::string& target_path);
+    unlink(const std::string& target_path,
+           const MaybeSeconds& = boost::none);
 
     void
     update_metadata_backend_config(const std::string& volume_id,
-                                   boost::shared_ptr<volumedriver::MetaDataBackendConfig> mdb_config);
+                                   boost::shared_ptr<volumedriver::MetaDataBackendConfig> mdb_config,
+                                   const MaybeSeconds& = boost::none);
 
     std::string
     create_clone_from_template(const std::string& target_path,
                                boost::shared_ptr<volumedriver::MetaDataBackendConfig> mdb_config,
                                const std::string& parent_volume_id,
-                               const std::string& node_id = "");
+                               const std::string& node_id = "",
+                               const MaybeSeconds& = boost::none);
 
     void
     rollback_volume(const std::string& volume_id,
-                    const std::string& snapshot_id);
+                    const std::string& snapshot_id,
+                    const MaybeSeconds& = boost::none);
 
     void
     delete_snapshot(const std::string& volume_id,
-                    const std::string& snapshot_id);
+                    const std::string& snapshot_id,
+                    const MaybeSeconds& = boost::none);
 
     void
-    set_volume_as_template(const std::string& vname);
+    set_volume_as_template(const std::string& vname,
+                           const MaybeSeconds& = boost::none);
 
     std::vector<std::string>
-    get_scrubbing_work(const std::string& volume_id);
+    get_scrubbing_work(const std::string& volume_id,
+                       const MaybeSeconds& = boost::none);
 
     void
-    apply_scrubbing_result(const boost::python::tuple& tuple);
+    apply_scrubbing_result(const boost::python::tuple& tuple,
+                           const MaybeSeconds& = boost::none);
 
     void
     apply_scrubbing_result(const std::string& volume_id,
-                           const std::string& scrub_res);
+                           const std::string& scrub_res,
+                           const MaybeSeconds& = boost::none);
 
     std::string
-    server_revision();
+    server_revision(const MaybeSeconds& = boost::none);
 
     std::string
     client_revision();
@@ -200,102 +219,126 @@ public:
     void
     migrate(const std::string& object_id,
             const std::string& node_id,
-            bool force = false);
+            bool force = false,
+            const MaybeSeconds& = boost::none);
 
     void
-    mark_node_offline(const std::string& node_id);
+    mark_node_offline(const std::string& node_id,
+                      const MaybeSeconds& = boost::none);
 
     void
-    mark_node_online(const std::string& node_id);
+    mark_node_online(const std::string& node_id,
+                     const MaybeSeconds& = boost::none);
 
     uint64_t
-    volume_potential(const std::string& node_id);
+    volume_potential(const std::string& node_id,
+                     const MaybeSeconds& = boost::none);
 
     std::map<NodeId, ClusterNodeStatus::State>
-    info_cluster();
+    info_cluster(const MaybeSeconds& = boost::none);
 
     boost::optional<ObjectId>
-    get_object_id(const std::string& path);
+    get_object_id(const std::string& path,
+                  const MaybeSeconds& = boost::none);
 
     boost::optional<volumedriver::VolumeId>
-    get_volume_id(const std::string& path);
+    get_volume_id(const std::string& path,
+                  const MaybeSeconds& = boost::none);
 
     boost::python::dict
-    get_sync_ignore(const std::string& volume_id);
-
+    get_sync_ignore(const std::string& volume_id,
+                    const MaybeSeconds& = boost::none);
 
     void
     set_sync_ignore(const std::string& volume_id,
                     uint64_t number_of_syncs_to_ignore,
-                    uint64_t maximum_time_to_ignore_syncs_in_seconds);
+                    uint64_t maximum_time_to_ignore_syncs_in_seconds,
+                    const MaybeSeconds& = boost::none);
 
     uint32_t
-    get_sco_multiplier(const std::string& volume_id);
-
+    get_sco_multiplier(const std::string& volume_id,
+                       const MaybeSeconds& = boost::none);
 
     void
     set_sco_multiplier(const std::string& volume_id,
-                       uint32_t sco_multiplier);
+                       uint32_t sco_multiplier,
+                       const MaybeSeconds& = boost::none);
 
     boost::optional<uint32_t>
-    get_tlog_multiplier(const std::string& volume_id);
+    get_tlog_multiplier(const std::string& volume_id,
+                        const MaybeSeconds& = boost::none);
 
 
     void
     set_tlog_multiplier(const std::string& volume_id,
-                        const boost::optional<uint32_t>& tlog_multiplier);
+                        const boost::optional<uint32_t>& tlog_multiplier,
+                        const MaybeSeconds& = boost::none);
 
     boost::optional<float>
-    get_sco_cache_max_non_disposable_factor(const std::string& volume_id);
+    get_sco_cache_max_non_disposable_factor(const std::string& volume_id,
+                                            const MaybeSeconds& = boost::none);
 
 
     void
     set_sco_cache_max_non_disposable_factor(const std::string& volume_id,
-                                            const boost::optional<float>& max_non_disposable_factor);
+                                            const boost::optional<float>& max_non_disposable_factor,
+                                            const MaybeSeconds& = boost::none);
 
     FailOverCacheConfigMode
-    get_failover_cache_config_mode(const std::string& volume_id);
+    get_failover_cache_config_mode(const std::string& volume_id,
+                                   const MaybeSeconds& = boost::none);
 
     boost::optional<volumedriver::FailOverCacheConfig>
-    get_failover_cache_config(const std::string& volume_id);
+    get_failover_cache_config(const std::string& volume_id,
+                              const MaybeSeconds& = boost::none);
 
     void
     set_manual_failover_cache_config(const std::string& volume_id,
-                                     const boost::optional<volumedriver::FailOverCacheConfig>& foc_config);
+                                     const boost::optional<volumedriver::FailOverCacheConfig>& foc_config,
+                                     const MaybeSeconds& = boost::none);
 
     void
-    set_automatic_failover_cache_config(const std::string& volume_id);
+    set_automatic_failover_cache_config(const std::string& volume_id,
+                                        const MaybeSeconds& = boost::none);
 
     boost::optional<volumedriver::ClusterCacheBehaviour>
-    get_cluster_cache_behaviour(const std::string& volume_id);
+    get_cluster_cache_behaviour(const std::string& volume_id,
+                                const MaybeSeconds& = boost::none);
 
     void
     set_cluster_cache_behaviour(const std::string& volume_id,
-                                const boost::optional<volumedriver::ClusterCacheBehaviour>&);
+                                const boost::optional<volumedriver::ClusterCacheBehaviour>&,
+                                const MaybeSeconds& = boost::none);
 
     boost::optional<volumedriver::ClusterCacheMode>
-    get_cluster_cache_mode(const std::string& volume_id);
+    get_cluster_cache_mode(const std::string& volume_id,
+                           const MaybeSeconds& = boost::none);
 
     void
     set_cluster_cache_mode(const std::string& volume_id,
-                           const boost::optional<volumedriver::ClusterCacheMode>&);
+                           const boost::optional<volumedriver::ClusterCacheMode>&,
+                           const MaybeSeconds& = boost::none);
 
     void
     set_cluster_cache_limit(const std::string& volume_id,
                             const boost::optional<volumedriver::ClusterCount>&
-                            cluster_cache_limit);
+                            cluster_cache_limit,
+                            const MaybeSeconds& = boost::none);
 
     boost::optional<volumedriver::ClusterCount>
-    get_cluster_cache_limit(const std::string& volume_id);
+    get_cluster_cache_limit(const std::string& volume_id,
+                            const MaybeSeconds& = boost::none);
 
     void
-    update_cluster_node_configs(const std::string& node_id);
+    update_cluster_node_configs(const std::string& node_id,
+                                const MaybeSeconds& = boost::none);
 
     void
     vaai_copy(const std::string& src_path,
               const std::string& target_path,
               const uint64_t& timeout,
-              const CloneFileFlags& flags);
+              const CloneFileFlags& flags,
+              const MaybeSeconds& = boost::none);
 
     boost::shared_ptr<LockedPythonClient>
     make_locked_client(const std::string& volume_id,
@@ -303,33 +346,41 @@ public:
                        const unsigned grace_period_secs = 5);
 
     volumedriver::TLogName
-    schedule_backend_sync(const std::string& volume_id);
+    schedule_backend_sync(const std::string& volume_id,
+                          const MaybeSeconds& = boost::none);
 
     bool
     is_volume_synced_up_to_tlog(const std::string& volume_id,
-                                const volumedriver::TLogName&);
+                                const volumedriver::TLogName&,
+                                const MaybeSeconds& = boost::none);
 
     bool
     is_volume_synced_up_to_snapshot(const std::string& volume_id,
-                                    const std::string& snapshot_name);
+                                    const std::string& snapshot_name,
+                                    const MaybeSeconds& = boost::none);
 
     boost::optional<size_t>
-    get_metadata_cache_capacity(const std::string& volume_id);
+    get_metadata_cache_capacity(const std::string& volume_id,
+                                const MaybeSeconds& = boost::none);
 
     void
     set_metadata_cache_capacity(const std::string& volume_id,
-                                const boost::optional<size_t>& num_pages);
+                                const boost::optional<size_t>& num_pages,
+                                const MaybeSeconds& = boost::none);
 
     void
     stop_object(const std::string& id,
-                bool delete_local_data = true);
+                bool delete_local_data = true,
+                const MaybeSeconds& = boost::none);
 
     void
     restart_object(const std::string& id,
-                   bool force_restart);
+                   bool force_restart,
+                   const MaybeSeconds& = boost::none);
 
     std::vector<ClientInfo>
-    list_client_connections(const std::string& node_id);
+    list_client_connections(const std::string& node_id,
+                            const MaybeSeconds& = boost::none);
 
     const MaybeSeconds&
     timeout() const
@@ -345,14 +396,16 @@ protected:
 
     XmlRpc::XmlRpcValue
     call(const char* method,
-         XmlRpc::XmlRpcValue& req);
+         XmlRpc::XmlRpcValue& req,
+         const MaybeSeconds&);
 
     XmlRpc::XmlRpcValue
     redirected_xmlrpc(const std::string& addr,
                       const uint16_t port,
                       const char* method,
                       XmlRpc::XmlRpcValue& req,
-                      unsigned& redirect_count);
+                      unsigned& redirect_count,
+                      const MaybeSeconds&);
 
     std::string cluster_id_;
     std::mutex lock_;


### PR DESCRIPTION
This allows to specify a client timeout per method call on
`{Local,}StorageRouterClient` instances. A call that times out on the
client side is *not* aborted on the server side and will still run to
completion there.

Default value: `None` -> maintains current behaviour of using the
timeout configured on the instance itself.

Addresses https://github.com/openvstorage/volumedriver/issues/128

CC @khenderick: I'll point you to a build for framework integration.