### PR TITLE
Feature/use dtl connect timeout when fetching scos

### DIFF
--- a/src/volumedriver/FailOverCacheProxy.h
+++ b/src/volumedriver/FailOverCacheProxy.h
@@ -41,7 +41,7 @@ public:
                        const LBASize,
                        const ClusterMultiplier,
                        const boost::chrono::milliseconds request_timeout,
-                       const boost::optional<boost::chrono::milliseconds>& connect_timeout = boost::none);
+                       const boost::optional<boost::chrono::milliseconds>& connect_timeout);
 
     FailOverCacheProxy(const FailOverCacheProxy&) = delete;
 

--- a/src/volumedriver/LocalTLogScanner.cpp
+++ b/src/volumedriver/LocalTLogScanner.cpp
@@ -17,6 +17,7 @@
 #include "MetaDataStoreInterface.h"
 #include "SnapshotPersistor.h"
 #include "TLogReaderInterface.h"
+#include "VolManager.h"
 #include "VolumeConfig.h"
 
 #include <youtils/UUID.h>

--- a/src/volumedriver/Makefile.am
+++ b/src/volumedriver/Makefile.am
@@ -207,7 +207,8 @@ libvolumedriver_la_SOURCES = \
 	VolumeOverview.cpp \
 	VolumeThreadPool.cpp \
 	WriteOnlyVolume.cpp \
-	WriteSCOCache.cpp
+	WriteSCOCache.cpp \
+	ZCOVetcher.cpp
 
 pkgconfigdir = @pkgconfigdir@
 pkgconfig_DATA = volumedriver.pc

--- a/src/volumedriver/SCOFetcher.cpp
+++ b/src/volumedriver/SCOFetcher.cpp
@@ -31,6 +31,7 @@
 namespace volumedriver
 {
 
+namespace bc = boost::chrono;
 namespace fs = boost::filesystem;
 
 BackendSCOFetcher::BackendSCOFetcher(SCO sconame,
@@ -210,7 +211,8 @@ RawFailOverCacheSCOFetcher::RawFailOverCacheSCOFetcher(SCO sconame,
                                                        const Namespace& ns,
                                                        const LBASize lba_size,
                                                        const ClusterMultiplier cmult,
-                                                       const boost::chrono::seconds timeout)
+                                                       const bc::milliseconds req_timeout,
+                                                       const boost::optional<bc::milliseconds>& connect_timeout)
     : sconame_(sconame)
 {
     VERIFY(sconame.cloneID() == 0);
@@ -220,7 +222,8 @@ RawFailOverCacheSCOFetcher::RawFailOverCacheSCOFetcher(SCO sconame,
                                                    ns,
                                                    lba_size,
                                                    cmult,
-                                                   timeout);
+                                                   req_timeout,
+                                                   connect_timeout);
     }
     CATCH_STD_ALL_LOG_IGNORE("Failed to instantiate FailOverCacheProxy");
 }

--- a/src/volumedriver/SCOFetcher.h
+++ b/src/volumedriver/SCOFetcher.h
@@ -114,8 +114,8 @@ public:
                                const Namespace&,
                                const LBASize,
                                const ClusterMultiplier,
-                               const boost::chrono::seconds timeout =
-                               boost::chrono::seconds(30));
+                               const boost::chrono::milliseconds req_timeout,
+                               const boost::optional<boost::chrono::milliseconds>& connect_timeout);
 
     RawFailOverCacheSCOFetcher(const RawFailOverCacheSCOFetcher&) = delete;
 

--- a/src/volumedriver/VolManager.h
+++ b/src/volumedriver/VolManager.h
@@ -475,6 +475,26 @@ public:
     size_t
     effective_metadata_cache_capacity(const VolumeConfig&) const;
 
+    boost::optional<boost::chrono::milliseconds>
+    dtl_connect_timeout() const
+    {
+        const unsigned t = dtl_connect_timeout_ms.value();
+        if (t == 0)
+        {
+            return boost::none;
+        }
+        else
+        {
+            return boost::chrono::milliseconds(t);
+        }
+    }
+
+    boost::chrono::milliseconds
+    dtl_request_timeout() const
+    {
+        return boost::chrono::milliseconds(dtl_request_timeout_ms.value());
+    }
+
 private:
     DECLARE_LOGGER("VolManager");
 
@@ -531,9 +551,10 @@ public:
     DECLARE_PARAMETER(dtl_queue_depth);
     DECLARE_PARAMETER(dtl_write_trigger);
     DECLARE_PARAMETER(dtl_busy_loop_usecs);
+private:
     DECLARE_PARAMETER(dtl_request_timeout_ms);
     DECLARE_PARAMETER(dtl_connect_timeout_ms);
-
+public:
     DECLARE_PARAMETER(number_of_scos_in_tlog);
     DECLARE_PARAMETER(non_disposable_scos_factor);
     DECLARE_PARAMETER(default_cluster_size);

--- a/src/volumedriver/Volume.cpp
+++ b/src/volumedriver/Volume.cpp
@@ -430,31 +430,6 @@ Volume::localRestartDataStore_(SCONumber last_sco_num_in_backend,
     }
 }
 
-namespace
-{
-
-boost::optional<bc::milliseconds>
-dtl_connect_timeout()
-{
-    const unsigned t = VolManager::get()->dtl_connect_timeout_ms.value();
-    if (t == 0)
-    {
-        return boost::none;
-    }
-    else
-    {
-        return bc::milliseconds(t);
-    }
-}
-
-bc::milliseconds
-dtl_request_timeout()
-{
-    return bc::milliseconds(VolManager::get()->dtl_request_timeout_ms.value());
-}
-
-}
-
 void
 Volume::localRestart()
 {
@@ -491,8 +466,8 @@ Volume::localRestart()
                                                      TODO("AR: fix getLBASize instead")
                                                      LBASize(getLBASize()),
                                                      getClusterMultiplier(),
-                                                     dtl_request_timeout(),
-                                                     dtl_connect_timeout());
+                                                     VolManager::get()->dtl_request_timeout(),
+                                                     VolManager::get()->dtl_connect_timeout());
         }
         CATCH_STD_ALL_EWHAT({
                 LOG_VINFO("Could not start with previous failover settings: " << EWHAT);
@@ -613,8 +588,8 @@ Volume::backend_restart(const CloneTLogs& restartTLogs,
                                                      cfg.getNS(),
                                                      LBASize(getLBASize()),
                                                      getClusterMultiplier(),
-                                                     dtl_request_timeout(),
-                                                     dtl_connect_timeout());
+                                                     VolManager::get()->dtl_request_timeout(),
+                                                     VolManager::get()->dtl_connect_timeout());
         }
         CATCH_STD_ALL_EWHAT({
                 if (ignoreFOCIfUnreachable == IgnoreFOCIfUnreachable::T)
@@ -2325,8 +2300,8 @@ Volume::setFailOverCacheConfig_(const FailOverCacheConfig& config)
                                                              getNamespace(),
                                                              LBASize(getLBASize()),
                                                              getClusterMultiplier(),
-                                                             dtl_request_timeout(),
-                                                             dtl_connect_timeout()));
+                                                             VolManager::get()->dtl_request_timeout(),
+                                                             VolManager::get()->dtl_connect_timeout()));
     failover_->Clear();
 
     MaybeCheckSum cs = dataStore_->finalizeCurrentSCO();

--- a/src/volumedriver/ZCOVetcher.cpp
+++ b/src/volumedriver/ZCOVetcher.cpp
@@ -1,0 +1,172 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#include "FailOverCacheConfigWrapper.h"
+#include "SCOAccessData.h"
+#include "SCOCache.h"
+#include "VolManager.h"
+#include "VolumeConfig.h"
+#include "ZCOVetcher.h"
+
+namespace volumedriver
+{
+
+namespace bc = boost::chrono;
+namespace fs = boost::filesystem;
+
+ZCOVetcher::ZCOVetcher(const VolumeConfig& volume_config)
+    : ns_(volume_config.getNS())
+    , sco_cache_(*VolManager::get()->getSCOCache())
+    , scosize_(volume_config.getSCOSize())
+    , lba_size_(volume_config.lba_size_)
+    , cluster_mult_(volume_config.cluster_mult_)
+{
+    if(not sco_cache_.hasDisabledNamespace(ns_))
+    {
+        if(sco_cache_.hasNamespace(ns_))
+        {
+            LOG_WARN("Trying to restart from a namespace that is still active " << ns_);
+            throw fungi::IOException("ZCOVetcher: namespace still active");
+        }
+        else
+        {
+            LOG_WARN("Namespace " << ns_ <<
+                     " not found in scocache, local restart not possible");
+            throw fungi::IOException("ZCOVetcher: No such namespace");
+        }
+    }
+    BackendInterfacePtr bi(VolManager::get()->createBackendInterface(ns_));
+    SCOAccessDataPersistor sadp(bi->clone());
+    SCOAccessDataPtr sad(sadp.pull());
+
+    foc_config_wrapper_ =
+        VolumeFactory::get_config_from_backend<FailOverCacheConfigWrapper>(*bi);
+    const uint64_t max_non_disposable =
+        VolManager::get()->get_sco_cache_max_non_disposable_bytes(volume_config);
+    sco_cache_.enableNamespace(ns_,
+                               0,
+                               max_non_disposable,
+                               *sad);
+}
+
+ZCOVetcher::~ZCOVetcher()
+{
+    sco_cache_.disableNamespace(ns_);
+}
+
+CachedSCOPtr
+ZCOVetcher::getSCO(SCO sco)
+{
+    if (foc_config_wrapper_->config())
+    {
+        LOG_INFO("Trying to get SCO " << ns_ << "/" << sco <<
+                 " from the DTL or the backend");
+
+        RawFailOverCacheSCOFetcher
+            fetcher(sco,
+                    *foc_config_wrapper_->config(),
+                    ns_,
+                    lba_size_,
+                    cluster_mult_,
+                    VolManager::get()->dtl_request_timeout(),
+                    VolManager::get()->dtl_connect_timeout());
+
+        return sco_cache_.getSCO(ns_,
+                                 sco,
+                                 scosize_,
+                                 fetcher);
+    }
+    else
+    {
+        LOG_INFO("No FailOverCache, trying to get SCO " << sco <<
+                 " from the backend");
+
+        return sco_cache_.findSCO(ns_,
+                                  sco);
+    }
+}
+
+bool
+ZCOVetcher::checkSCO(ClusterLocation cluster_location,
+                     CheckSum::value_type cs,
+                     bool retry)
+{
+    try
+    {
+        CachedSCOPtr sco_ptr = getSCO(cluster_location.sco());
+        if (not sco_ptr)
+        {
+            return false;
+        }
+
+        fs::path sco_path = sco_ptr->path();
+        if(sco_path != incremental_checksum_.first)
+        {
+            incremental_checksum_.second.reset(new IncrementalChecksum(sco_path));
+            incremental_checksum_.first = sco_path;
+        }
+
+        try
+        {
+            const CheckSum& s =
+                incremental_checksum_.second->checksum((cluster_location.offset() + 1) *
+                                                      lba_size_ * cluster_mult_);
+
+            if(s.getValue() == cs)
+            {
+                return true;
+            }
+        }
+        catch(youtils::CheckSumFileNotLargeEnough& e)
+        {
+            LOG_ERROR("File Not Large Enough");
+        }
+
+        if(retry and
+           foc_config_wrapper_->config())
+        {
+            fs::path tmp = FileUtils::create_temp_file(sco_path);
+            FileUtils::safe_copy(sco_path, tmp);
+            fs::remove(sco_path);
+            incremental_checksum_.first.clear();
+            incremental_checksum_.second.reset(0);
+
+            sco_cache_.removeSCO(ns_,
+                                 cluster_location.sco(),
+                                 true,
+                                 false);
+            if(checkSCO(cluster_location,
+                        cs,
+                        false))
+            {
+                fs::remove(tmp);
+                return true;
+            }
+
+            fs::remove(sco_path);
+            fs::rename(tmp, sco_path);
+        }
+
+        return false;
+    }
+    CATCH_STD_ALL_EWHAT({
+            LOG_ERROR("Could not retrieve SCO for clusterlocation " <<
+                      cluster_location << ": " << EWHAT);
+            return false;
+        });
+
+}
+
+}

--- a/src/volumedriver/ZCOVetcher.h
+++ b/src/volumedriver/ZCOVetcher.h
@@ -16,163 +16,38 @@
 #ifndef ZCO_VETCHER_H
 #define ZCO_VETCHER_H
 
-#include "FailOverCacheConfigWrapper.h"
-#include "SCOAccessData.h"
-#include "SCOCache.h"
-#include "VolManager.h"
-#include "VolumeConfig.h"
+#include "Types.h"
 
 #include <memory>
 
-#include <backend/BackendInterface.h>
+#include <boost/filesystem/path.hpp>
+
+#include <youtils/IncrementalChecksum.h>
+#include <youtils/Logger.h>
+
+#include <backend/Namespace.h>
 
 namespace volumedriver
 {
 
+class SCOCache;
+class FailOverCacheConfigWrapper;
+class VolumeConfig;
+
 class ZCOVetcher
 {
 public:
-    ZCOVetcher(const VolumeConfig& volume_config)
-        : ns_(volume_config.getNS())
-        , sco_cache_(*VolManager::get()->getSCOCache())
-        , scosize_(volume_config.getSCOSize())
-        , lba_size_(volume_config.lba_size_)
-        , cluster_mult_(volume_config.cluster_mult_)
-    {
-        if(not sco_cache_.hasDisabledNamespace(ns_))
-        {
-            if(sco_cache_.hasNamespace(ns_))
-            {
-                LOG_WARN("Trying to restart from a namespace that is still active " << ns_);
-                throw fungi::IOException("ZCOVetcher: namespace still active");
-            }
-            else
-            {
-                LOG_WARN("Namespace " << ns_ <<
-                         " not found in scocache, local restart not possible");
-                throw fungi::IOException("ZCOVetcher: No such namespace");
-            }
-        }
-        BackendInterfacePtr bi(VolManager::get()->createBackendInterface(ns_));
-        SCOAccessDataPersistor sadp(bi->clone());
-        SCOAccessDataPtr sad(sadp.pull());
+    explicit ZCOVetcher(const VolumeConfig&);
 
-        foc_config_wrapper_ =
-            VolumeFactory::get_config_from_backend<FailOverCacheConfigWrapper>(*bi);
-        const uint64_t max_non_disposable =
-            VolManager::get()->get_sco_cache_max_non_disposable_bytes(volume_config);
-        sco_cache_.enableNamespace(ns_,
-                                   0,
-                                   max_non_disposable,
-                                   *sad);
-    }
-
-    ~ZCOVetcher()
-    {
-        sco_cache_.disableNamespace(ns_);
-    }
+    ~ZCOVetcher();
 
     CachedSCOPtr
-    getSCO(SCO sco)
-    {
-        if (foc_config_wrapper_->config())
-        {
-            LOG_INFO("Trying to get SCO " << ns_ << "/" << sco <<
-                     " from the DTL or the backend");
-
-            RawFailOverCacheSCOFetcher
-                fetcher(sco,
-                        *foc_config_wrapper_->config(),
-                        ns_,
-                        lba_size_,
-                        cluster_mult_,
-                        VolManager::get()->dtl_request_timeout(),
-                        VolManager::get()->dtl_connect_timeout());
-
-            return sco_cache_.getSCO(ns_,
-                                     sco,
-                                     scosize_,
-                                     fetcher);
-        }
-        else
-        {
-            LOG_INFO("No FailOverCache, trying to get SCO " << sco <<
-                     " from the backend");
-
-            return sco_cache_.findSCO(ns_,
-                                      sco);
-        }
-    }
+    getSCO(SCO sco);
 
     bool
-    checkSCO(ClusterLocation cluster_location,
-             CheckSum::value_type cs,
-             bool retry)
-    {
-        try
-        {
-            CachedSCOPtr sco_ptr = getSCO(cluster_location.sco());
-            if (not sco_ptr)
-            {
-                return false;
-            }
-
-            fs::path sco_path = sco_ptr->path();
-            if(sco_path != incremental_checksum.first)
-            {
-                incremental_checksum.second.reset(new IncrementalChecksum(sco_path));
-                incremental_checksum.first = sco_path;
-            }
-
-            try
-            {
-                const CheckSum& s =
-                    incremental_checksum.second->checksum((cluster_location.offset() + 1) *
-                                                          lba_size_ * cluster_mult_);
-
-                if(s.getValue() == cs)
-                {
-                    return true;
-                }
-            }
-            catch(youtils::CheckSumFileNotLargeEnough& e)
-            {
-                LOG_ERROR("File Not Large Enough");
-            }
-
-            if(retry and
-               foc_config_wrapper_->config())
-            {
-                fs::path tmp = FileUtils::create_temp_file(sco_path);
-                FileUtils::safe_copy(sco_path, tmp);
-                fs::remove(sco_path);
-                incremental_checksum.first.clear();
-                incremental_checksum.second.reset(0);
-
-                sco_cache_.removeSCO(ns_,
-                                     cluster_location.sco(),
-                                     true,
-                                     false);
-                if(checkSCO(cluster_location,
-                            cs,
-                            false))
-                {
-                    fs::remove(tmp);
-                    return true;
-                }
-
-                fs::remove(sco_path);
-                fs::rename(tmp, sco_path);
-            }
-
-            return false;
-        }
-        CATCH_STD_ALL_EWHAT({
-                LOG_ERROR("Could not retrieve SCO for clusterlocation " <<
-                          cluster_location << ": " << EWHAT);
-                return false;
-            });
-    }
+    checkSCO(ClusterLocation,
+             CheckSum::value_type,
+             bool retry);
 
 private:
     DECLARE_LOGGER("ZCOVetcher");
@@ -182,7 +57,7 @@ private:
     const uint64_t scosize_;
     const LBASize lba_size_;
     const ClusterMultiplier cluster_mult_;
-    std::pair<fs::path, std::unique_ptr<youtils::IncrementalChecksum> > incremental_checksum;
+    std::pair<boost::filesystem::path, std::unique_ptr<youtils::IncrementalChecksum> > incremental_checksum_;
     std::unique_ptr<FailOverCacheConfigWrapper> foc_config_wrapper_;
 };
 

--- a/src/volumedriver/ZCOVetcher.h
+++ b/src/volumedriver/ZCOVetcher.h
@@ -77,13 +77,17 @@ public:
     {
         if (foc_config_wrapper_->config())
         {
-            LOG_INFO("With FailOverCache, trying to get SCO " << sco <<
-                     " from the FOC or the backend");
-            RawFailOverCacheSCOFetcher fetcher(sco,
-                                               *foc_config_wrapper_->config(),
-                                               ns_,
-                                               lba_size_,
-                                               cluster_mult_);
+            LOG_INFO("Trying to get SCO " << ns_ << "/" << sco <<
+                     " from the DTL or the backend");
+
+            RawFailOverCacheSCOFetcher
+                fetcher(sco,
+                        *foc_config_wrapper_->config(),
+                        ns_,
+                        lba_size_,
+                        cluster_mult_,
+                        VolManager::get()->dtl_request_timeout(),
+                        VolManager::get()->dtl_connect_timeout());
 
             return sco_cache_.getSCO(ns_,
                                      sco,

--- a/src/volumedriver/failovercache/test/FailOverCacheClientPerfTest.cpp
+++ b/src/volumedriver/failovercache/test/FailOverCacheClientPerfTest.cpp
@@ -185,7 +185,8 @@ public:
                                                                        *ns_,
                                                                        lba_size,
                                                                        cmult,
-                                                                       failover_bridge->getDefaultRequestTimeout()));
+                                                                       failover_bridge->getDefaultRequestTimeout(),
+                                                                       boost::none));
         failover_bridge->Clear();
 
         ClusterFactory source(ClusterSize(lba_size * cmult),

--- a/src/volumedriver/failovercache/test/failovercache_tester.cpp
+++ b/src/volumedriver/failovercache/test/failovercache_tester.cpp
@@ -184,7 +184,8 @@ TEST_F(FailOverCacheTest, put_and_retrieve)
               FailOverCacheTestMain::ns(),
               LBASize(512),
               ClusterMultiplier(8),
-              boost::chrono::seconds(8));
+              boost::chrono::seconds(8),
+              boost::none);
 
     FailOverCacheEntryFactory factory(cluster_size,
                                       num_clusters_per_sco);
@@ -239,7 +240,8 @@ TEST_F(FailOverCacheTest, GetSCORange)
               FailOverCacheTestMain::ns(),
               LBASize(512),
               ClusterMultiplier(8),
-              boost::chrono::seconds(8));
+              boost::chrono::seconds(8),
+              boost::none);
 
     FailOverCacheEntryFactory factory(cluster_size,
                                       num_clusters_per_sco);
@@ -315,7 +317,8 @@ TEST_F(FailOverCacheTest, GetOneSCO)
               FailOverCacheTestMain::ns(),
               LBASize(512),
               ClusterMultiplier(8),
-              boost::chrono::seconds(8));
+              boost::chrono::seconds(8),
+              boost::none);
 
     FailOverCacheEntryFactory factory(cluster_size,
                                       num_clusters_per_sco);
@@ -390,7 +393,8 @@ TEST_F(FailOverCacheTest, DISABLED_DoubleRegister)
                FailOverCacheTestMain::ns(),
                LBASize(512),
                ClusterMultiplier(8),
-               boost::chrono::seconds(8));
+               boost::chrono::seconds(8),
+               boost::none);
 }
 
 struct FailOverCacheOneProcessor
@@ -454,7 +458,8 @@ public:
                  backend::Namespace(content),
                  LBASize(512),
                  ClusterMultiplier(8),
-                 boost::chrono::seconds(30))
+                 boost::chrono::seconds(30),
+                 boost::none)
         , factory_(cluster_size_,
                    num_clusters_per_sco_)
         , next_location_(1)
@@ -663,7 +668,8 @@ TEST_F(FailOverCacheTest, get_entries_xxl)
               FailOverCacheTestMain::ns(),
               lba_size,
               cmult,
-              boost::chrono::seconds(8));
+              boost::chrono::seconds(8),
+              boost::none);
 
     const SCOMultiplier smult(4096);
 

--- a/src/volumedriver/test/FailOverCacheTester.cpp
+++ b/src/volumedriver/test/FailOverCacheTester.cpp
@@ -755,7 +755,8 @@ TEST_P(FailOverCacheTester, clear)
                              wrns->ns(),
                              default_lba_size(),
                              default_cluster_multiplier(),
-                             boost::chrono::seconds(60));
+                             boost::chrono::seconds(60),
+                             boost::none);
 
     EXPECT_NO_THROW(proxy.clear());
 
@@ -815,7 +816,8 @@ TEST_P(FailOverCacheTester, non_standard_cluster_size)
                              wrns->ns(),
                              default_lba_size(),
                              cmult,
-                             boost::chrono::seconds(60));
+                             boost::chrono::seconds(60),
+                             boost::none);
 
     size_t count = 0;
 
@@ -873,7 +875,8 @@ TEST_P(FailOverCacheTester, wrong_cluster_size)
                                     wrns->ns(),
                                     LBASize(default_lba_size()),
                                     ClusterMultiplier(default_cluster_multiplier()),
-                                    bc::milliseconds(60000)),
+                                    bc::milliseconds(60000),
+                                    boost::none),
                  std::exception);
 }
 
@@ -926,7 +929,8 @@ TEST_P(FailOverCacheTester, DISABLED_a_whole_lotta_clients)
                                                                       wrns.back()->ns(),
                                                                       default_lba_size(),
                                                                       default_cluster_multiplier(),
-                                                                      bc::milliseconds(1000)));
+                                                                      bc::milliseconds(1000),
+                                                                      boost::none));
         }
 
         FAIL() << "eventually the DTL should've run out of FDs";

--- a/src/volumedriver/test/SimpleVolumeTest.cpp
+++ b/src/volumedriver/test/SimpleVolumeTest.cpp
@@ -2535,7 +2535,8 @@ TEST_P(SimpleVolumeTest, synchronous_foc)
                              wrns->ns(),
                              LBASize(v->getLBASize()),
                              v->getClusterMultiplier(),
-                             boost::chrono::seconds(10));
+                             boost::chrono::seconds(10),
+                             boost::none);
 
     size_t count = 0;
 


### PR DESCRIPTION
The `volume_manager/dtl_connect_request_timeout` was not used by SCOFetchers during local restart - cf. #213 