### PR TITLE
backend: blacklist / avoid conn pools on error

### DIFF
--- a/src/backend/BackendConnectionManager.h
+++ b/src/backend/BackendConnectionManager.h
@@ -27,6 +27,7 @@
 #include <youtils/ConfigurationReport.h>
 #include <youtils/EnableMakeShared.h>
 #include <youtils/IOException.h>
+#include <youtils/SourceOfUncertainty.h>
 #include <youtils/StrongTypedString.h>
 #include <youtils/VolumeDriverComponent.h>
 
@@ -169,7 +170,7 @@ public:
     }
 
     std::shared_ptr<ConnectionPool>
-    pool(const Namespace& nspace) const
+    pool(const Namespace& nspace)
     {
         return pool_(nspace);
     }
@@ -178,6 +179,7 @@ private:
     DECLARE_LOGGER("BackendConnectionManager");
 
     DECLARE_PARAMETER(backend_connection_pool_capacity);
+    DECLARE_PARAMETER(backend_connection_pool_blacklist_secs);
     DECLARE_PARAMETER(backend_interface_retries_on_error);
     DECLARE_PARAMETER(backend_interface_retry_interval_secs);
     DECLARE_PARAMETER(backend_interface_retry_backoff_multiplier);
@@ -185,12 +187,13 @@ private:
 
     std::vector<std::shared_ptr<ConnectionPool>> connection_pools_;
     std::unique_ptr<BackendConfig> config_;
+    youtils::SourceOfUncertainty rand_;
 
     explicit BackendConnectionManager(const boost::property_tree::ptree&,
                                       const RegisterComponent = RegisterComponent::T);
 
     const std::shared_ptr<ConnectionPool>&
-    pool_(const Namespace& nspace) const;
+    pool_(const Namespace& nspace);
 
     friend class toolcut::BackendToolCut;
     friend class toolcut::BackendConnectionToolCut;

--- a/src/backend/BackendParameters.cpp
+++ b/src/backend/BackendParameters.cpp
@@ -153,12 +153,19 @@ DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(backend_connection_pool_capacity,
                                       ShowDocumentation::T,
                                       64);
 
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(backend_connection_pool_blacklist_secs,
+                                      backend_connection_manager_name,
+                                      "backend_connection_pool_blacklist_secs",
+                                      "Duration (in seconds) in which to skip a connection pool after an error",
+                                      ShowDocumentation::T,
+                                      60U);
+
 DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(backend_interface_retries_on_error,
                                       backend_connection_manager_name,
                                       "backend_interface_retries_on_error",
                                       "How many times to retry a failed backend operation",
                                       ShowDocumentation::T,
-                                      1U);
+                                      2U);
 
 DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(backend_interface_retry_interval_secs,
                                       backend_connection_manager_name,

--- a/src/backend/BackendParameters.h
+++ b/src/backend/BackendParameters.h
@@ -64,6 +64,8 @@ const char backend_connection_manager_name[] = "backend_connection_manager";
 
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(backend_connection_pool_capacity,
                                                   uint32_t);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(backend_connection_pool_blacklist_secs,
+                                                  std::atomic<uint32_t>);
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(backend_interface_retries_on_error,
                                                   std::atomic<uint32_t>);
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(backend_interface_retry_interval_secs,

--- a/src/backend/ConnectionDeleter.h
+++ b/src/backend/ConnectionDeleter.h
@@ -46,6 +46,12 @@ public:
     void
     operator()(BackendConnectionInterface*);
 
+    std::shared_ptr<ConnectionPool>
+    pool() const
+    {
+        return pool_;
+    }
+
 private:
     std::shared_ptr<ConnectionPool> pool_;
 };

--- a/src/backend/ConnectionPool.h
+++ b/src/backend/ConnectionPool.h
@@ -22,6 +22,7 @@
 #include <iosfwd>
 #include <memory>
 
+#include <boost/chrono.hpp>
 #include <boost/intrusive/slist.hpp>
 
 #include <youtils/BooleanEnum.h>
@@ -36,6 +37,7 @@ namespace backend
 
 class BackendConfig;
 class BackendInterface;
+class BackendTestBase;
 class Namespace;
 
 using BackendConnectionInterfacePtr = std::unique_ptr<BackendConnectionInterface,
@@ -85,10 +87,16 @@ public:
     Counters
     counters() const;
 
+    using Clock = boost::chrono::steady_clock;
+
+    Clock::time_point
+    last_error() const;
+
 private:
     DECLARE_LOGGER("BackendConnectionPool");
 
     friend class youtils::EnableMakeShared<ConnectionPool>;
+    friend class BackendTestBase;
     friend class ConnectionDeleter;
 
     ConnectionPool(std::unique_ptr<BackendConfig>,
@@ -102,9 +110,13 @@ private:
     std::unique_ptr<BackendConfig> config_;
     size_t capacity_;
     Counters counters_;
+    Clock::time_point last_error_;
 
     std::unique_ptr<BackendConnectionInterface>
-    make_one_() const;
+    make_one_();
+
+    void
+    error_();
 
     static std::unique_ptr<BackendConnectionInterface>
     pop_(Connections&);

--- a/src/backend/test/BackendTestBase.h
+++ b/src/backend/test/BackendTestBase.h
@@ -87,6 +87,11 @@ protected:
                    const std::string& pattern,
                    const youtils::CheckSum* expected_chksum);
 
+    static void
+    inject_error_into_connection_pool(ConnectionPool& p)
+    {
+        p.error_();
+    }
 };
 
 }


### PR DESCRIPTION
This introduces a new configurable:
backend_connection_manager/backend_connection_pool_blacklist_secs,
dynamically reconfigurable, default value "60".

https://github.com/openvstorage/volumedriver/issues/215