### PR TITLE
Feature/python api list halted volumes

### DIFF
--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -154,6 +154,7 @@ DEFINE_EXCEPTION_TRANSLATOR(PreviousSnapshotNotOnBackendException);
 DEFINE_EXCEPTION_TRANSLATOR(ObjectStillHasChildrenException);
 DEFINE_EXCEPTION_TRANSLATOR(SnapshotNameAlreadyExistsException);
 DEFINE_EXCEPTION_TRANSLATOR(VolumeRestartInProgressException);
+DEFINE_EXCEPTION_TRANSLATOR(VolumeHaltedException);
 
 void
 reminder(vfs::XMLRPCErrorCode code) __attribute__((unused));
@@ -177,6 +178,7 @@ reminder(vfs::XMLRPCErrorCode code)
     case vfs::XMLRPCErrorCode::ObjectStillHasChildren:
     case vfs::XMLRPCErrorCode::SnapshotNameAlreadyExists:
     case vfs::XMLRPCErrorCode::VolumeRestartInProgress:
+    case vfs::XMLRPCErrorCode::VolumeHalted:
         break;
     }
 }
@@ -322,6 +324,7 @@ BOOST_PYTHON_MODULE(storagerouterclient)
     REGISTER_EXCEPTION_TRANSLATOR(ObjectStillHasChildrenException);
     REGISTER_EXCEPTION_TRANSLATOR(SnapshotNameAlreadyExistsException);
     REGISTER_EXCEPTION_TRANSLATOR(VolumeRestartInProgressException);
+    REGISTER_EXCEPTION_TRANSLATOR(VolumeHaltedException);
 
     REGISTER_STRINGY_CONVERTER(vfs::ObjectId);
     REGISTER_STRINGY_CONVERTER(vd::VolumeId);

--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -538,6 +538,14 @@ BOOST_PYTHON_MODULE(storagerouterclient)
              "@param node_id: optional string, list volumes on a particular node)\n"
              "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: a list of volume IDs\n")
+        .def("list_halted_volumes",
+             &vfs::PythonClient::list_halted_volumes,
+             (bpy::arg("node_id"),
+              bpy::args("req_timeout_secs") = MaybeSeconds()),
+             "List the halted volumes of a given node.\n"
+             "@param node_id: string, NodeId\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
+             "@returns: a list of volume IDs\n")
         .def("list_volumes_by_path",
              &vfs::PythonClient::list_volumes_by_path,
              (bpy::args("req_timeout_secs") = MaybeSeconds()),

--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -621,10 +621,12 @@ BOOST_PYTHON_MODULE(storagerouterclient)
         .def("info_volume",
              &vfs::PythonClient::info_volume,
              (bpy::args("volume_id"),
-              bpy::args("req_timeout_secs") = MaybeSeconds()),
+              bpy::args("req_timeout_secs") = MaybeSeconds(),
+              bpy::args("redirect_fenced") = true),
              "Show information about a volume.\n"
              "@param volume_id: string, volume_identifier\n"
              "@param req_timeout_secs: optional timeout in seconds for this request\n"
+             "@param redirect_fenced: bool, whether to look up the info from the real owner if a volume was found to be fenced\n"
              "@returns: VolumeInfo object\n"
              "@raises \n"
              "      ObjectNotFoundException\n")

--- a/src/filesystem/PythonClient.cpp
+++ b/src/filesystem/PythonClient.cpp
@@ -549,11 +549,15 @@ PythonClient::info_snapshot(const std::string& volume_id,
 
 XMLRPCVolumeInfo
 PythonClient::info_volume(const std::string& volume_id,
-                          const MaybeSeconds& timeout)
+                          const MaybeSeconds& timeout,
+                          const bool redirect_fenced)
 {
     XmlRpc::XmlRpcValue req;
 
     req[XMLRPCKeys::volume_id] = volume_id;
+    XMLRPCUtils::put(req,
+                     XMLRPCKeys::redirect_fenced,
+                     redirect_fenced);
     auto rsp(call(VolumeInfo::method_name(), req, timeout));
     return XMLRPCStructsBinary::deserialize_from_xmlrpc_value<XMLRPCVolumeInfo>(rsp);
 }

--- a/src/filesystem/PythonClient.cpp
+++ b/src/filesystem/PythonClient.cpp
@@ -164,6 +164,8 @@ PythonClient::redirected_xmlrpc(const std::string& addr,
             throw clienterrors::SnapshotNameAlreadyExistsException(errorstring.c_str());
         case XMLRPCErrorCode::VolumeRestartInProgress:
             throw clienterrors::VolumeRestartInProgressException(errorstring.c_str());
+        case XMLRPCErrorCode::VolumeHalted:
+            throw clienterrors::VolumeHaltedException(errorstring.c_str());
         default:
             {
                 //forward compatibility

--- a/src/filesystem/PythonClient.cpp
+++ b/src/filesystem/PythonClient.cpp
@@ -459,6 +459,18 @@ PythonClient::list_volumes(const boost::optional<std::string>& node_id,
 }
 
 std::vector<std::string>
+PythonClient::list_halted_volumes(const std::string& node_id,
+                                  const MaybeSeconds& timeout)
+{
+    XmlRpc::XmlRpcValue req;
+    req[XMLRPCKeys::vrouter_id] = node_id;
+
+    return extract_vec(call(VolumesListHalted::method_name(),
+                            req,
+                            timeout));
+}
+
+std::vector<std::string>
 PythonClient::list_volumes_by_path(const MaybeSeconds& timeout)
 {
     XmlRpc::XmlRpcValue req;

--- a/src/filesystem/PythonClient.h
+++ b/src/filesystem/PythonClient.h
@@ -130,6 +130,10 @@ public:
                  const MaybeSeconds& = boost::none);
 
     std::vector<std::string>
+    list_halted_volumes(const std::string& node_id,
+                        const MaybeSeconds& = boost::none);
+
+    std::vector<std::string>
     list_volumes_by_path(const MaybeSeconds& = boost::none);
 
     std::vector<std::string>

--- a/src/filesystem/PythonClient.h
+++ b/src/filesystem/PythonClient.h
@@ -71,6 +71,7 @@ MAKE_EXCEPTION(NodeNotReachableException, fungi::IOException);
 MAKE_EXCEPTION(ClusterNotReachableException, fungi::IOException);
 MAKE_EXCEPTION(ObjectStillHasChildrenException, fungi::IOException);
 MAKE_EXCEPTION(VolumeRestartInProgressException, fungi::IOException);
+MAKE_EXCEPTION(VolumeHaltedException, fungi::IOException);
 
 class MaxRedirectsExceededException
     : public PythonClientException

--- a/src/filesystem/PythonClient.h
+++ b/src/filesystem/PythonClient.h
@@ -143,7 +143,8 @@ public:
 
     XMLRPCVolumeInfo
     info_volume(const std::string& volume_id,
-                const MaybeSeconds& = boost::none);
+                const MaybeSeconds& = boost::none,
+                const bool redirect_fenced = true);
 
     XMLRPCStatistics
     statistics_volume(const std::string& volume_id,

--- a/src/filesystem/XMLRPC.cpp
+++ b/src/filesystem/XMLRPC.cpp
@@ -398,6 +398,14 @@ XMLRPCTimingWrapper<T>::execute(::XmlRpc::XmlRpcValue& params,
                     e.what());
         return;
     }
+    catch (vd::VolumeHaltedException& e)
+    {
+        LOG_XMLRPCERROR(T::_name << " " << boost::diagnostic_information(e));
+        T::setError(result,
+                    XMLRPCErrorCode::VolumeHalted,
+                    e.what());
+        return;
+    }
     catch(fungi::IOException& e)
 
     {

--- a/src/filesystem/XMLRPC.cpp
+++ b/src/filesystem/XMLRPC.cpp
@@ -582,6 +582,31 @@ VolumesList::execute_internal(::XmlRpc::XmlRpcValue& params,
 }
 
 void
+VolumesListHalted::execute_internal(::XmlRpc::XmlRpcValue& params,
+                                    ::XmlRpc::XmlRpcValue& result)
+{
+    result.clear();
+    result.setSize(0);
+
+    std::list<vd::VolumeId> l;
+
+    {
+        fungi::ScopedLock g(api::getManagementMutex());
+        api::getVolumeList(l);
+    }
+
+    int k = 0;
+    for (const auto& v : l)
+    {
+        fungi::ScopedLock g(api::getManagementMutex());
+        if (api::getHalted(v))
+        {
+            result[k++] = ::XmlRpc::XmlRpcValue(v.str());
+        }
+    }
+}
+
+void
 VolumesListByPath::execute_internal(::XmlRpc::XmlRpcValue& /* params */,
                                     ::XmlRpc::XmlRpcValue& result)
 {

--- a/src/filesystem/XMLRPC.h
+++ b/src/filesystem/XMLRPC.h
@@ -48,6 +48,7 @@ enum class XMLRPCErrorCode
     ObjectStillHasChildren = 7,
     SnapshotNameAlreadyExists = 8,
     VolumeRestartInProgress = 9,
+    VolumeHalted = 10,
 };
 
 class FileSystem;

--- a/src/filesystem/XMLRPC.h
+++ b/src/filesystem/XMLRPC.h
@@ -261,6 +261,11 @@ REGISTER_XMLRPC(XMLRPCCallTimingRedirect,
                 "volumesList",
                 "Get a list of volumes");
 
+REGISTER_XMLRPC(XMLRPCCallTimingRedirect,
+                VolumesListHalted,
+                "volumesListHalted",
+                "Get a list of halted volumes");
+
 REGISTER_XMLRPC(XMLRPCCallTiming,
                 VolumesListByPath,
                 "volumesListByPath",
@@ -719,10 +724,11 @@ REGISTER_XMLRPC(XMLRPCCallTimingRedirectLock,
                 "getMetaDataCacheCapacity",
                 "get capacity of the metadata cache (in pages)");
 
-typedef LOKI_TYPELIST_90(
+typedef LOKI_TYPELIST_91(
 // ================== EXPOSED IN XMLRPC CLIENT ===================
                          VolumeCreate,
                          VolumesList,
+                         VolumesListHalted,
                          VolumesListByPath,
                          VolumeInfo,
                          Unlink,

--- a/src/filesystem/XMLRPCKeys.cpp
+++ b/src/filesystem/XMLRPCKeys.cpp
@@ -102,6 +102,7 @@ DEFINE_XMLRPC_KEY(problem);
 DEFINE_XMLRPC_KEY(problems);
 DEFINE_XMLRPC_KEY(queue_count);
 DEFINE_XMLRPC_KEY(queue_size);
+DEFINE_XMLRPC_KEY(redirect_fenced);
 DEFINE_XMLRPC_KEY(restart_local);
 DEFINE_XMLRPC_KEY(reset);
 DEFINE_XMLRPC_KEY(sco_cache_hits);

--- a/src/filesystem/XMLRPCKeys.h
+++ b/src/filesystem/XMLRPCKeys.h
@@ -105,6 +105,7 @@ struct XMLRPCKeys
     static const std::string problems;
     static const std::string queue_count;
     static const std::string queue_size;
+    static const std::string redirect_fenced;
     static const std::string restart_local;
     static const std::string reset;
     static const std::string sco_cache_hits;

--- a/src/filesystem/test/PythonClientTest.cpp
+++ b/src/filesystem/test/PythonClientTest.cpp
@@ -2275,4 +2275,27 @@ TEST_F(PythonClientTest, fenced_volume_info)
     EXPECT_FALSE(remote_info.halted);
 }
 
+TEST_F(PythonClientTest, list_halted_volumes)
+{
+    const FrontendPath path(make_volume_name("/volume"));
+    const ObjectId oid(create_file(path));
+
+    EXPECT_TRUE(client_.list_halted_volumes(local_node_id()).empty());
+
+    {
+        LOCKVD();
+        vd::SharedVolumePtr
+            v(api::getVolumePointer(static_cast<const vd::VolumeId>(oid)));
+        v->halt();
+    }
+
+    const std::vector<std::string>
+        vols(client_.list_halted_volumes(local_node_id()));
+
+    ASSERT_FALSE(vols.empty());
+    EXPECT_EQ(1, vols.size());
+    EXPECT_EQ(oid,
+              ObjectId(vols[0]));
+}
+
 }

--- a/src/volumedriver/SnapshotManagement.cpp
+++ b/src/volumedriver/SnapshotManagement.cpp
@@ -303,6 +303,11 @@ SnapshotManagement::createSnapshot(const SnapshotName& name,
                   ": a snapshot with this name already exists");
         throw;
     }
+    catch (SnapshotPersistor::ExcessiveMetaDataException& e)
+    {
+        LOG_ERROR(VOLNAME() << ": " << e.what());
+        throw;
+    }
     CATCH_STD_ALL_VLOG_HALT_RETHROW("could not create snapshot")
 }
 

--- a/src/volumedriver/SnapshotPersistor.cpp
+++ b/src/volumedriver/SnapshotPersistor.cpp
@@ -333,7 +333,7 @@ SnapshotPersistor::snapshot(const SnapshotName& name,
                   " as the attached metadata exceeds the limit of " <<
                   max_snapshot_metadata_size <<
                   "bytes");
-        throw SnapshotPersistorException("Metadata size exceeds limit",
+        throw ExcessiveMetaDataException("Metadata size exceeds limit",
                                          name.c_str());
     }
 

--- a/src/volumedriver/SnapshotPersistor.h
+++ b/src/volumedriver/SnapshotPersistor.h
@@ -66,6 +66,7 @@ public:
 
     MAKE_EXCEPTION(SnapshotPersistorException, fungi::IOException);
     MAKE_EXCEPTION(SnapshotNameAlreadyExists, SnapshotPersistorException);
+    MAKE_EXCEPTION(ExcessiveMetaDataException, SnapshotPersistorException);
 
     explicit SnapshotPersistor(const MaybeParentConfig&);
 

--- a/src/volumedriver/Volume.cpp
+++ b/src/volumedriver/Volume.cpp
@@ -2982,8 +2982,8 @@ Volume::checkNotHalted_() const
 {
     if (halted_)
     {
-        throw fungi::IOException("Volume is halted due to previous errors",
-                                 getName().c_str());
+        throw VolumeHaltedException("Volume is halted due to previous errors",
+                                    getName().c_str());
     }
 }
 

--- a/src/volumedriver/VolumeException.h
+++ b/src/volumedriver/VolumeException.h
@@ -29,6 +29,7 @@ MAKE_EXCEPTION(VolumeIsTemplateException, VolumeException);
 MAKE_EXCEPTION(PreviousSnapshotNotOnBackendException, VolumeException);
 MAKE_EXCEPTION(SnapshotNotOnBackendException, VolumeException);
 MAKE_EXCEPTION(InvalidOperation, VolumeException);
+MAKE_EXCEPTION(VolumeHaltedException, VolumeException);
 
 }
 


### PR DESCRIPTION
This PR introduces
* a new API call `list_halted_volumes(node_id)` to list volume instances that are in `halted` state for a given node
* a distinct `VolumeHaltedException` exception (raised on volume mgmt calls *other than* `info_volume`)
* a redirection of mgmt calls to a healthy instance (if any) if a `halted` instance is encountered

CC @khenderick , @JeffreyDevloo 

Addresses #290 , #291 .
