### PR TITLE
Feature/unify unaligned request handling

### DIFF
--- a/src/filesystem/LocalNode.cpp
+++ b/src/filesystem/LocalNode.cpp
@@ -451,10 +451,15 @@ LocalNode::read_(vd::WeakVolumePtr vol,
     LOG_TRACE("reading, off " << (lba.t * lbasize) << " (LBA " << lba <<
               "), size " << rsize << ", unaligned " << unaligned);
 
+    using Reader = void (*)(vd::WeakVolumePtr,
+                            const vd::Lba,
+                            uint8_t*,
+                            uint64_t);
+
     if (unaligned)
     {
         std::vector<uint8_t> bounce_buf(rsize);
-        maybe_retry_<void>(&api::Read,
+        maybe_retry_<void>(static_cast<Reader>(&api::Read),
                            vol,
                            lba,
                            bounce_buf.data(),
@@ -465,7 +470,7 @@ LocalNode::read_(vd::WeakVolumePtr vol,
     else
     {
         ASSERT(to_read == rsize);
-        maybe_retry_<void>(&api::Read,
+        maybe_retry_<void>(static_cast<Reader>(&api::Read),
                            vol,
                            lba,
                            buf,
@@ -658,12 +663,17 @@ LocalNode::write_(vd::WeakVolumePtr vol,
                                      const uint8_t*,
                                      uint64_t);
 
+    using Reader = void (*)(vd::WeakVolumePtr,
+                            const vd::Lba,
+                            uint8_t*,
+                            uint64_t);
+
     // Const casts here are necessary
     if (unaligned)
     {
         std::vector<uint8_t> bounce_buf(wsize);
 
-        maybe_retry_<void>(&api::Read,
+        maybe_retry_<void>(static_cast<Reader>(&api::Read),
                            vol,
                            const_cast<vd::Lba&>(lba),
                            bounce_buf.data(),

--- a/src/filesystem/LocalNode.cpp
+++ b/src/filesystem/LocalNode.cpp
@@ -429,7 +429,7 @@ LocalNode::read_(vd::WeakVolumePtr vol,
     }
 
     const uint64_t lbasize = api::GetLbaSize(vol);
-    const uint64_t lba = off / lbasize;
+    const vd::Lba lba(off / lbasize);
     const uint64_t lbaoff = off % lbasize;
 
     uint64_t to_read = std::min(volume_size-off, *size);
@@ -448,7 +448,7 @@ LocalNode::read_(vd::WeakVolumePtr vol,
         rsize += lbasize - (rsize % lbasize);
     }
 
-    LOG_TRACE("reading, off " << (lba * lbasize) << " (LBA " << lba <<
+    LOG_TRACE("reading, off " << (lba.t * lbasize) << " (LBA " << lba <<
               "), size " << rsize << ", unaligned " << unaligned);
 
     if (unaligned)
@@ -634,7 +634,7 @@ LocalNode::write_(vd::WeakVolumePtr vol,
                   vd::DtlInSync& dtl_in_sync)
 {
     const uint64_t lbasize = api::GetLbaSize(vol);
-    const uint64_t lba = off / lbasize;
+    const vd::Lba lba(off / lbasize);
     const uint64_t lbaoff = off % lbasize;
     uint64_t wsize = size;
     bool unaligned = lbaoff != 0;
@@ -650,11 +650,11 @@ LocalNode::write_(vd::WeakVolumePtr vol,
         wsize += lbasize - wsize % lbasize;
     }
 
-    LOG_TRACE("writing, off " << (lba * lbasize) << " (LBA " << lba <<
+    LOG_TRACE("writing, off " << (lba.t * lbasize) << " (LBA " << lba <<
               "), size " << wsize << ", unaligned " << unaligned);
 
     using Writer = vd::DtlInSync (*)(vd::WeakVolumePtr,
-                                     uint64_t,
+                                     const vd::Lba,
                                      const uint8_t*,
                                      uint64_t);
 
@@ -665,7 +665,7 @@ LocalNode::write_(vd::WeakVolumePtr vol,
 
         maybe_retry_<void>(&api::Read,
                            vol,
-                           const_cast<uint64_t&>(lba),
+                           const_cast<vd::Lba&>(lba),
                            bounce_buf.data(),
                            bounce_buf.size());
 

--- a/src/volumedriver/Api.cpp
+++ b/src/volumedriver/Api.cpp
@@ -92,7 +92,7 @@ api::updateMetaDataBackendConfig(const vd::VolumeId& volume_id,
 
 vd::DtlInSync
 api::Write(WeakVolumePtr vol,
-           const uint64_t lba,
+           const vd::Lba lba,
            const uint8_t *buf,
            const uint64_t buflen)
 {
@@ -103,7 +103,7 @@ api::Write(WeakVolumePtr vol,
 
 void
 api::Read(WeakVolumePtr vol,
-          const uint64_t lba,
+          const vd::Lba lba,
           uint8_t *buf,
           const uint64_t buflen)
 {
@@ -114,7 +114,7 @@ api::Read(WeakVolumePtr vol,
 
 void
 api::Write(WriteOnlyVolume* vol,
-           uint64_t lba,
+           const vd::Lba lba,
            const uint8_t *buf,
            uint64_t buflen)
 {

--- a/src/volumedriver/Api.cpp
+++ b/src/volumedriver/Api.cpp
@@ -93,7 +93,7 @@ api::updateMetaDataBackendConfig(const vd::VolumeId& volume_id,
 vd::DtlInSync
 api::Write(WeakVolumePtr vol,
            const vd::Lba lba,
-           const uint8_t *buf,
+           const uint8_t* buf,
            const uint64_t buflen)
 {
     return SharedVolumePtr(vol)->write(lba,
@@ -101,10 +101,21 @@ api::Write(WeakVolumePtr vol,
                                        buflen);
 }
 
+vd::DtlInSync
+api::Write(WeakVolumePtr vol,
+           const uint64_t off,
+           const uint8_t* buf,
+           const uint64_t buflen)
+{
+    return SharedVolumePtr(vol)->write(off,
+                                       buf,
+                                       buflen);
+}
+
 void
 api::Read(WeakVolumePtr vol,
           const vd::Lba lba,
-          uint8_t *buf,
+          uint8_t* buf,
           const uint64_t buflen)
 {
     SharedVolumePtr(vol)->read(lba,
@@ -113,9 +124,20 @@ api::Read(WeakVolumePtr vol,
 }
 
 void
+api::Read(WeakVolumePtr vol,
+          const uint64_t off,
+          uint8_t* buf,
+          const uint64_t buflen)
+{
+    SharedVolumePtr(vol)->read(off,
+                               buf,
+                               buflen);
+}
+
+void
 api::Write(WriteOnlyVolume* vol,
            const vd::Lba lba,
-           const uint8_t *buf,
+           const uint8_t* buf,
            uint64_t buflen)
 {
     VERIFY(vol);

--- a/src/volumedriver/Api.h
+++ b/src/volumedriver/Api.h
@@ -25,6 +25,7 @@
 #include "DtlInSync.h"
 #include "Events.h"
 #include "FailOverCacheConfig.h"
+#include "Lba.h"
 #include "MetaDataStoreStats.h"
 #include "OwnerTag.h"
 #include "PerformanceCounters.h"
@@ -109,20 +110,20 @@ public:
     getVolumeId(volumedriver::WeakVolumePtr);
 
     static volumedriver::DtlInSync
-    Write(volumedriver::WeakVolumePtr vol,
-          uint64_t lba,
+    Write(volumedriver::WeakVolumePtr,
+          const volumedriver::Lba,
           const uint8_t *buf,
           uint64_t buflen);
 
     static void
-    Write(volumedriver::WriteOnlyVolume* vol,
-          const uint64_t lba,
+    Write(volumedriver::WriteOnlyVolume*,
+          const volumedriver::Lba,
           const uint8_t *buf,
           const uint64_t buflen);
 
     static void
     Read(volumedriver::WeakVolumePtr vol,
-         const uint64_t lba,
+         const volumedriver::Lba,
          uint8_t *buf,
          const uint64_t buflen);
 

--- a/src/volumedriver/Api.h
+++ b/src/volumedriver/Api.h
@@ -115,6 +115,12 @@ public:
           const uint8_t *buf,
           uint64_t buflen);
 
+    static volumedriver::DtlInSync
+    Write(volumedriver::WeakVolumePtr,
+          const uint64_t off,
+          const uint8_t* buf,
+          uint64_t buflen);
+
     static void
     Write(volumedriver::WriteOnlyVolume*,
           const volumedriver::Lba,
@@ -124,6 +130,12 @@ public:
     static void
     Read(volumedriver::WeakVolumePtr vol,
          const volumedriver::Lba,
+         uint8_t *buf,
+         const uint64_t buflen);
+
+    static void
+    Read(volumedriver::WeakVolumePtr vol,
+         const uint64_t off,
          uint8_t *buf,
          const uint64_t buflen);
 

--- a/src/volumedriver/Backup.cpp
+++ b/src/volumedriver/Backup.cpp
@@ -766,7 +766,7 @@ Backup::replay_tlogs_on_target()
                             try
                             {
                                 api::Write(target_volume_.get(),
-                                           cluster_address << 3,
+                                           Lba(cluster_address * source_volume_config->cluster_mult_),
                                            &buf[0] + (cluster_location.offset() * cluster_size),
                                            cluster_size);
                                 finished = true;

--- a/src/volumedriver/FailOverCacheProxy.cpp
+++ b/src/volumedriver/FailOverCacheProxy.cpp
@@ -235,7 +235,7 @@ FailOverCacheProxy::getObject_(SCOProcessorFun processor,
 
             int32_t size = (int32_t) bal;
             buf.store(stream_.getSink(), size);
-            processor(cli, lba, buf.data(), size);
+            processor(cli, Lba(lba), buf.data(), size);
             ret += size;
         }
     }

--- a/src/volumedriver/Lba.h
+++ b/src/volumedriver/Lba.h
@@ -13,20 +13,11 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
-#ifndef VD_SCOPROCESSORINTERFACE_H
-#define VD_SCOPROCESSORINTERFACE_H
+#ifndef VD_LBA_H_
+#define VD_LBA_H_
 
-#include "ClusterLocation.h"
-#include "Lba.h"
+#include <youtils/OurStrongTypedef.h>
 
-namespace volumedriver
-{
+OUR_STRONG_ARITHMETIC_TYPEDEF(uint64_t, Lba, volumedriver);
 
-using SCOProcessorFun = std::function<void(ClusterLocation,
-                                           Lba,
-                                           const uint8_t* /* buf */,
-                                           size_t /* bufsize */)>;
-
-} // namespace volumedriver
-
-#endif // VD_SCOPROCESSORINTERFACE_H
+#endif // !VD_LBA_H_

--- a/src/volumedriver/Volume.h
+++ b/src/volumedriver/Volume.h
@@ -21,6 +21,7 @@
 #include "DtlInSync.h"
 #include "FailOverCacheConfigWrapper.h"
 #include "FailOverCacheProxy.h"
+#include "Lba.h"
 #include "NSIDMap.h"
 #include "PerformanceCounters.h"
 #include "RestartContext.h"
@@ -126,7 +127,7 @@ public:
         return nsidmap_;
     }
 
-    uint64_t LBA2Addr(const uint64_t) const;
+    uint64_t LBA2Addr(const Lba) const;
     ClusterAddress addr2CA(const uint64_t) const;
     uint64_t getSize() const;
     uint64_t getLBASize() const;
@@ -154,19 +155,23 @@ public:
 
     /** @exception IOException */
     void
-    validateIOLength(uint64_t lba, uint64_t len) const;
+    validateIOLength(const Lba, uint64_t len) const;
 
     /** @exception IOException */
     void
-    validateIOAlignment(uint64_t lba, uint64_t len) const;
+    validateIOAlignment(const Lba, uint64_t len) const;
 
     /** @exception IOException, MetaDataStoreException */
     DtlInSync
-    write(uint64_t lba, const uint8_t *buf, uint64_t len);
+    write(const Lba,
+          const uint8_t *buf,
+          uint64_t len);
 
    /** @exception IOException, MetaDataStoreException */
     void
-    read(uint64_t lba, uint8_t *buf, uint64_t len);
+    read(const Lba,
+         uint8_t *buf,
+         uint64_t len);
 
     /** @exception IOException */
     DtlInSync

--- a/src/volumedriver/Volume.h
+++ b/src/volumedriver/Volume.h
@@ -127,7 +127,6 @@ public:
         return nsidmap_;
     }
 
-    uint64_t LBA2Addr(const Lba) const;
     ClusterAddress addr2CA(const uint64_t) const;
     uint64_t getSize() const;
     uint64_t getLBASize() const;
@@ -155,11 +154,11 @@ public:
 
     /** @exception IOException */
     void
-    validateIOLength(const Lba, uint64_t len) const;
+    validateIOLength(const uint64_t off, uint64_t len) const;
 
     /** @exception IOException */
     void
-    validateIOAlignment(const Lba, uint64_t len) const;
+    validateIOAlignment(const uint64_t off, uint64_t len) const;
 
     /** @exception IOException, MetaDataStoreException */
     DtlInSync
@@ -167,9 +166,19 @@ public:
           const uint8_t *buf,
           uint64_t len);
 
+    DtlInSync
+    write(const uint64_t off,
+          const uint8_t *buf,
+          uint64_t len);
+
    /** @exception IOException, MetaDataStoreException */
     void
     read(const Lba,
+         uint8_t *buf,
+         uint64_t len);
+
+    void
+    read(const uint64_t off,
          uint8_t *buf,
          uint64_t len);
 
@@ -532,7 +541,9 @@ private:
     // - write_lock_ is required to prevent write throttling from delaying reads,
     //   which together with the write_lock_ boils down to a single write / multiple reads
     //   for the moment.
-    // -> lock order: write_lock_ before rwlock
+    // - unaligned_lock_  is taken by unaligned writes to prevent RMW (the read part happens
+    //   outside the write_lock_) from interfering with writes to the same cluster
+    // -> lock order: unaligned_lock_ > write_lock_ > rwlock_
     typedef boost::mutex lock_type;
     mutable lock_type write_lock_;
 
@@ -547,6 +558,7 @@ private:
     // desirable (vs. boost's shared mutex which is fair towards writers but
     // does not perform as well in the absence of writers).
     mutable fungi::RWLock rwlock_;
+    mutable fungi::RWLock unaligned_lock_;
 
     bool halted_;
 
@@ -556,8 +568,6 @@ private:
     std::unique_ptr<FailOverCacheClientInterface> failover_;
 
     std::unique_ptr<MetaDataStoreInterface> metaDataStore_;
-
-    uint64_t caMask_; // to be used with LBAs!
 
     const ClusterSize clusterSize_;
 
@@ -748,6 +758,11 @@ private:
 
     PrefetchData&
     get_prefetch_data_();
+
+    DtlInSync
+    write_aligned_(const uint64_t off,
+                   const uint8_t *buf,
+                   uint64_t len);
 };
 
 using SharedVolumePtr = std::shared_ptr<Volume>;

--- a/src/volumedriver/WriteOnlyVolume.cpp
+++ b/src/volumedriver/WriteOnlyVolume.cpp
@@ -217,13 +217,13 @@ ClusterAddress WriteOnlyVolume::addr2CA(const uint64_t addr) const
     return addr / getClusterSize();
 }
 
-uint64_t WriteOnlyVolume::LBA2Addr(const uint64_t lba) const
+uint64_t WriteOnlyVolume::LBA2Addr(const Lba lba) const
 {
     return (lba & caMask_) * getLBASize();
 }
 
 void
-WriteOnlyVolume::validateIOLength(uint64_t lba, uint64_t len) const
+WriteOnlyVolume::validateIOLength(const Lba lba, uint64_t len) const
 {
     if (lba + len / getLBASize() > getLBACount())
     {
@@ -236,7 +236,7 @@ WriteOnlyVolume::validateIOLength(uint64_t lba, uint64_t len) const
 }
 
 void
-WriteOnlyVolume::validateIOAlignment(uint64_t lba, uint64_t len) const
+WriteOnlyVolume::validateIOAlignment(const Lba lba, uint64_t len) const
 {
     if (len % getClusterSize())
     {
@@ -264,7 +264,7 @@ WriteOnlyVolume::writeClusterMetaData_(ClusterAddress ca,
 
 
 void
-WriteOnlyVolume::write(uint64_t lba,
+WriteOnlyVolume::write(const Lba lba,
                        const uint8_t *buf,
                        uint64_t buflen)
 {

--- a/src/volumedriver/WriteOnlyVolume.h
+++ b/src/volumedriver/WriteOnlyVolume.h
@@ -17,6 +17,7 @@
 #define WRITEONLYVOLUME_H_
 
 #include "BackendTasks.h"
+#include "Lba.h"
 #include "NSIDMap.h"
 #include "PerformanceCounters.h"
 #include "TLogReader.h"
@@ -83,7 +84,7 @@ public:
         return nsidmap_;
     }
 
-    uint64_t LBA2Addr(const uint64_t) const;
+    uint64_t LBA2Addr(const Lba) const;
     ClusterAddress addr2CA(const uint64_t) const;
     uint64_t getSize() const;
     uint64_t getLBASize() const;
@@ -118,15 +119,17 @@ public:
 
     /** @exception IOException */
     void
-    validateIOLength(uint64_t lba, uint64_t len) const;
+    validateIOLength(const Lba, uint64_t len) const;
 
     /** @exception IOException */
     void
-    validateIOAlignment(uint64_t lba, uint64_t len) const;
+    validateIOAlignment(const Lba, uint64_t len) const;
 
     /** @exception IOException, MetaDataStoreException */
     void
-    write(uint64_t lba, const uint8_t *buf, uint64_t len);
+    write(const Lba,
+          const uint8_t *buf,
+          uint64_t len);
 
     /** @exception IOException */
     void

--- a/src/volumedriver/test/ApiTest.cpp
+++ b/src/volumedriver/test/ApiTest.cpp
@@ -81,7 +81,7 @@ public:
         {
             const std::vector<byte> wbuf(4096, pattern);
             LOCK_MGMT();
-            api::Write(vol, 0, &wbuf[0], wbuf.size());
+            api::Write(vol, Lba(0), &wbuf[0], wbuf.size());
         }
 
         {
@@ -101,7 +101,7 @@ public:
 
         {
             LOCK_MGMT();
-            api::Read(vol, 0, &rbuf[0], rbuf.size());
+            api::Read(vol, Lba(0), &rbuf[0], rbuf.size());
         }
 
         EXPECT_TRUE(ref == rbuf);
@@ -340,7 +340,7 @@ TEST_P(ApiTest, QueueCount)
         for(int i = 0; i < 5; i++)
         {
             writeToVolume(*v,
-                          0,
+                          Lba(0),
                           4096,
                           "xyz");
         }

--- a/src/volumedriver/test/BackendNamesFilterVolumeTest.cpp
+++ b/src/volumedriver/test/BackendNamesFilterVolumeTest.cpp
@@ -47,7 +47,7 @@ TEST_P(BackendNamespaceFilterVolumeTest, ditto)
     v->setFailOverCacheConfig(foc_ctx->config(FailOverCacheMode::Asynchronous));
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getClusterSize(),
                   "Not of any importance");
 

--- a/src/volumedriver/test/BigReadWriteTest.cpp
+++ b/src/volumedriver/test/BigReadWriteTest.cpp
@@ -41,7 +41,7 @@ TEST_P(BigReadWriteTest, bigReadsOnEmpty)
 
     for(size_t i = 0; i < scoMul; ++i)
     {
-        checkVolume(*v,0, csz*scoMul, pattern);
+        checkVolume(*v, Lba(0), csz * scoMul, pattern);
     }
 }
 
@@ -60,13 +60,13 @@ TEST_P(BigReadWriteTest, bigReadsOnFull)
     size_t scoMul = v->getSCOMultiplier();
     for(size_t i = 0;i < 50*scoMul; ++i)
     {
-        writeToVolume(*v, i* csz / lba_size, csz, pattern);
+        writeToVolume(*v, Lba(i * csz / lba_size), csz, pattern);
     }
 
     // Stop here to manually delete sco's to check error handling
     for(size_t i = 0; i < scoMul; ++i)
     {
-        checkVolume(*v,0, csz*scoMul, pattern);
+        checkVolume(*v, Lba(0), csz * scoMul, pattern);
     }
 
 }
@@ -85,13 +85,13 @@ TEST_P(BigReadWriteTest, bigWritesBigReads)
     size_t scoMul = v->getSCOMultiplier();
     for (size_t i = 0; i < scoMul; ++i)
     {
-        writeToVolume(*v, 0, csz * (i + 1), pattern);
+        writeToVolume(*v, Lba(0), csz * (i + 1), pattern);
     }
 
     // Stop here to manually delete sco's to check error handling
     for (size_t i = 0; i < scoMul; ++i)
     {
-        checkVolume(*v, 0, csz * (i + 1), pattern);
+        checkVolume(*v, Lba(0), csz * (i + 1), pattern);
     }
 
 }
@@ -109,10 +109,10 @@ TEST_P(BigReadWriteTest, OneBigWriteOneBigRead)
 
     const std::string pattern(csz,'a');
     size_t scoMul = v->getSCOMultiplier();
-    writeToVolume(*v, 0, csz * scoMul, pattern);
+    writeToVolume(*v, Lba(0), csz * scoMul, pattern);
 
     // Stop here to manually delete sco's to check error handling
-    checkVolume(*v,0, csz*scoMul, pattern);
+    checkVolume(*v, Lba(0), csz*scoMul, pattern);
 
 }
 

--- a/src/volumedriver/test/CloneManagementTest.cpp
+++ b/src/volumedriver/test/CloneManagementTest.cpp
@@ -53,7 +53,7 @@ TEST_P(CloneManagementTest, noclonesfromsnapshotsnotinbackend)
         SCOPED_BLOCK_BACKEND(*v);
 
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "xyz");
         v->createSnapshot(snap);
@@ -77,7 +77,7 @@ TEST_P(CloneManagementTest, noclonesfromsnapshotsnotinbackend)
 
     ASSERT_TRUE(c != nullptr);
     checkVolume(*c,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 }
@@ -96,7 +96,7 @@ TEST_P(CloneManagementTest, sad_clone)
 
     ASSERT_TRUE(v != nullptr);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "xyz");
 
@@ -144,7 +144,7 @@ TEST_P(CloneManagementTest, recursiveclonelookup)
 
     ASSERT_TRUE(v != nullptr);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "xyz");
 
@@ -167,12 +167,12 @@ TEST_P(CloneManagementTest, recursiveclonelookup)
 
     ASSERT_TRUE(c != nullptr);
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 
     writeToVolume(*c,
-                  8,
+                  Lba(8),
                   4096,
                   "abc");
 
@@ -193,12 +193,12 @@ TEST_P(CloneManagementTest, recursiveclonelookup)
 
     ASSERT_TRUE(d != nullptr);
     checkVolume(*d,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 
     checkVolume(*d,
-                8,
+                Lba(8),
                 4096,
                 "abc");
 }

--- a/src/volumedriver/test/CloneVolumeTest.cpp
+++ b/src/volumedriver/test/CloneVolumeTest.cpp
@@ -80,7 +80,7 @@ TEST_P(CloneVolumeTest, test1)
                   ns1);
     ASSERT_TRUE(v != nullptr);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "a");
 
@@ -101,7 +101,7 @@ TEST_P(CloneVolumeTest, test1)
                      snap1);
     checkCurrentBackendSize(*c1);
     writeToVolume(*c1,
-                  4096,
+                  Lba(4096),
                   4096,
                   "x");
 
@@ -110,12 +110,12 @@ TEST_P(CloneVolumeTest, test1)
 
     waitForThisBackendWrite(*c1);
     writeToVolume(*c1,
-                  4096,
+                  Lba(4096),
                   4096,
                   "b");
 
     writeToVolume(*c1,
-                  0,
+                  Lba(0),
                   4096,
                   "c");
     checkCurrentBackendSize(*c1);
@@ -124,8 +124,8 @@ TEST_P(CloneVolumeTest, test1)
 
     c1->restoreSnapshot(snap2);
 
-    checkVolume(*c1, 0, 4096, "a");
-    checkVolume(*c1, 4096, 4096, "x");
+    checkVolume(*c1, Lba(0), 4096, "a");
+    checkVolume(*c1, Lba(4096), 4096, "x");
     checkCurrentBackendSize(*c1);
 }
 

--- a/src/volumedriver/test/DataStoreNGTest.cpp
+++ b/src/volumedriver/test/DataStoreNGTest.cpp
@@ -564,7 +564,7 @@ TEST_P(DataStoreNGTest, checksum)
         SCOPED_BLOCK_BACKEND(*vol_);
 
         writeToVolume(*vol_,
-                      0,
+                      Lba(0),
                       size,
                       pattern);
 

--- a/src/volumedriver/test/DestroyVolumeTest.cpp
+++ b/src/volumedriver/test/DestroyVolumeTest.cpp
@@ -110,7 +110,7 @@ public:
                                                    ns_ptr->ns());
 
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "bad");
 
@@ -195,7 +195,7 @@ TEST_P(DestroyVolumeTest, test_errors_when_deleting_mdstore)
                                                 ns);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   4096,
                   "bad");
 
@@ -237,7 +237,7 @@ TEST_P(DestroyVolumeTest, test_errors_when_deleting_tlogs)
                                                 ns);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   4096,
                   "bad");
 

--- a/src/volumedriver/test/ErrorHandlingTest.cpp
+++ b/src/volumedriver/test/ErrorHandlingTest.cpp
@@ -223,13 +223,13 @@ public:
         }
 
         writeToVolume(*vol_,
-                      0,
+                      Lba(0),
                       size,
                       pattern);
 
         breakCurrentSCO();
 
-        uint64_t off = size / vol_->getLBASize();
+        Lba off(size / vol_->getLBASize());
         unsigned cnt = 1;
 
         if (with_foc)
@@ -240,7 +240,7 @@ public:
                           pattern);
 
             checkVolume(*vol_,
-                        0,
+                        Lba(0),
                         2 * size,
                         pattern);
 
@@ -252,13 +252,13 @@ public:
         }
 
         EXPECT_THROW(writeToVolume(*vol_,
-                                   (size * cnt) / vol_->getLBASize(),
+                                   Lba((size * cnt) / vol_->getLBASize()),
                                    size,
                                    pattern),
                      std::exception);
 
         EXPECT_THROW(checkVolume(*vol_,
-                                 0,
+                                 Lba(0),
                                  size * cnt,
                                  pattern),
                      std::exception);
@@ -298,7 +298,7 @@ public:
         const std::string pattern("abc");
 
         writeToVolume(*vol_,
-                      0,
+                      Lba(0),
                       size,
                       pattern);
 
@@ -327,7 +327,7 @@ public:
         if (with_foc || disposable)
         {
             checkVolume(*vol_,
-                        0,
+                        Lba(0),
                         size,
                         pattern);
 
@@ -336,7 +336,7 @@ public:
             scocorrupter(sco_to_break);
 
             EXPECT_THROW(checkVolume(*vol_,
-                                     0,
+                                     Lba(0),
                                      vol_->getClusterSize(),
                                      pattern),
                          std::exception);
@@ -344,7 +344,7 @@ public:
             EXPECT_EQ(0U, getMountPointList().size());
 
             EXPECT_THROW(writeToVolume(*vol_,
-                                       0,
+                                       Lba(0),
                                        vol_->getClusterSize(),
                                        pattern),
                          std::exception) <<
@@ -353,7 +353,7 @@ public:
         else
         {
             EXPECT_THROW(checkVolume(*vol_,
-                                     0,
+                                     Lba(0),
                                      size,
                                      pattern),
                          std::exception);
@@ -382,7 +382,7 @@ public:
         std::string pattern("abcd");
 
         writeToVolume(*vol_,
-                      0,
+                      Lba(0),
                       size,
                       pattern);
 
@@ -422,14 +422,14 @@ public:
             blocker.reset(new ScopedBackendBlocker(this, *vol_));
 
             checkVolume(*vol_,
-                        0,
+                        Lba(0),
                         size,
                         pattern);
 
             pattern = "efgh";
 
             writeToVolume(*vol_,
-                          0,
+                          Lba(0),
                           size,
                           pattern);
 
@@ -448,7 +448,7 @@ public:
         sleep(10);
 
         EXPECT_THROW(checkVolume(*vol_,
-                                 0,
+                                 Lba(0),
                                  size,
                                  pattern),
                      std::exception);
@@ -483,7 +483,7 @@ public:
         }
 
         writeToVolume(*vol_,
-                      0,
+                      Lba(0),
                       size,
                       pattern);
 
@@ -507,13 +507,13 @@ public:
         removeSCOAndBreakMountPoint_(loc.sco());
 
         EXPECT_NO_THROW(checkVolume(*vol_,
-                                    0,
+                                    Lba(0),
                                     size,
                                     pattern));
 
         EXPECT_EQ(1U, getMountPointList().size());
         ASSERT_NO_THROW(writeToVolume(*vol_,
-                                      size / vol_->getLBASize(),
+                                      Lba(size / vol_->getLBASize()),
                                       size,
                                       pattern));
 
@@ -525,7 +525,7 @@ public:
         removeSCOAndBreakMountPoint_(loc.sco());
 
         EXPECT_THROW(checkVolume(*vol_,
-                                 0,
+                                 Lba(0),
                                  size,
                                  pattern),
                      std::exception);
@@ -533,7 +533,7 @@ public:
         EXPECT_EQ(0U, getMountPointList().size());
 
         EXPECT_THROW(writeToVolume(*vol_,
-                                   0,
+                                   Lba(0),
                                    size,
                                    pattern),
                      std::exception) <<
@@ -553,9 +553,9 @@ public:
         ASSERT_THROW(vol_->checkNotHalted_(),
                      std::exception);
 
-        ASSERT_THROW(vol_->read(0, &buf[0], buf.size()),
+        ASSERT_THROW(vol_->read(Lba(0), &buf[0], buf.size()),
                      std::exception);
-        ASSERT_THROW(vol_->write(0, &buf[0], buf.size()),
+        ASSERT_THROW(vol_->write(Lba(0), &buf[0], buf.size()),
                      std::exception);
         ASSERT_THROW(vol_->scheduleBackendSync(),
                      std::exception);
@@ -748,7 +748,7 @@ TEST_P(ErrorHandlingTest, cleanupError)
     size_t size = 2 * mp_size_ - (2 * sco_size_);
 
     writeToVolume(*vol_,
-                  0,
+                  Lba(0),
                   size,
                   pattern);
 
@@ -793,7 +793,7 @@ TEST_P(ErrorHandlingTest, cleanupError)
     for (size_t i = 0; i < size; i += sco_size_)
     {
         checkVolume(*vol_,
-                    i % lba_size_,
+                    Lba(i % lba_size_),
                     sco_size_,
                     pattern);
         cache->cleanup();
@@ -804,7 +804,7 @@ TEST_P(ErrorHandlingTest, cleanupError)
     size = (size / sco_size_) * sco_size_;
 
     writeToVolume(*vol_,
-                  0,
+                  Lba(0),
                   size,
                   pattern);
 
@@ -843,7 +843,7 @@ TEST_P(ErrorHandlingTest, cleanupError)
     //              std::exception);
 
     EXPECT_THROW(writeToVolume(*vol_,
-                               0,
+                               Lba(0),
                                lba_size_ * cluster_mult_,
                                pattern),
                  std::exception);
@@ -867,7 +867,7 @@ TEST_P(ErrorHandlingTest, haltedVolume)
 
     const size_t size = sco_size_ / 2;
     writeToVolume(*vol_,
-                  0,
+                  Lba(0),
                   size,
                   "blah");
 

--- a/src/volumedriver/test/FailOverCacheTester.cpp
+++ b/src/volumedriver/test/FailOverCacheTester.cpp
@@ -134,13 +134,13 @@ TEST_P(FailOverCacheTester, VolumeWithFOC)
     for(int i =0; i < 128; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "xyz");
     }
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 
@@ -167,12 +167,12 @@ TEST_P(FailOverCacheTester, VolumeWithoutFOC)
     for(int i =0; i < 128; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "xyz");
     }
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 
@@ -202,7 +202,7 @@ TEST_P(FailOverCacheTester, StopRace)
         {
 
             writeToVolume(*v,
-                          0,
+                          Lba(0),
                           4096,
                           "xyz");
         }
@@ -211,7 +211,7 @@ TEST_P(FailOverCacheTester, StopRace)
     for(int i =0; i < 4; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "xyz");
     }
@@ -244,7 +244,7 @@ TEST_P(FailOverCacheTester, StopCacheServer)
         for(int i = 0; i < 128; ++i)
         {
             writeToVolume(*v,
-                          0,
+                          Lba(0),
                           4096,
                           "xyz");
         }
@@ -253,7 +253,7 @@ TEST_P(FailOverCacheTester, StopCacheServer)
     for(int i =0; i < 128; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "xyz");
     }
@@ -292,7 +292,7 @@ TEST_P(FailOverCacheTester, CacheServerHasNoMemory)
         for (size_t i = 0; i < num_clusters; ++i)
         {
             writeToVolume(*v,
-                          0,
+                          Lba(0),
                           4096,
                           "xyz");
         }
@@ -345,7 +345,7 @@ TEST_P(FailOverCacheTester, ResetCacheServer)
         }
 
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "xyz");
     }
@@ -371,7 +371,7 @@ TEST_P(FailOverCacheTester, ClearCacheServer)
     for(unsigned i = 0; i < numwrites; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "xyz");
     }
@@ -402,12 +402,12 @@ TEST_P(FailOverCacheTester, test2)
     v->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode()));
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "xyz");
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 
@@ -418,7 +418,7 @@ TEST_P(FailOverCacheTester, test2)
     ASSERT_NO_THROW(v2 = localRestart(ns));
 
     checkVolume(*v2,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 
@@ -443,13 +443,13 @@ TEST_P(FailOverCacheTester, test3)
     for(int i =0; i < 50; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "xyz");
     }
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 
@@ -474,7 +474,7 @@ TEST_P(FailOverCacheTester, resetToSelf)
 
     for(unsigned i = 0; i < entries; i++)
     {
-        writeToVolume(*v, i * 4096, 4096, "bdv");
+        writeToVolume(*v, Lba(i * 4096), 4096, "bdv");
     }
     v->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode()));
 
@@ -484,7 +484,7 @@ TEST_P(FailOverCacheTester, resetToSelf)
 
     for(unsigned i = 0; i < entries; i++)
     {
-        writeToVolume(*v, i * 4096, 4096, "bdv");
+        writeToVolume(*v, Lba(i * 4096), 4096, "bdv");
     }
 
     flushFailOverCache(*v);
@@ -513,7 +513,7 @@ TEST_P(FailOverCacheTester, resetToOther)
 
     for(unsigned i = 0; i < entries; i++)
     {
-        writeToVolume(*v, i * 4096, 4096, "bdv");
+        writeToVolume(*v, Lba(i * 4096), 4096, "bdv");
     }
     EXPECT_EQ(VolumeFailOverState::OK_STANDALONE,
               v->getVolumeFailOverState());
@@ -539,7 +539,7 @@ TEST_P(FailOverCacheTester, resetToOther)
 
     for(unsigned i = 0; i < entries; i++)
     {
-        writeToVolume(*v, i * 4096, 4096, "bdv");
+        writeToVolume(*v, Lba(i * 4096), 4096, "bdv");
     }
 }
 
@@ -561,7 +561,7 @@ TEST_P(FailOverCacheTester, TLogsAreRemoved)
         ss << i;
         for(int j = 0; j < 32; ++j)
         {
-            writeToVolume(*v, j*4096,4096, "bdv");
+            writeToVolume(*v, Lba(j*4096),4096, "bdv");
         }
         waitForThisBackendWrite(*v);
         createSnapshot(*v,ss.str());
@@ -569,7 +569,7 @@ TEST_P(FailOverCacheTester, TLogsAreRemoved)
 
     for(int j = 0; j < 32; ++j)
     {
-        writeToVolume(*v, j*4096,4096, "bdv");
+        writeToVolume(*v, Lba(j*4096),4096, "bdv");
     }
 
     waitForThisBackendWrite(*v);
@@ -654,7 +654,7 @@ TEST_P(FailOverCacheTester, DirectoryRemovedOnUnRegister)
         ASSERT_TRUE(fs::is_directory(*foc_ns_path));
         EXPECT_TRUE(fs::is_empty(*foc_ns_path));
 
-        writeToVolume(*v, 0, 4096, "bdv");
+        writeToVolume(*v, Lba(0), 4096, "bdv");
         v->sync();
 
         ASSERT_FALSE(fs::is_empty(*foc_ns_path));
@@ -805,7 +805,7 @@ TEST_P(FailOverCacheTester, non_standard_cluster_size)
     for (size_t i = 0; i < num_clusters; ++i)
     {
         writeToVolume(*v,
-                      i * cmult,
+                      Lba(i * cmult),
                       csize,
                       make_pattern(i));
     }
@@ -865,7 +865,7 @@ TEST_P(FailOverCacheTester, wrong_cluster_size)
 
     const std::string pattern("cluster");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   csize,
                   pattern);
 
@@ -956,7 +956,7 @@ TEST_P(FailOverCacheTester, dtl_in_sync)
     EXPECT_EQ(VolumeFailOverState::OK_STANDALONE,
               v->getVolumeFailOverState());
     EXPECT_EQ(DtlInSync::F,
-              v->write(0, buf.data(), buf.size()));
+              v->write(Lba(0), buf.data(), buf.size()));
     EXPECT_EQ(DtlInSync::F,
               v->sync());
 
@@ -966,7 +966,7 @@ TEST_P(FailOverCacheTester, dtl_in_sync)
         v->setFailOverCacheConfig(foc_ctx->config(mode));
 
         EXPECT_EQ(DtlInSync::F,
-                  v->write(0, buf.data(), buf.size()));
+                  v->write(Lba(0), buf.data(), buf.size()));
         EXPECT_EQ(DtlInSync::F,
                   v->sync());
     }
@@ -977,7 +977,7 @@ TEST_P(FailOverCacheTester, dtl_in_sync)
     ASSERT_EQ(VolumeFailOverState::OK_SYNC,
               v->getVolumeFailOverState());
 
-    const DtlInSync dtl_in_sync = v->write(0, buf.data(), buf.size());
+    const DtlInSync dtl_in_sync = v->write(Lba(0), buf.data(), buf.size());
 
     if (mode == FailOverCacheMode::Synchronous)
     {

--- a/src/volumedriver/test/FencingTest.cpp
+++ b/src/volumedriver/test/FencingTest.cpp
@@ -91,7 +91,7 @@ TEST_P(FencingTest, write)
     const size_t wsize = 64UL << 10;
     const std::string pattern1("before");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   wsize,
                   pattern1);
 
@@ -105,7 +105,7 @@ TEST_P(FencingTest, write)
 
     const std::string pattern2("after");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   wsize,
                   pattern2);
 
@@ -114,7 +114,7 @@ TEST_P(FencingTest, write)
     wait_for_halt(*v);
 
     std::vector<uint8_t> buf(4096);
-    EXPECT_THROW(v->read(0,
+    EXPECT_THROW(v->read(Lba(0),
                          buf.data(),
                          buf.size()),
                  std::exception);
@@ -128,7 +128,7 @@ TEST_P(FencingTest, write)
     ASSERT_TRUE(v != nullptr);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 wsize,
                 pattern1);
 }

--- a/src/volumedriver/test/FileDescriptorResourceLimitTest.cpp
+++ b/src/volumedriver/test/FileDescriptorResourceLimitTest.cpp
@@ -107,7 +107,7 @@ TEST_P(Test1, DISABLED_filedescriptors)
     ASSERT_TRUE(v2 != nullptr);
 
     writeToVolume(*v2,
-                  0,
+                  Lba(0),
                   4096,
                   "foo");
 
@@ -115,7 +115,7 @@ TEST_P(Test1, DISABLED_filedescriptors)
     v2->createSnapshot(snapname);
 
     writeToVolume(*v2,
-                  0,
+                  Lba(0),
                   4096,
                   "bar");
 

--- a/src/volumedriver/test/LocalRestartTest.cpp
+++ b/src/volumedriver/test/LocalRestartTest.cpp
@@ -93,7 +93,7 @@ public:
         }
 
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       max_tlog_entries * cluster_size,
                       tlog_1_pattern);
 
@@ -126,7 +126,7 @@ public:
                                                   DeleteLocalData::F,
                                                   RemoveVolumeCompletely::F);
             writeToVolume(*v,
-                          max_tlog_entries * cluster_mult,
+                          Lba(max_tlog_entries * cluster_mult),
                           (max_tlog_entries - 1) * cluster_size,
                           tlog_2_pattern);
 
@@ -244,14 +244,14 @@ public:
                                                   RemoveVolumeCompletely::F);
             for(unsigned i = 0; i <  sco_mult; ++i)
             {
-                writeToVolume(*v, 0, cluster_size, pattern1);
+                writeToVolume(*v, Lba(0), cluster_size, pattern1);
             }
 
             // SCO rollover adds a CRC
 
             for(unsigned i = 0; i < 2 * sco_mult - 1; ++i)
             {
-                writeToVolume(*v, 0, cluster_size, pattern2);
+                writeToVolume(*v, Lba(0), cluster_size, pattern2);
             }
             v->getMetaDataStore()->getStats(mds1);
             // EXPECT_LT(0, mds1.used_clusters);
@@ -287,7 +287,7 @@ public:
         //    EXPECT_TRUE(v->mdstore_was_rebuilt_);
 
         checkVolume(*v,
-                    0,
+                    Lba(0),
                     cluster_size,
                     focmode == FOCMode::Healthy ?
                     pattern2 :
@@ -322,7 +322,7 @@ TEST_P(LocalRestartTest, normalRestart)
     for(size_t i = 0; i < count; i++)
     {
         writeToVolume(*v1,
-                      0,
+                      Lba(0),
                       v1->getClusterSize(),
                       boost::lexical_cast<std::string>(i));
     }
@@ -337,7 +337,7 @@ TEST_P(LocalRestartTest, normalRestart)
     // EXPECT_FALSE(v1->mdstore_was_rebuilt_);
 
     checkVolume(*v1,
-                0,
+                Lba(0),
                 v1->getClusterSize(),
                 boost::lexical_cast<std::string>(count - 1));
 
@@ -367,7 +367,7 @@ TEST_P(LocalRestartTest, readCacheRestart1)
     for(int i = 0; i < 1024; i++)
     {
         writeToVolume(*v1,
-                      0,
+                      Lba(0),
                       v1->getClusterSize(),
                       "kristafke");
     }
@@ -381,7 +381,7 @@ TEST_P(LocalRestartTest, readCacheRestart1)
     ASSERT_TRUE(v1 != nullptr);
     // EXPECT_FALSE(v1->mdstore_was_rebuilt_);
 
-    checkVolume(*v1, 0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     checkCurrentBackendSize(*v1);
 
     ASSERT_TRUE(*v1->get_cluster_cache_behaviour() == behaviour);
@@ -402,7 +402,7 @@ TEST_P(LocalRestartTest, normalRestart2)
     for(int i = 0; i < 1024; i++)
     {
         writeToVolume(*v1,
-                      0,
+                      Lba(0),
                       v1->getClusterSize(),
                       "kristafke");
     }
@@ -417,7 +417,7 @@ TEST_P(LocalRestartTest, normalRestart2)
 
     // EXPECT_FALSE(v1->mdstore_was_rebuilt_);
 
-    checkVolume(*v1, 0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     checkCurrentBackendSize(*v1);
 
     ASSERT_TRUE(*v1->get_cluster_cache_behaviour() == behaviour);
@@ -438,7 +438,7 @@ TEST_P(LocalRestartTest, normalRestartwithPrefetch)
     for(int i = 0; i < 1024; i++)
     {
         writeToVolume(*v1,
-                      0,
+                      Lba(0),
                       v1->getClusterSize(),
                       "kristafke");
     }
@@ -458,7 +458,7 @@ TEST_P(LocalRestartTest, normalRestartwithPrefetch)
 
     v1->startPrefetch();
     sleep(1);
-    checkVolume(*v1, 0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     checkCurrentBackendSize(*v1);
 
 }
@@ -483,7 +483,7 @@ TEST_P(LocalRestartTest, restartNothing)
 
     //    EXPECT_FALSE(v1->mdstore_was_rebuilt_);
 
-    checkVolume(*v1, 0, v1->getClusterSize(), "\0");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "\0");
     checkCurrentBackendSize(*v1);
 
 }
@@ -502,7 +502,7 @@ TEST_P(LocalRestartTest, restartNothingWithBackendSync)
     for(int i = 0; i < 1024; i++)
     {
         writeToVolume(*v1,
-                      0,
+                      Lba(0),
                       v1->getClusterSize(),
                       "kristafke");
     }
@@ -516,7 +516,7 @@ TEST_P(LocalRestartTest, restartNothingWithBackendSync)
 
     //    EXPECT_FALSE(v1->mdstore_was_rebuilt_);
 
-    checkVolume(*v1, 0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     checkCurrentBackendSize(*v1);
 
 }
@@ -538,7 +538,7 @@ TEST_P(LocalRestartTest, restartWithSnapshot)
                                               DeleteLocalData::F,
                                               RemoveVolumeCompletely::F);
         writeToVolume(*v1,
-                      0,
+                      Lba(0),
                       v1->getClusterSize(),
                       "kristafke");
         createSnapshot(*v1, "Snapshot1");
@@ -549,7 +549,7 @@ TEST_P(LocalRestartTest, restartWithSnapshot)
 
     //     EXPECT_FALSE(v1->mdstore_was_rebuilt_);
 
-    checkVolume(*v1, 0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     checkCurrentBackendSize(*v1);
 
 }
@@ -568,7 +568,7 @@ TEST_P(LocalRestartTest, restartWithSnapshotButNoSCO)
                            ns1);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "kristafke");
     createSnapshot(*v1, "snapshot1");
@@ -586,7 +586,7 @@ TEST_P(LocalRestartTest, restartWithSnapshotButNoSCO)
 
     //     EXPECT_FALSE(v1->mdstore_was_rebuilt_);
 
-    checkVolume(*v1, 0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
 
     waitForThisBackendWrite(*v1);
 
@@ -608,7 +608,7 @@ TEST_P(LocalRestartTest, RestartWithFOC)
                           ns);
     ASSERT_NO_THROW(v->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode())));
 
-    writeToVolume(*v,0,v->getClusterSize(), "bart");
+    writeToVolume(*v, Lba(0),v->getClusterSize(), "bart");
     destroyVolume(v,
                   DeleteLocalData::F,
                   RemoveVolumeCompletely::F);
@@ -814,7 +814,7 @@ TEST_P(LocalRestartTest, funnyTLogCRC)
     ASSERT_TRUE(v1 != nullptr);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "bdv");
     waitForThisBackendWrite(*v1);
@@ -825,7 +825,7 @@ TEST_P(LocalRestartTest, funnyTLogCRC)
         SCOPED_DESTROY_VOLUME_UNBLOCK_BACKEND(v1, 2,
                                               DeleteLocalData::F,
                                               RemoveVolumeCompletely::F);
-        writeToVolume(*v1, 0, v1->getClusterSize(),"ar");
+        writeToVolume(*v1, Lba(0), v1->getClusterSize(),"ar");
         getTLogsNotInBackend(vid1,
                          tlogs);
     }
@@ -893,7 +893,7 @@ TEST_P(LocalRestartTest, DISABLED_NoSyncToTC)
     ASSERT_TRUE(v1 != nullptr);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "bdv");
     waitForThisBackendWrite(*v1);
@@ -905,7 +905,7 @@ TEST_P(LocalRestartTest, DISABLED_NoSyncToTC)
         SCOPED_DESTROY_VOLUME_UNBLOCK_BACKEND(v1, 2,
                                               DeleteLocalData::F,
                                               RemoveVolumeCompletely::F);
-        writeToVolume(*v1, 0, v1->getClusterSize(), "ar");
+        writeToVolume(*v1, Lba(0), v1->getClusterSize(), "ar");
         getTLogsNotInBackend(vid1,
                          tlogs);
 
@@ -934,7 +934,7 @@ TEST_P(LocalRestartTest, DISABLED_NoSyncToTC)
 
     EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v1, 0, v1->getClusterSize(), "ar");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "ar");
     checkCurrentBackendSize(*v1);
 }
 
@@ -951,14 +951,14 @@ TEST_P(LocalRestartTest, MetaDataStoreRunsAhead)
     ASSERT_TRUE(v1 != nullptr);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "bdv");
 
     ASSERT_NO_THROW(createSnapshot(*v1,"asnapshot"));
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "il");
     waitForThisBackendWrite(*v1);
@@ -970,7 +970,7 @@ TEST_P(LocalRestartTest, MetaDataStoreRunsAhead)
                                               2,
                                               DeleteLocalData::F,
                                               RemoveVolumeCompletely::F);
-        writeToVolume(*v1, 0, v1->getClusterSize(),"ar");
+        writeToVolume(*v1, Lba(0), v1->getClusterSize(),"ar");
 
         v1->getMetaDataStore()->getStats(mds1);
         EXPECT_LT(0U, mds1.used_clusters);
@@ -992,7 +992,7 @@ TEST_P(LocalRestartTest, MetaDataStoreRunsAhead)
     v1->getMetaDataStore()->getStats(mds2);
     EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
     ASSERT_TRUE(v1->isSyncedToBackendUpTo(SnapshotName("asnapshot")));
-    checkVolume(*v1, 0, v1->getClusterSize(), "ar");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "ar");
     checkCurrentBackendSize(*v1);
 }
 
@@ -1019,7 +1019,7 @@ TEST_P(LocalRestartTest, RestartWithFOCAndRemovedSCO)
         for(int i = 0; i < (1 << 12); ++i)
         {
             writeToVolume(*v,
-                          i * (cluster_size / 512),
+                          Lba(i * (cluster_size / 512)),
                           cluster_size,
                           "bart");
         }
@@ -1065,7 +1065,7 @@ TEST_P(LocalRestartTest, RestartWithFOCAndRemovedSCO)
 
     for(int i = 0; i < 1 << 12; ++i)
     {
-        checkVolume(*v,i*(cluster_size/512), cluster_size, "bart");
+        checkVolume(*v, Lba(i*(cluster_size/512)), cluster_size, "bart");
     }
     checkCurrentBackendSize(*v);
 }
@@ -1090,7 +1090,7 @@ TEST_P(LocalRestartTest, RestartWithoutFOCAndRemovedSCO)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,i* (cluster_size/512), cluster_size, "bart");
+            writeToVolume(*v, Lba(i* (cluster_size/512)), cluster_size, "bart");
 
         }
     }
@@ -1146,11 +1146,11 @@ TEST_P(LocalRestartTest, RestartWithFuckedUpFOCAndTruncatedSCO)
                                                   RemoveVolumeCompletely::F);
             for(int i = 0; i <  32; ++i)
             {
-                writeToVolume(*v, 0, cluster_size, "bart");
+                writeToVolume(*v, Lba(0), cluster_size, "bart");
             }
             for(int i = 0; i < 32; ++i)
             {
-                writeToVolume(*v, 0, cluster_size, "immanuel");
+                writeToVolume(*v, Lba(0), cluster_size, "immanuel");
             }
             v->getMetaDataStore()->getStats(mds1);
             // also disabled on default
@@ -1186,7 +1186,7 @@ TEST_P(LocalRestartTest, RestartWithFuckedUpFOCAndTruncatedSCO)
 
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v,0, cluster_size, "bart");
+    checkVolume(*v, Lba(0), cluster_size, "bart");
     checkCurrentBackendSize(*v);
 }
 
@@ -1279,11 +1279,11 @@ TEST_P(LocalRestartTest, RestartWithMetaDataReplay)
                                                       RemoveVolumeCompletely::F);
                 for(int i = 0; i <  8; ++i)
                 {
-                    writeToVolume(*v,0, cluster_size, "bart");
+                    writeToVolume(*v, Lba(0), cluster_size, "bart");
                 }
                 for(int i = 0; i <  8; ++i)
                 {
-                    writeToVolume(*v,8, cluster_size, "bart");
+                    writeToVolume(*v, Lba(8), cluster_size, "bart");
                 }
 
                 v->sync();
@@ -1291,12 +1291,12 @@ TEST_P(LocalRestartTest, RestartWithMetaDataReplay)
 
                 for(int i = 0; i < 16; ++i)
                 {
-                    writeToVolume(*v,8, cluster_size, "immanuel");
+                    writeToVolume(*v, Lba(8), cluster_size, "immanuel");
                 }
 
                 for(int i = 0; i < 16; ++i)
                 {
-                    writeToVolume(*v,0, cluster_size, "immanuel");
+                    writeToVolume(*v, Lba(0), cluster_size, "immanuel");
                 }
                 v->getMetaDataStore()->getStats(mds1);
                 // EXPECT_LT(0, mds1.used_clusters);
@@ -1318,8 +1318,8 @@ TEST_P(LocalRestartTest, RestartWithMetaDataReplay)
             ASSERT_TRUE(v != nullptr);
             //         EXPECT_TRUE(v->mdstore_was_rebuilt_);
 
-            checkVolume(*v,0, cluster_size, "immanuel");
-            checkVolume(*v,8, cluster_size, "immanuel");
+            checkVolume(*v, Lba(0), cluster_size, "immanuel");
+            checkVolume(*v, Lba(8), cluster_size, "immanuel");
 
             MetaDataStoreStats mds2;
             v->getMetaDataStore()->getStats(mds2);
@@ -1368,11 +1368,11 @@ TEST_P(LocalRestartTest, WithFOCAndTruncatedSCO)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i <  32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "bart");
+            writeToVolume(*v, Lba(0), cluster_size, "bart");
         }
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "immanuel");
+            writeToVolume(*v, Lba(0), cluster_size, "immanuel");
         }
 
         v->getMetaDataStore()->getStats(mds1);
@@ -1404,7 +1404,7 @@ TEST_P(LocalRestartTest, WithFOCAndTruncatedSCO)
     v->getMetaDataStore()->getStats(mds2);
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v,0, cluster_size, "immanuel");
+    checkVolume(*v, Lba(0), cluster_size, "immanuel");
     checkCurrentBackendSize(*v);
 }
 
@@ -1428,11 +1428,11 @@ TEST_P(LocalRestartTest, RestartWithoutFOCAndTruncatedSCO)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i <  32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "bart");
+            writeToVolume(*v, Lba(0), cluster_size, "bart");
         }
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "immanuel");
+            writeToVolume(*v, Lba(0), cluster_size, "immanuel");
         }
         v->getMetaDataStore()->getStats(mds1);
         // EXPECT_LT(0, mds1.used_clusters);
@@ -1463,7 +1463,7 @@ TEST_P(LocalRestartTest, RestartWithoutFOCAndTruncatedSCO)
     v->getMetaDataStore()->getStats(mds2);
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v,0, cluster_size, "bart");
+    checkVolume(*v, Lba(0), cluster_size, "bart");
     checkCurrentBackendSize(*v);
 }
 
@@ -1491,11 +1491,11 @@ TEST_P(LocalRestartTest, RestartWithFOCAndRemovedSCO2)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i <  32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "bart");
+            writeToVolume(*v, Lba(0), cluster_size, "bart");
         }
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "immanuel");
+            writeToVolume(*v, Lba(0), cluster_size, "immanuel");
         }
         v->getMetaDataStore()->getStats(mds1);
         // EXPECT_LT(0, mds1.used_clusters);
@@ -1526,7 +1526,7 @@ TEST_P(LocalRestartTest, RestartWithFOCAndRemovedSCO2)
     v->getMetaDataStore()->getStats(mds2);
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v,0, cluster_size, "immanuel");
+    checkVolume(*v, Lba(0), cluster_size, "immanuel");
     checkCurrentBackendSize(*v);
 }
 
@@ -1554,11 +1554,11 @@ TEST_P(LocalRestartTest, RestartWithFOCAndFuckedUpSCO)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i <  32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "bart");
+            writeToVolume(*v, Lba(0), cluster_size, "bart");
         }
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "immanuel");
+            writeToVolume(*v, Lba(0), cluster_size, "immanuel");
         }
 
         v->getMetaDataStore()->getStats(mds1);
@@ -1592,7 +1592,7 @@ TEST_P(LocalRestartTest, RestartWithFOCAndFuckedUpSCO)
     v->getMetaDataStore()->getStats(mds2);
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v,0, cluster_size, "immanuel");
+    checkVolume(*v, Lba(0), cluster_size, "immanuel");
     checkCurrentBackendSize(*v);
 }
 
@@ -1617,11 +1617,11 @@ TEST_P(LocalRestartTest, RestartWithoutFOCAndFuckedUpSCO)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i <  32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "bart");
+            writeToVolume(*v, Lba(0), cluster_size, "bart");
         }
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "immanuel");
+            writeToVolume(*v, Lba(0), cluster_size, "immanuel");
         }
         v->getMetaDataStore()->getStats(mds1);
         // EXPECT_LT(0, mds1.used_clusters);
@@ -1654,7 +1654,7 @@ TEST_P(LocalRestartTest, RestartWithoutFOCAndFuckedUpSCO)
     v->getMetaDataStore()->getStats(mds2);
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v,0, cluster_size, "bart");
+    checkVolume(*v, Lba(0), cluster_size, "bart");
     checkCurrentBackendSize(*v);
 }
 
@@ -1682,9 +1682,9 @@ TEST_P(LocalRestartTest, CreateSnapshotPutsSCOCRCInTLog)
     VolumeConfig cfg = v->get_config();
 
     const uint64_t cluster_size = v->getClusterSize();
-    writeToVolume(*v,0, cluster_size, "immanuel");
+    writeToVolume(*v, Lba(0), cluster_size, "immanuel");
     v->createSnapshot(SnapshotName("snap1"));
-    writeToVolume(*v,0, cluster_size, "bart");
+    writeToVolume(*v, Lba(0), cluster_size, "bart");
     const fs::path tlogs_path = VolManager::get()->getTLogPath(cfg);
     OrderedTLogIds tlogs(v->getSnapshotManagement().getAllTLogs());
 
@@ -1711,13 +1711,13 @@ TEST_P(LocalRestartTest, BigWritesPutSCOCRCInTLog)
                           ns);
 
     const uint64_t cluster_size = v->getClusterSize();
-    writeToVolume(*v,0, cluster_size, "immanuel");
+    writeToVolume(*v, Lba(0), cluster_size, "immanuel");
 
     const uint64_t sco_size = v->getSCOMultiplier() * cluster_size;
 
-    writeToVolume(*v,0, sco_size, "bart");
-    writeToVolume(*v,0, sco_size, "arne");
-    writeToVolume(*v,0, sco_size, "wouter");
+    writeToVolume(*v, Lba(0), sco_size, "bart");
+    writeToVolume(*v, Lba(0), sco_size, "arne");
+    writeToVolume(*v, Lba(0), sco_size, "wouter");
     VolumeConfig cfg = v->get_config();
     const fs::path tlogs_path = VolManager::get()->getTLogPath(cfg);
     const OrderedTLogIds tlogs(v->getSnapshotManagement().getAllTLogs());
@@ -1749,12 +1749,12 @@ TEST_P(LocalRestartTest, SetFailOVerPutsSCOCRCInTLog)
     VolumeConfig cfg = v->get_config();
 
     const uint64_t cluster_size = v->getClusterSize();
-    writeToVolume(*v,0, cluster_size, "immanuel");
+    writeToVolume(*v, Lba(0), cluster_size, "immanuel");
     ASSERT_NO_THROW(v->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode())));
 
-    writeToVolume(*v,0, cluster_size, "bart");
+    writeToVolume(*v, Lba(0), cluster_size, "bart");
     v->createSnapshot(SnapshotName("snap1"));
-    writeToVolume(*v,0, cluster_size, "arne");
+    writeToVolume(*v, Lba(0), cluster_size, "arne");
 
     const fs::path tlogs_path = VolManager::get()->getTLogPath(cfg);
     const OrderedTLogIds tlogs(v->getSnapshotManagement().getAllTLogs());
@@ -1791,7 +1791,7 @@ TEST_P(LocalRestartTest, FailOverRestartPutsSCOCRCInTLog)
 
     for(unsigned i = 0; i <  clusters; ++i)
     {
-        writeToVolume(*v,0, cluster_size, "immanuel");
+        writeToVolume(*v, Lba(0), cluster_size, "immanuel");
     }
     waitForThisBackendWrite(*v);
     OrderedTLogIds tlogs;
@@ -1811,7 +1811,7 @@ TEST_P(LocalRestartTest, FailOverRestartPutsSCOCRCInTLog)
         uint64_t rand  = drand48() * v->getSCOMultiplier();
         for(unsigned i = 0; i <  clusters; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "bart");
+            writeToVolume(*v, Lba(0), cluster_size, "bart");
             if(clusters % v->getSCOMultiplier() == rand)
             {
                 rand = drand48() * v->getSCOMultiplier();
@@ -1833,7 +1833,7 @@ TEST_P(LocalRestartTest, FailOverRestartPutsSCOCRCInTLog)
     v->getMetaDataStore()->getStats(mds2);
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v,0, cluster_size,"bart");
+    checkVolume(*v, Lba(0), cluster_size,"bart");
 
     const OrderedTLogIds tlogs2(v->getSnapshotManagement().getAllTLogs());
 
@@ -2072,7 +2072,7 @@ TEST_P(LocalRestartTest, RestartWithMissingSCOCRC)
     ASSERT_TRUE(v1 != nullptr);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "bdv");
 
@@ -2087,7 +2087,7 @@ TEST_P(LocalRestartTest, RestartWithMissingSCOCRC)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i < 63; ++i)
         {
-            writeToVolume(*v1, 0, v1->getClusterSize(),"ar");
+            writeToVolume(*v1, Lba(0), v1->getClusterSize(),"ar");
         }
 
         getTLogsNotInBackend(vid1,
@@ -2129,15 +2129,15 @@ TEST_P(LocalRestartTest, RestartWithFOCAndFuckedUpSCO2)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i <  32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "bart");
+            writeToVolume(*v, Lba(0), cluster_size, "bart");
         }
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "immanuel");
+            writeToVolume(*v, Lba(0), cluster_size, "immanuel");
         }
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "immanuel");
+            writeToVolume(*v, Lba(0), cluster_size, "immanuel");
         }
 
         v->getMetaDataStore()->getStats(mds1);
@@ -2170,7 +2170,7 @@ TEST_P(LocalRestartTest, RestartWithFOCAndFuckedUpSCO2)
     v->getMetaDataStore()->getStats(mds2);
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v,0, cluster_size, "immanuel");
+    checkVolume(*v, Lba(0), cluster_size, "immanuel");
     checkCurrentBackendSize(*v);
 }
 
@@ -2193,15 +2193,15 @@ TEST_P(LocalRestartTest, RestartWithoutFOCAndFuckedUpSCO2)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i <  32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "bart");
+            writeToVolume(*v, Lba(0), cluster_size, "bart");
         }
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "immanuel");
+            writeToVolume(*v, Lba(0), cluster_size, "immanuel");
         }
         for(int i = 0; i < 32; ++i)
         {
-            writeToVolume(*v,0, cluster_size, "immanuel");
+            writeToVolume(*v, Lba(0), cluster_size, "immanuel");
         }
         v->getMetaDataStore()->getStats(mds1);
         // EXPECT_LT(0, mds1.used_clusters);
@@ -2259,7 +2259,7 @@ TEST_P(LocalRestartTest, RestartWithFOCAndOfflinedMountPoint)
                                               RemoveVolumeCompletely::F);
         for(int i = 0; i < (1 << 12); ++i)
         {
-            writeToVolume(*v,i* (cluster_size/512), cluster_size, "bart");
+            writeToVolume(*v, Lba(i* (cluster_size/512)), cluster_size, "bart");
         }
         v->getMetaDataStore()->getStats(mds1);
         // EXPECT_LT(0, mds1.used_clusters);
@@ -2285,7 +2285,7 @@ TEST_P(LocalRestartTest, RestartWithFOCAndOfflinedMountPoint)
 
     for(int i = 0; i < 1 << 12; ++i)
     {
-        checkVolume(*v,i*(cluster_size/512), cluster_size, "bart");
+        checkVolume(*v,Lba(i*(cluster_size/512)), cluster_size, "bart");
     }
     checkCurrentBackendSize(*v);
 }
@@ -2302,7 +2302,7 @@ TEST_P(LocalRestartTest, NothingToRestartLocallyFrom)
     SharedVolumePtr v1 = newVolume(vid1,
                            ns1);
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "bdv");
     waitForThisBackendWrite(*v1);
@@ -2314,7 +2314,7 @@ TEST_P(LocalRestartTest, NothingToRestartLocallyFrom)
                                               2,
                                               DeleteLocalData::F,
                                               RemoveVolumeCompletely::F);
-        writeToVolume(*v1, 0, v1->getClusterSize(),"ar");
+        writeToVolume(*v1, Lba(0), v1->getClusterSize(),"ar");
         v1->getMetaDataStore()->getStats(mds1);
         // EXPECT_LT(0, mds1.used_clusters);
     }
@@ -2329,7 +2329,7 @@ TEST_P(LocalRestartTest, NothingToRestartLocallyFrom)
     v1->getMetaDataStore()->getStats(mds2);
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v1, 0, v1->getClusterSize(), "ar");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "ar");
     checkCurrentBackendSize(*v1);
 }
 
@@ -2357,7 +2357,7 @@ TEST_P(LocalRestartTest, MDStoreOutToLunch)
             SharedVolumePtr v1 = newVolume(vid1,
                                    ns1);
             writeToVolume(*v1,
-                          0,
+                          Lba(0),
                           v1->getClusterSize(),
                           "bdv");
             waitForThisBackendWrite(*v1);
@@ -2371,7 +2371,7 @@ TEST_P(LocalRestartTest, MDStoreOutToLunch)
                                                       2,
                                                       DeleteLocalData::F,
                                                       RemoveVolumeCompletely::F);
-                writeToVolume(*v1, 0, v1->getClusterSize(),"ar");
+                writeToVolume(*v1, Lba(0), v1->getClusterSize(),"ar");
                 v1->getMetaDataStore()->getStats(mds1);
                 // EXPECT_LT(0, mds1.used_clusters);
             }
@@ -2391,7 +2391,7 @@ TEST_P(LocalRestartTest, MDStoreOutToLunch)
             v1->getMetaDataStore()->getStats(mds2);
             // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-            checkVolume(*v1, 0, v1->getClusterSize(), "ar");
+            checkVolume(*v1, Lba(0), v1->getClusterSize(), "ar");
             checkCurrentBackendSize(*v1);
         }
         break;
@@ -2409,7 +2409,7 @@ TEST_P(LocalRestartTest, MDStoreOutToLunchWithSnapshotsFile)
     SharedVolumePtr v1 = newVolume(vid1,
                            ns1);
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "bdv");
     waitForThisBackendWrite(*v1);
@@ -2423,7 +2423,7 @@ TEST_P(LocalRestartTest, MDStoreOutToLunchWithSnapshotsFile)
                                               2,
                                               DeleteLocalData::T,
                                               RemoveVolumeCompletely::F);
-        writeToVolume(*v1, 0, v1->getClusterSize(),"ar");
+        writeToVolume(*v1, Lba(0), v1->getClusterSize(),"ar");
         v1->getMetaDataStore()->getStats(mds1);
         // EXPECT_LT(0, mds1.used_clusters);
     }
@@ -2447,7 +2447,7 @@ TEST_P(LocalRestartTest, testRescheduledSCOS)
     SharedVolumePtr v = newVolume(v1,
                           ns1);
     VolumeConfig cfg = v->get_config();
-    writeToVolume(*v, 0, 4096, "doh");
+    writeToVolume(*v, Lba(0), 4096, "doh");
     ClusterLocation l(1);
 
     std::string scoptr_name =
@@ -2502,7 +2502,7 @@ TEST_P(LocalRestartTest, restartClone)
     for(int i = 0; i < 1024; i++)
     {
         writeToVolume(*v1,
-                      0,
+                      Lba(0),
                       v1->getClusterSize(),
                       "kristafke");
     }
@@ -2526,7 +2526,7 @@ TEST_P(LocalRestartTest, restartClone)
     for(int i = 0; i < 1; i++)
     {
         writeToVolume(*v2,
-                      v2->getClusterSize(),
+                      Lba(v2->getClusterSize()),
                       v2->getClusterSize(),
                       "kristafke");
     }
@@ -2553,7 +2553,7 @@ TEST_P(LocalRestartTest, restartClone)
     v2->getMetaDataStore()->getStats(mds2);
     // EXPECT_EQ(mds1.used_clusters, mds2.used_clusters);
 
-    checkVolume(*v2, v2->getClusterSize(), v2->getClusterSize(), "kristafke");
+    checkVolume(*v2, Lba(v2->getClusterSize()), v2->getClusterSize(), "kristafke");
     checkCurrentBackendSize(*v2);
 }
 
@@ -2673,12 +2673,12 @@ TEST_P(LocalRestartTest, LostMDStoreCacheAndNoUsableLocalData)
     //     EXPECT_TRUE(v->mdstore_was_rebuilt_);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 max_tlog_entries * cluster_size,
                 pattern1);
 
     checkVolume(*v,
-                max_tlog_entries * cluster_mult,
+                Lba(max_tlog_entries * cluster_mult),
                 max_tlog_entries * cluster_size,
                 "\0");
     checkCurrentBackendSize(*v);
@@ -2723,17 +2723,17 @@ TEST_P(LocalRestartTest, LostMDStoreCacheAndUsableLocalData)
     //    EXPECT_TRUE(v->mdstore_was_rebuilt_);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 max_tlog_entries * cluster_size,
                 pattern1);
 
     checkVolume(*v,
-                max_tlog_entries * cluster_mult,
+                Lba(max_tlog_entries * cluster_mult),
                 sco_mult * cluster_size,
                 pattern2);
 
     checkVolume(*v,
-                (max_tlog_entries + sco_mult) * cluster_mult,
+                Lba((max_tlog_entries + sco_mult) * cluster_mult),
                 sco_mult * cluster_size,
                 "\0");
     checkCurrentBackendSize(*v);
@@ -2811,20 +2811,20 @@ TEST_P(LocalRestartTest, DISABLED_ReliabilityOfTheBigOneIfTheMDStoreLRUWouldWork
     for (uint32_t i = 0; i < mdstore_cache_pages; ++i)
     {
         writeToVolume(*v,
-                      i * cluster_mult * page_entries,
+                      Lba(i * cluster_mult * page_entries),
                       cluster_size,
                       pattern1);
     }
 
     const std::string pattern2("first page entry, before the big one");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   cluster_size,
                   pattern2);
 
     const std::string pattern3("first page entry on second page aka The Big One");
     writeToVolume(*v,
-                  cluster_mult * page_entries,
+                  Lba(cluster_mult * page_entries),
                   cluster_size,
                   pattern3);
 
@@ -2856,7 +2856,7 @@ TEST_P(LocalRestartTest, DISABLED_ReliabilityOfTheBigOneIfTheMDStoreLRUWouldWork
         const std::string pattern4("second entry of the first page");
 
         writeToVolume(*v,
-                      cluster_mult,
+                      Lba(cluster_mult),
                       cluster_size,
                       pattern4);
 
@@ -2866,7 +2866,7 @@ TEST_P(LocalRestartTest, DISABLED_ReliabilityOfTheBigOneIfTheMDStoreLRUWouldWork
         for (uint32_t i = 2; i <= mdstore_cache_pages; ++i)
         {
             writeToVolume(*v,
-                          i * cluster_mult * page_entries,
+                          Lba(i * cluster_mult * page_entries),
                           cluster_size,
                           pattern5);
         }
@@ -2891,13 +2891,13 @@ TEST_P(LocalRestartTest, DISABLED_ReliabilityOfTheBigOneIfTheMDStoreLRUWouldWork
 
     // the big one
     checkVolume(*v,
-                cluster_mult * page_entries,
+                Lba(cluster_mult * page_entries),
                 cluster_size,
                 pattern3);
 
     // the one before
     checkVolume(*v,
-                0,
+                Lba(0),
                 cluster_size,
                 pattern2);
     checkCurrentBackendSize(*v);
@@ -3134,7 +3134,7 @@ TEST_P(LocalRestartTest, mdstore_running_ahead)
 
     const std::string fst("first");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   cluster_size,
                   fst);
 
@@ -3142,7 +3142,7 @@ TEST_P(LocalRestartTest, mdstore_running_ahead)
 
     const std::string snd("second");
     writeToVolume(*v,
-                  off,
+                  Lba(off),
                   cluster_size,
                   snd);
 
@@ -3179,12 +3179,12 @@ TEST_P(LocalRestartTest, mdstore_running_ahead)
     }
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 cluster_size,
                 fst);
 
     checkVolume(*v,
-                off,
+                Lba(off),
                 cluster_size,
                 snd);
 }

--- a/src/volumedriver/test/LocalRestartTestNoBackend.cpp
+++ b/src/volumedriver/test/LocalRestartTestNoBackend.cpp
@@ -46,7 +46,7 @@ TEST_P(LocalRestartTestNoBackend, restartWithSnapshot1)
     SharedVolumePtr v1 = newVolume(vid1,
                            ns1);
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "kristafke");
     createSnapshot(*v1, SnapshotName("snapshot1"));
@@ -59,7 +59,7 @@ TEST_P(LocalRestartTestNoBackend, restartWithSnapshot1)
     ASSERT_FALSE(v1 = getVolume(vid1));
     ASSERT_NO_THROW(v1 = localRestart(ns1));
     ASSERT_TRUE(getVolume(vid1) != nullptr);
-    checkVolume(*v1, 0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     EXPECT_FALSE(v1->isSyncedToBackendUpTo(SnapshotName("snapshot1")));
 }
 

--- a/src/volumedriver/test/MDSVolumeTest.cpp
+++ b/src/volumedriver/test/MDSVolumeTest.cpp
@@ -181,7 +181,7 @@ protected:
             SCOPED_BLOCK_BACKEND(*v);
 
             writeToVolume(*v,
-                          v->getClusterMultiplier() * CachePage::capacity(),
+                          Lba(v->getClusterMultiplier() * CachePage::capacity()),
                           v->getClusterSize(),
                           pattern);
 
@@ -190,7 +190,7 @@ protected:
                 mds_manager_->stop_one(ncfgs[0]);
 
                 checkVolume(*v,
-                            0,
+                            Lba(0),
                             v->getClusterSize(),
                             "");
             }
@@ -208,7 +208,7 @@ protected:
                          true);
 
             checkVolume(*v,
-                        v->getClusterMultiplier() * CachePage::capacity(),
+                        Lba(v->getClusterMultiplier() * CachePage::capacity()),
                         v->getClusterSize(),
                         pattern);
         }
@@ -224,7 +224,7 @@ protected:
                      true);
 
         checkVolume(*v,
-                    v->getClusterMultiplier() * CachePage::capacity(),
+                    Lba(v->getClusterMultiplier() * CachePage::capacity()),
                     v->getClusterSize(),
                     pattern);
     }
@@ -242,7 +242,7 @@ protected:
             SCOPED_BLOCK_BACKEND(*v);
 
             writeToVolume(*v,
-                          v->getClusterMultiplier() * CachePage::capacity(),
+                          Lba(v->getClusterMultiplier() * CachePage::capacity()),
                           v->getClusterSize(),
                           pattern1);
         }
@@ -253,7 +253,7 @@ protected:
         const std::string pattern2("Such A Little Thing Makes Such A Big Difference");
 
         writeToVolume(*v,
-                      2 * v->getClusterMultiplier() * CachePage::capacity(),
+                      Lba(2 * v->getClusterMultiplier() * CachePage::capacity()),
                       v->getClusterSize(),
                       pattern2);
 
@@ -264,7 +264,7 @@ protected:
             mds_manager_->stop_one(ncfgs[0]);
 
             checkVolume(*v,
-                        0,
+                        Lba(0),
                         v->getClusterSize(),
                         "");
         }
@@ -282,12 +282,12 @@ protected:
                      true);
 
         checkVolume(*v,
-                    v->getClusterMultiplier() * CachePage::capacity(),
+                    Lba(v->getClusterMultiplier() * CachePage::capacity()),
                     v->getClusterSize(),
                     pattern1);
 
         checkVolume(*v,
-                    2 * v->getClusterMultiplier() * CachePage::capacity(),
+                    Lba(2 * v->getClusterMultiplier() * CachePage::capacity()),
                     v->getClusterSize(),
                     pattern2);
 
@@ -302,12 +302,12 @@ protected:
                      true);
 
         checkVolume(*v,
-                    v->getClusterMultiplier() * CachePage::capacity(),
+                    Lba(v->getClusterMultiplier() * CachePage::capacity()),
                     v->getClusterSize(),
                     pattern1);
 
         checkVolume(*v,
-                    2 * v->getClusterMultiplier() * CachePage::capacity(),
+                    Lba(2 * v->getClusterMultiplier() * CachePage::capacity()),
                     v->getClusterSize(),
                     pattern2);
     }
@@ -387,7 +387,7 @@ protected:
             for (size_t i = 0; i < clusters; ++i)
             {
                 writeToVolume(*&v,
-                              i * v.getClusterMultiplier(),
+                              Lba(i * v.getClusterMultiplier()),
                               csize,
                               make_pattern(worker_iterations,
                                            i));
@@ -398,7 +398,7 @@ protected:
             for (size_t i = 0; i < clusters; ++i)
             {
                 checkVolume(*&v,
-                            i * v.getClusterMultiplier(),
+                            Lba(i * v.getClusterMultiplier()),
                             csize,
                             make_pattern(worker_iterations,
                                          i));
@@ -485,7 +485,7 @@ protected:
         const size_t wsize(v.getClusterSize());
 
         writeToVolume(*&v,
-                      0,
+                      Lba(0),
                       wsize,
                       fst_cluster_pattern);
 
@@ -496,7 +496,7 @@ protected:
         for (size_t i = 0; i < nclusters; ++i)
         {
             writeToVolume(v,
-                          v.getClusterMultiplier(),
+                          Lba(v.getClusterMultiplier()),
                           wsize,
                           tmp_pattern);
         }
@@ -506,7 +506,7 @@ protected:
         waitForThisBackendWrite(v);
 
         writeToVolume(v,
-                      v.getClusterMultiplier(),
+                      Lba(v.getClusterMultiplier()),
                       wsize,
                       snd_cluster_pattern);
 
@@ -669,7 +669,7 @@ TEST_P(MDSVolumeTest, broken_config_update)
     const size_t wsize(v->getClusterSize() * CachePage::capacity() * 3);
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   wsize,
                   pattern);
 
@@ -689,7 +689,7 @@ TEST_P(MDSVolumeTest, broken_config_update)
               ncfgs2);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 wsize,
                 pattern);
 }
@@ -710,7 +710,7 @@ TEST_P(MDSVolumeTest, sole_mds_temporarily_gone)
     const size_t wsize(v->getClusterSize());
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   wsize,
                   pattern);
 
@@ -721,12 +721,12 @@ TEST_P(MDSVolumeTest, sole_mds_temporarily_gone)
     const std::string pattern2("test2");
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   wsize,
                   pattern2);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 wsize,
                 pattern2);
 
@@ -737,7 +737,7 @@ TEST_P(MDSVolumeTest, sole_mds_temporarily_gone)
                     snap);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 wsize,
                 pattern);
 }
@@ -758,7 +758,7 @@ TEST_P(MDSVolumeTest, slave_catchup)
 
     const std::string pattern1("first");
     writeToVolume(*v,
-                  v->getClusterMultiplier(),
+                  Lba(v->getClusterMultiplier()),
                   v->getClusterSize(),
                   pattern1);
 
@@ -772,7 +772,7 @@ TEST_P(MDSVolumeTest, slave_catchup)
 
     const std::string pattern2("second");
     writeToVolume(*v,
-                  2 * v->getClusterMultiplier(),
+                  Lba(2 * v->getClusterMultiplier()),
                   v->getClusterSize(),
                   pattern2);
 
@@ -839,7 +839,7 @@ TEST_P(MDSVolumeTest, catch_up)
     {
         const auto pattern(boost::lexical_cast<std::string>(i));
         writeToVolume(*v,
-                      i * v->getClusterMultiplier() * CachePage::capacity(),
+                      Lba(i * v->getClusterMultiplier() * CachePage::capacity()),
                       csize,
                       pattern);
         scheduleBackendSync(*v);
@@ -879,7 +879,7 @@ TEST_P(MDSVolumeTest, catch_up)
     {
         const auto pattern(boost::lexical_cast<std::string>(i));
         checkVolume(*v,
-                    i * v->getClusterMultiplier() * CachePage::capacity(),
+                    Lba(i * v->getClusterMultiplier() * CachePage::capacity()),
                     csize,
                     pattern);
     }
@@ -1069,7 +1069,7 @@ TEST_P(MDSVolumeTest, futile_scrub)
     const std::string pattern1("one");
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   wsize,
                   pattern1);
 
@@ -1080,7 +1080,7 @@ TEST_P(MDSVolumeTest, futile_scrub)
     const std::string pattern2("two");
 
     writeToVolume(*v,
-                  wsize / v->getLBASize(),
+                  Lba(wsize / v->getLBASize()),
                   wsize,
                   pattern2);
 
@@ -1228,12 +1228,12 @@ TEST_P(MDSVolumeTest, scrub_with_slave_out_to_lunch)
                     relocmap);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 v->getClusterSize(),
                 pattern1);
 
     checkVolume(*v,
-                v->getClusterMultiplier(),
+                Lba(v->getClusterMultiplier()),
                 v->getClusterSize(),
                 pattern2);
 
@@ -1258,7 +1258,7 @@ TEST_P(MDSVolumeTest, scrub_id_mismatch)
 
     const std::string pattern("some data");
     writeToVolume(*v,
-                  v->getClusterMultiplier() * 2,
+                  Lba(v->getClusterMultiplier() * 2),
                   v->getClusterSize(),
                   pattern);
 
@@ -1444,7 +1444,7 @@ TEST_P(MDSVolumeTest, local_restart_of_pristine_clone_with_empty_mds)
 
     const std::string pattern("template content");
     writeToVolume(*p,
-                  0,
+                  Lba(0),
                   p->getClusterSize(),
                   pattern);
 
@@ -1498,7 +1498,7 @@ TEST_P(MDSVolumeTest, local_restart_of_pristine_clone_with_empty_mds)
     c = getVolume(VolumeId(cns->ns().str()));
 
     checkVolume(*c,
-                0,
+                Lba(0),
                 c->getClusterSize(),
                 pattern);
 }
@@ -1527,7 +1527,7 @@ TEST_P(MDSVolumeTest, incremental_update_and_snapshots)
                    Reset::F);
 
     writeToVolume(*v,
-                  v->getClusterMultiplier() * 2,
+                  Lba(v->getClusterMultiplier() * 2),
                   v->getClusterSize(),
                   "one");
 
@@ -1544,7 +1544,7 @@ TEST_P(MDSVolumeTest, incremental_update_and_snapshots)
                    Reset::F);
 
     writeToVolume(*v,
-                  v->getClusterMultiplier() * 2,
+                  Lba(v->getClusterMultiplier() * 2),
                   v->getClusterSize(),
                   "two");
 
@@ -1591,7 +1591,7 @@ TEST_P(MDSVolumeTest, table_counters)
                    Reset::F);
 
     writeToVolume(*v,
-                  v->getClusterMultiplier() * 2,
+                  Lba(v->getClusterMultiplier() * 2),
                   v->getClusterSize(),
                   "one");
 
@@ -1616,7 +1616,7 @@ TEST_P(MDSVolumeTest, table_counters)
                    Reset::F);
 
     writeToVolume(*v,
-                  v->getClusterMultiplier() * 2,
+                  Lba(v->getClusterMultiplier() * 2),
                   v->getClusterSize(),
                   "two");
 
@@ -1688,7 +1688,7 @@ TEST_P(MDSVolumeTest, no_failover_on_owner_tag_mismatch)
                      new_owner_tag());
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getClusterSize(),
                   pattern);
 

--- a/src/volumedriver/test/MTVolumeTester.cpp
+++ b/src/volumedriver/test/MTVolumeTester.cpp
@@ -59,7 +59,7 @@ public:
 
 
         const std::string pattern("12345678");
-        writeToVolume(*v, 0, size, pattern);
+        writeToVolume(*v, Lba(0), size, pattern);
 
         boost::thread c1(boost::bind(&VolManagerTestSetup::checkVolume,
                                      boost::ref(*v),

--- a/src/volumedriver/test/MetaDataStoreBuilderTest.cpp
+++ b/src/volumedriver/test/MetaDataStoreBuilderTest.cpp
@@ -118,7 +118,7 @@ TEST_P(MetaDataStoreBuilderTest, basics)
 
     const std::string pattern1("before-first-snapshot");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getSize() / 2,
                   pattern1);
 
@@ -134,7 +134,7 @@ TEST_P(MetaDataStoreBuilderTest, basics)
 
     const std::string pattern2("before-second-snapshot");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getSize() / 4,
                   pattern2);
 
@@ -159,7 +159,7 @@ TEST_P(MetaDataStoreBuilderTest, clone)
 
     const std::string pattern1("parent");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getSize() / 2,
                   pattern1);
 
@@ -175,7 +175,7 @@ TEST_P(MetaDataStoreBuilderTest, clone)
     const std::string pattern2("clone");
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getSize() / 4,
                   pattern2);
 

--- a/src/volumedriver/test/MetaDataStoreTest.cpp
+++ b/src/volumedriver/test/MetaDataStoreTest.cpp
@@ -651,7 +651,7 @@ TEST_P(MetaDataStoreTest, DataStoreMap)
 			     ns);
 
     // This depends on clustersize, sectorsize and such!!
-    writeToVolume(*vol_, 0, 8192, "pattern");
+    writeToVolume(*vol_, Lba(0), 8192, "pattern");
     Counter c;
     vol_->scheduleBackendSync();
     waitForThisBackendWrite(*vol_);
@@ -661,9 +661,9 @@ TEST_P(MetaDataStoreTest, DataStoreMap)
 
     ASSERT_EQ(2U, c.map.size());
 
-    writeToVolume(*vol_,0, 4096, "pattern");
+    writeToVolume(*vol_,Lba(0), 4096, "pattern");
 
-    writeToVolume(*vol_, 13,4096,"pattern");
+    writeToVolume(*vol_, Lba(13), 4096,"pattern");
 
     c.map.clear();
     vol_->scheduleBackendSync();
@@ -673,7 +673,7 @@ TEST_P(MetaDataStoreTest, DataStoreMap)
                                                        100000));
     ASSERT_EQ(3U, c.map.size());
 
-    writeToVolume(*vol_, 25,4096,"pattern");
+    writeToVolume(*vol_, Lba(25),4096,"pattern");
 
     c.map.clear();
     vol_->scheduleBackendSync();

--- a/src/volumedriver/test/PrefetchThreadTest.cpp
+++ b/src/volumedriver/test/PrefetchThreadTest.cpp
@@ -43,7 +43,7 @@ TEST_P(PrefetchThreadTest, test_one)
     for(size_t i = 0; i < numwrites; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "Superflous");
     }
@@ -73,7 +73,7 @@ TEST_P(PrefetchThreadTest, test_two)
     for(size_t i = 0; i < numwrites; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       scoSize,
                       "Superflous");
     }

--- a/src/volumedriver/test/ReadParallelismTest.cpp
+++ b/src/volumedriver/test/ReadParallelismTest.cpp
@@ -59,7 +59,7 @@ struct VolumeReader
         {
             const uint64_t lba = dist(gen_);
             api::Read(v_,
-                      lba*8,
+                      Lba(lba*8),
                       buf_.data(),
                       len_);
         }
@@ -141,7 +141,7 @@ public:
         {
             VERIFY(4096*sco_multiplier == sco_size);
             writeToVolume(*v,
-                          i*8,
+                          Lba(i*8),
                           4096*sco_multiplier,
                           "kutmetperen");
         }

--- a/src/volumedriver/test/ResourceLimitTest.cpp
+++ b/src/volumedriver/test/ResourceLimitTest.cpp
@@ -94,7 +94,7 @@ TEST_P(ResourceLimitTest, scrutinize_metadata_freespace_when_cloning_or_restarti
                           ns1);
     ASSERT_TRUE(v != nullptr);
 
-    writeToVolume(*v, 0, 65536, vname);
+    writeToVolume(*v, Lba(0), 65536, vname);
     const SnapshotName snap("snap");
     v->createSnapshot(snap);
     waitForThisBackendWrite(*v);

--- a/src/volumedriver/test/SCOWrittenToBackendActionTest.cpp
+++ b/src/volumedriver/test/SCOWrittenToBackendActionTest.cpp
@@ -154,7 +154,7 @@ protected:
             SCOPED_BLOCK_BACKEND(*v);
 
             writeToVolume(*v,
-                          0,
+                          Lba(0),
                           cs * sm * tm,
                           "of no importance whatsoever");
 

--- a/src/volumedriver/test/ScrubberTest.cpp
+++ b/src/volumedriver/test/ScrubberTest.cpp
@@ -149,8 +149,8 @@ TEST_P(ScrubberTest, DeletedSnap)
         ss << i;
         what = ss.str();
 
-        writeToVolume(*v1, 0, default_cluster_size(),what);
-        writeToVolume(*v1, 1 << 10, default_cluster_size(), what + "-" );
+        writeToVolume(*v1, Lba(0), default_cluster_size(),what);
+        writeToVolume(*v1, Lba(1ULL << 10), default_cluster_size(), what + "-" );
     }
 
     const SnapshotName snap1("snap1");
@@ -189,8 +189,8 @@ TEST_P(ScrubberTest, DeletedSnap2)
         ss << i;
         what = ss.str();
 
-        writeToVolume(*v1, 0, default_cluster_size(), what);
-        writeToVolume(*v1, 1 << 10, default_cluster_size(), what + "-" );
+        writeToVolume(*v1, Lba(0), default_cluster_size(), what);
+        writeToVolume(*v1, Lba(1ULL << 10), default_cluster_size(), what + "-" );
     }
 
     const SnapshotName snap1("snap1");
@@ -259,8 +259,8 @@ TEST_P(ScrubberTest, GetWork)
         ss << i;
         what = ss.str();
 
-        writeToVolume(*v1, 0, default_cluster_size(),what);
-        writeToVolume(*v1, 1 << 10, default_cluster_size(), what + "-" );
+        writeToVolume(*v1, Lba(0), default_cluster_size(),what);
+        writeToVolume(*v1, Lba(1ULL << 10), default_cluster_size(), what + "-" );
     }
 
     {
@@ -325,17 +325,17 @@ TEST_P(ScrubberTest, GetWork2)
                        ns);
 
     const SnapshotName snapa("A");
-    writeToVolume(*v, 0, default_cluster_size(), snapa);
+    writeToVolume(*v, Lba(0), default_cluster_size(), snapa);
     v->createSnapshot(snapa);
     waitForThisBackendWrite(*v);
 
     const SnapshotName snapb("B");
-    writeToVolume(*v, 0, default_cluster_size(), snapb);
+    writeToVolume(*v, Lba(0), default_cluster_size(), snapb);
     v->createSnapshot(snapb);
     waitForThisBackendWrite(*v);
 
     const SnapshotName snapc("C");
-    writeToVolume(*v, 0, default_cluster_size(), snapc);
+    writeToVolume(*v, Lba(0), default_cluster_size(), snapc);
     v->createSnapshot(snapc);
     waitForThisBackendWrite(*v);
 
@@ -442,8 +442,8 @@ TEST_P(ScrubberTest, Serialization)
         ss << i;
         what = ss.str();
 
-        writeToVolume(*v1, 0, default_cluster_size(),what);
-        writeToVolume(*v1, 1 << 10, default_cluster_size(), what + "-" );
+        writeToVolume(*v1, Lba(0), default_cluster_size(),what);
+        writeToVolume(*v1, Lba(1ULL << 10), default_cluster_size(), what + "-" );
     }
 
     const SnapshotName snap1("snap1");
@@ -463,8 +463,8 @@ TEST_P(ScrubberTest, Serialization)
     ASSERT_NO_THROW(apply_scrubbing(vid,
                                     scrub_result));
 
-    checkVolume(*v1, 0, default_cluster_size(),what);
-    checkVolume(*v1,1 << 10, default_cluster_size(), what + "-");
+    checkVolume(*v1, Lba(0), default_cluster_size(),what);
+    checkVolume(*v1, Lba(1ULL << 10), default_cluster_size(), what + "-");
     EXPECT_EQ(default_cluster_size() * 2,
               v1->getSnapshotBackendSize(snap1));
 }
@@ -496,8 +496,8 @@ TEST_P(ScrubberTest, ScrubNothing)
         ASSERT_EQ(0U, scrub_work_units.size());
     }
 
-    writeToVolume(*v1, 0, default_cluster_size(), "arner");
-    checkVolume(*v1, 0, default_cluster_size(), "arner");
+    writeToVolume(*v1, Lba(0), default_cluster_size(), "arner");
+    checkVolume(*v1, Lba(0), default_cluster_size(), "arner");
     destroyVolume(v1,
                   DeleteLocalData::T,
                   RemoveVolumeCompletely::T);
@@ -522,7 +522,7 @@ TEST_P(ScrubberTest, SimpleScrub2)
         ss << i;
         what = ss.str();
 
-        writeToVolume(*v1, 0, default_cluster_size(),what);
+        writeToVolume(*v1, Lba(0), default_cluster_size(),what);
     }
 
     v1->createSnapshot(SnapshotName("snap1"));
@@ -535,7 +535,7 @@ TEST_P(ScrubberTest, SimpleScrub2)
     ASSERT_NO_THROW(scrub_result = do_scrub(scrub_work_units.front()));
     ASSERT_NO_THROW(apply_scrubbing(vid,
                                     scrub_result));
-    checkVolume(*v1, 0, default_cluster_size(),what);
+    checkVolume(*v1, Lba(0), default_cluster_size(),what);
 }
 
 TEST_P(ScrubberTest, SimpleScrub3)
@@ -557,8 +557,8 @@ TEST_P(ScrubberTest, SimpleScrub3)
         ss << i;
         what = ss.str();
 
-        writeToVolume(*v1, 0, default_cluster_size(),what);
-        writeToVolume(*v1, 1 << 10, default_cluster_size(), what + "-" );
+        writeToVolume(*v1, Lba(0), default_cluster_size(),what);
+        writeToVolume(*v1, Lba(1ULL << 10), default_cluster_size(), what + "-" );
     }
 
     v1->createSnapshot(SnapshotName("snap1"));
@@ -577,8 +577,8 @@ TEST_P(ScrubberTest, SimpleScrub3)
                                     scrub_result,
                                     ScrubbingCleanup::OnError));
 
-    checkVolume(*v1, 0, default_cluster_size(),what);
-    checkVolume(*v1,1 << 10, default_cluster_size(), what + "-");
+    checkVolume(*v1, Lba(0), default_cluster_size(),what);
+    checkVolume(*v1, Lba(1ULL << 10), default_cluster_size(), what + "-");
     destroyVolume(v1,
                   DeleteLocalData::T,
                   RemoveVolumeCompletely::T);
@@ -604,9 +604,9 @@ TEST_P(ScrubberTest, SimpleScrub4)
         ss << i;
         what = ss.str();
 
-        writeToVolume(*v1, 0, default_cluster_size(),what);
-        writeToVolume(*v1, 1 << 10, default_cluster_size(), what + "-" );
-        writeToVolume(*v1, 1 << 15, default_cluster_size(), what + "--" );
+        writeToVolume(*v1, Lba(0), default_cluster_size(),what);
+        writeToVolume(*v1, Lba(1ULL << 10), default_cluster_size(), what + "-" );
+        writeToVolume(*v1, Lba(1ULL << 15), default_cluster_size(), what + "--" );
     }
 
     v1->createSnapshot(SnapshotName("snap1"));
@@ -623,9 +623,9 @@ TEST_P(ScrubberTest, SimpleScrub4)
     ASSERT_NO_THROW(apply_scrubbing(vid,
                                     scrub_result,
                                     ScrubbingCleanup::OnError));
-    checkVolume(*v1, 0, default_cluster_size(),what);
-    checkVolume(*v1,1 << 10, default_cluster_size(), what + "-");
-    checkVolume(*v1,1 << 15, default_cluster_size(), what + "--");
+    checkVolume(*v1, Lba(0), default_cluster_size(),what);
+    checkVolume(*v1, Lba(1ULL << 10), default_cluster_size(), what + "-");
+    checkVolume(*v1, Lba(1ULL << 15), default_cluster_size(), what + "--");
 }
 
 TEST_P(ScrubberTest, SmallRegionScrub1)
@@ -647,11 +647,11 @@ TEST_P(ScrubberTest, SmallRegionScrub1)
         ss << i;
         what = ss.str();
         writeToVolume(*v1,
-                      i * default_cluster_multiplier(),
+                      Lba(i * default_cluster_multiplier()),
                       default_cluster_size(),
                       what);
         writeToVolume(*v1,
-                      513 * default_cluster_multiplier(),
+                      Lba(513 * default_cluster_multiplier()),
                       default_cluster_size(),
                       "rest");
     }
@@ -676,12 +676,12 @@ TEST_P(ScrubberTest, SmallRegionScrub1)
         what = ss.str();
 
         checkVolume(*v1,
-                    i * default_cluster_multiplier(),
+                    Lba(i * default_cluster_multiplier()),
                     default_cluster_size(),
                     what);
     }
     checkVolume(*v1,
-                513 * default_cluster_multiplier(),
+                Lba(513 * default_cluster_multiplier()),
                 default_cluster_size(),
                 "rest");
 
@@ -703,14 +703,14 @@ TEST_P(ScrubberTest, CloneScrubbin)
 
     for(int i =0; i < num_writes; ++i)
     {
-        writeToVolume(*v1, 0, default_cluster_size(), "xxx");
-        writeToVolume(*v1, default_cluster_multiplier(), default_cluster_size(), "xxx");
-        writeToVolume(*v1, 2 * default_cluster_multiplier(), default_cluster_size(), "xxx");
+        writeToVolume(*v1, Lba(0), default_cluster_size(), "xxx");
+        writeToVolume(*v1, Lba(default_cluster_multiplier()), default_cluster_size(), "xxx");
+        writeToVolume(*v1, Lba(2 * default_cluster_multiplier()), default_cluster_size(), "xxx");
     }
 
-    writeToVolume(*v1, 0, default_cluster_size(), "bart");
-    writeToVolume(*v1, default_cluster_multiplier(), default_cluster_size(), "arne");
-    writeToVolume(*v1, 2 * default_cluster_multiplier(), default_cluster_size(), "immanuel");
+    writeToVolume(*v1, Lba(0), default_cluster_size(), "bart");
+    writeToVolume(*v1, Lba(default_cluster_multiplier()), default_cluster_size(), "arne");
+    writeToVolume(*v1, Lba(2 * default_cluster_multiplier()), default_cluster_size(), "immanuel");
 
     const SnapshotName v1_snap1("v1_snap1");
 
@@ -733,23 +733,23 @@ TEST_P(ScrubberTest, CloneScrubbin)
     for(int i = 0; i < num_writes; ++i)
     {
         writeToVolume(*c1,
-                      default_cluster_multiplier(),
+                      Lba(default_cluster_multiplier()),
                       default_cluster_size(),
                       "blah");
 
         writeToVolume(*c1,
-                      2 * default_cluster_multiplier(),
+                      Lba(2 * default_cluster_multiplier()),
                       default_cluster_size(),
                       "blah");
     }
 
     writeToVolume(*c1,
-                  default_cluster_multiplier(),
+                  Lba(default_cluster_multiplier()),
                   default_cluster_size(),
                   "joost");
 
     writeToVolume(*c1,
-                  2 * default_cluster_multiplier(),
+                  Lba(2 * default_cluster_multiplier()),
                   default_cluster_size(),
                   "wouter");
 
@@ -773,13 +773,13 @@ TEST_P(ScrubberTest, CloneScrubbin)
     for(int i = 0; i < num_writes; ++i)
     {
         writeToVolume(*c2,
-                      2 * default_cluster_multiplier(),
+                      Lba(2 * default_cluster_multiplier()),
                       default_cluster_size(),
                       "fubar");
     }
 
     writeToVolume(*c2,
-                  2 * default_cluster_multiplier(),
+                  Lba(2 * default_cluster_multiplier()),
                   default_cluster_size(),
                   "wim");
 
@@ -790,15 +790,15 @@ TEST_P(ScrubberTest, CloneScrubbin)
 
     auto check_volumes([&]
     {
-        checkVolume(*v1, 0, default_cluster_size(), "bart");
-        checkVolume(*v1, default_cluster_multiplier(), default_cluster_size(), "arne");
-        checkVolume(*v1, 2 * default_cluster_multiplier(), default_cluster_size(), "immanuel");
-        checkVolume(*c1, 0, default_cluster_size(), "bart");
-        checkVolume(*c1, default_cluster_multiplier(), default_cluster_size(), "joost");
-        checkVolume(*c1, 2 * default_cluster_multiplier(), default_cluster_size(), "wouter");
-        checkVolume(*c2, 0, default_cluster_size(), "bart");
-        checkVolume(*c2, default_cluster_multiplier(), default_cluster_size(), "joost");
-        checkVolume(*c2, 2 * default_cluster_multiplier(), default_cluster_size(), "wim");
+        checkVolume(*v1, Lba(0), default_cluster_size(), "bart");
+        checkVolume(*v1, Lba(default_cluster_multiplier()), default_cluster_size(), "arne");
+        checkVolume(*v1, Lba(2 * default_cluster_multiplier()), default_cluster_size(), "immanuel");
+        checkVolume(*c1, Lba(0), default_cluster_size(), "bart");
+        checkVolume(*c1, Lba(default_cluster_multiplier()), default_cluster_size(), "joost");
+        checkVolume(*c1, Lba(2 * default_cluster_multiplier()), default_cluster_size(), "wouter");
+        checkVolume(*c2, Lba(0), default_cluster_size(), "bart");
+        checkVolume(*c2, Lba(default_cluster_multiplier()), default_cluster_size(), "joost");
+        checkVolume(*c2, Lba(2 * default_cluster_multiplier()), default_cluster_size(), "wim");
     });
 
     auto check_consistency([&](Volume& v)
@@ -913,13 +913,13 @@ TEST_P(ScrubberTest, idempotent_scrub_result_application)
 
     for(int i =0; i < num_writes; ++i)
     {
-        writeToVolume(*v1, 0, default_cluster_size(), "xxx");
-        writeToVolume(*v1, 8, default_cluster_size(), "xxx");
-        writeToVolume(*v1, 16, default_cluster_size(), "xxx");
+        writeToVolume(*v1, Lba(0), default_cluster_size(), "xxx");
+        writeToVolume(*v1, Lba(8), default_cluster_size(), "xxx");
+        writeToVolume(*v1, Lba(16), default_cluster_size(), "xxx");
     }
-    writeToVolume(*v1, 0, default_cluster_size(), "bart");
-    writeToVolume(*v1, 8, default_cluster_size(), "arne");
-    writeToVolume(*v1, 16, default_cluster_size(), "immanuel");
+    writeToVolume(*v1, Lba(0), default_cluster_size(), "bart");
+    writeToVolume(*v1, Lba(8), default_cluster_size(), "arne");
+    writeToVolume(*v1, Lba(16), default_cluster_size(), "immanuel");
 
     const SnapshotName snap1("snap1");
     v1->createSnapshot(snap1);
@@ -992,7 +992,7 @@ TEST_P(ScrubberTest, consistency)
 
     for(unsigned i =0; i < num_writes ; ++i)
     {
-        writeToVolume(*v1, 0, default_cluster_size(), "xxx");
+        writeToVolume(*v1, Lba(0), default_cluster_size(), "xxx");
     }
 
     const SnapshotName v1_snap1("v1_snap1");
@@ -1029,8 +1029,8 @@ TEST_P(ScrubberTest, consistency)
                                     scrub_result,
                                     ScrubbingCleanup::OnError));
 
-    checkVolume(*c1,0,default_cluster_size(),"xxx");
-    checkVolume(*v1,0,default_cluster_size(),"xxx");
+    checkVolume(*c1,Lba(0),default_cluster_size(),"xxx");
+    checkVolume(*v1,Lba(0),default_cluster_size(),"xxx");
 
     ASSERT_TRUE(c1->checkConsistency());
     ASSERT_TRUE(v1->checkConsistency());
@@ -1049,7 +1049,7 @@ TEST_P(ScrubberTest, backend_error_while_fetching_relocations)
     SharedVolumePtr v = newVolume(*wrns);
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   default_cluster_size(),
                   "0");
 
@@ -1058,7 +1058,7 @@ TEST_P(ScrubberTest, backend_error_while_fetching_relocations)
     for (size_t i = 0; i < overwrites; ++i)
     {
         writeToVolume(*v,
-                      v->getClusterMultiplier(),
+                      Lba(v->getClusterMultiplier()),
                       default_cluster_size(),
                       boost::lexical_cast<std::string>(i + 1));
     }
@@ -1088,12 +1088,12 @@ TEST_P(ScrubberTest, backend_error_while_fetching_relocations)
     EXPECT_FALSE(v->is_halted());
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 default_cluster_size(),
                 "0");
 
     checkVolume(*v,
-                v->getClusterMultiplier(),
+                Lba(v->getClusterMultiplier()),
                 default_cluster_size(),
                 boost::lexical_cast<std::string>(overwrites));
 }

--- a/src/volumedriver/test/SimpleBackupRestoreTest.cpp
+++ b/src/volumedriver/test/SimpleBackupRestoreTest.cpp
@@ -128,7 +128,7 @@ public:
 
         const std::string pattern("back up?");
         const size_t size = 1024 * 1024;
-        writeToVolume(*wov, 0, size, pattern);
+        writeToVolume(*wov, Lba(0), size, pattern);
         wov->createSnapshot(SnapshotName("snap"));
         waitForThisBackendWrite(*wov);
         destroyVolume(wov,
@@ -156,7 +156,7 @@ public:
                                          IgnoreFOCIfUnreachable::T);
                 }
                 SharedVolumePtr v = getVolume(vid);
-                checkVolume(*v, 0, size, pattern);
+                checkVolume(*v, Lba(0), size, pattern);
             }
         }
         else
@@ -191,7 +191,7 @@ TEST_P(SimpleBackupRestoreTest, no_promotion_without_snapshot)
 
     const std::string pattern("back up?");
     const size_t size = 1024 * 1024;
-    writeToVolume(*wov, 0, size, pattern);
+    writeToVolume(*wov, Lba(0), size, pattern);
     wov->scheduleBackendSync();
     waitForThisBackendWrite(*wov);
     destroyVolume(wov,
@@ -230,7 +230,7 @@ TEST_P(SimpleBackupRestoreTest, no_promotion_without_snapshot)
     }
 
     SharedVolumePtr v = getVolume(vid);
-    checkVolume(*v, 0, size, pattern);
+    checkVolume(*v, Lba(0), size, pattern);
 }
 
 TEST_P(SimpleBackupRestoreTest, discard_trailing_tlogs_on_promotion)
@@ -251,11 +251,11 @@ TEST_P(SimpleBackupRestoreTest, discard_trailing_tlogs_on_promotion)
 
     const std::string pattern("back up?");
     const size_t size = 1024 * 1024;
-    writeToVolume(*wov, 0, size, pattern);
+    writeToVolume(*wov, Lba(0), size, pattern);
     wov->createSnapshot(SnapshotName("snap"));
 
     const std::string pattern2("This is invisible. Or is it?");
-    writeToVolume(*wov, 0, size, pattern2);
+    writeToVolume(*wov, Lba(0), size, pattern2);
     wov->scheduleBackendSync();
     waitForThisBackendWrite(*wov);
     destroyVolume(wov,
@@ -279,7 +279,7 @@ TEST_P(SimpleBackupRestoreTest, discard_trailing_tlogs_on_promotion)
     }
 
     SharedVolumePtr v = getVolume(vid);
-    checkVolume(*v, 0, size, pattern);
+    checkVolume(*v, Lba(0), size, pattern);
 }
 
 TEST_P(SimpleBackupRestoreTest, rollback_to_previous_snap_if_snapshot_didnt_make_it)
@@ -301,12 +301,12 @@ TEST_P(SimpleBackupRestoreTest, rollback_to_previous_snap_if_snapshot_didnt_make
 
     const std::string pattern("a mysteriously returning message");
     const size_t size = 1024 * 1024;
-    writeToVolume(*wov, 0, size, pattern);
+    writeToVolume(*wov, Lba(0), size, pattern);
     const SnapshotName snap("snap");
     wov->createSnapshot(snap);
     waitForThisBackendWrite(*wov);
     const std::string pattern2("a mysteriously disappearing message");
-    writeToVolume(*wov, 0, size, pattern2);
+    writeToVolume(*wov, Lba(0), size, pattern2);
     wov->scheduleBackendSync();
     waitForThisBackendWrite(*wov);
     {
@@ -337,7 +337,7 @@ TEST_P(SimpleBackupRestoreTest, rollback_to_previous_snap_if_snapshot_didnt_make
     }
 
     SharedVolumePtr v = getVolume(vid);
-    checkVolume(*v, 0, size, pattern);
+    checkVolume(*v, Lba(0), size, pattern);
     std::list<SnapshotName> snaps;
     v->listSnapshots(snaps);
     EXPECT_EQ(1U, snaps.size());
@@ -363,12 +363,12 @@ TEST_P(SimpleBackupRestoreTest,
 
     const std::string pattern("blah");
     const size_t size = 1024 * 1024;
-    writeToVolume(*wov, 0, size, pattern);
+    writeToVolume(*wov, Lba(0), size, pattern);
     const SnapshotName snap("snap");
     wov->createSnapshot(snap);
     waitForThisBackendWrite(*wov);
     const std::string pattern2("meh");
-    writeToVolume(*wov, 0, size, pattern2);
+    writeToVolume(*wov, Lba(0), size, pattern2);
     wov->scheduleBackendSync();
     waitForThisBackendWrite(*wov);
 
@@ -376,7 +376,7 @@ TEST_P(SimpleBackupRestoreTest,
         SCOPED_DESTROY_WRITE_ONLY_VOLUME_UNBLOCK_BACKEND_FOR_BACKEND_RESTART(wov, 3);
         wov->createSnapshot(SnapshotName("snap2"));
         const std::string pattern3("blub");
-        writeToVolume(*wov, 0, size, pattern3);
+        writeToVolume(*wov, Lba(0), size, pattern3);
         wov->scheduleBackendSync();
 
         const SnapshotPersistor& sp =

--- a/src/volumedriver/test/SimpleVolumeTest.cpp
+++ b/src/volumedriver/test/SimpleVolumeTest.cpp
@@ -60,7 +60,7 @@ public:
 
         const std::string pattern("some data");
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       v->getClusterSize(),
                       pattern);
 
@@ -240,7 +240,7 @@ struct VolumeWriter
     {
         while(not stop_)
         {
-            VolManagerTestSetup::writeToVolume(*vol_,0, 4096,"blah");
+            VolManagerTestSetup::writeToVolume(*vol_,Lba(0), 4096,"blah");
             usleep(100);
         }
     }
@@ -295,25 +295,25 @@ TEST_P(SimpleVolumeTest, halted)
 
     ASSERT_TRUE(v != nullptr);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   pattern);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 pattern);
 
     v->halt();
 
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "fubar"),
                  std::exception);
 
     EXPECT_THROW(checkVolume(*v,
-                             0,
+                             Lba(0),
                              4096,
                              pattern),
                  std::exception);
@@ -329,29 +329,29 @@ TEST_P(SimpleVolumeTest, test1)
 			  ns);
     ASSERT_TRUE(v != nullptr);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "immanuel");
     writeToVolume(*v,
-                  4096,
+                  Lba(4096),
                   4096,
                   "joost");
 
     writeToVolume(*v,
-                  2*4096,
+                  Lba(2*4096),
                   4096,
                   "arne");
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "immanuel");
     checkVolume(*v,
-                4096,
+                Lba(4096),
                 4096,
                 "joost");
     checkVolume(*v,
-                2*4096,
+                Lba(2*4096),
                 4096,
                 "arne");
 }
@@ -366,21 +366,21 @@ TEST_P(SimpleVolumeTest, test2)
 			  ns);
     ASSERT_TRUE(v != nullptr);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "immanuel");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "joost");
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "arne");
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "arne");
 
@@ -400,7 +400,7 @@ TEST_P(SimpleVolumeTest, test3)
     ASSERT_TRUE(v != nullptr);
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "immanuel");
 
@@ -422,7 +422,7 @@ TEST_P(SimpleVolumeTest, test3)
                     snap1);
 
     checkVolume(*c,
-                0,
+                Lba(0),
                 4096,
                 "immanuel");
 }
@@ -439,7 +439,7 @@ TEST_P(SimpleVolumeTest, test4)
                   ns1);
     ASSERT_TRUE(v != nullptr);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "a");
 
@@ -459,18 +459,18 @@ TEST_P(SimpleVolumeTest, test4)
                      ns1,
                      snap1);
     writeToVolume(*c1,
-                  4096,
+                  Lba(4096),
                   4096,
                   "b");
 
     checkVolume(*c1,
-                0,
+                Lba(0),
                 4096,
                 "a");
 
 
     checkVolume(*c1,
-                4096,
+                Lba(4096),
                 4096,
                 "b");
 
@@ -491,21 +491,21 @@ TEST_P(SimpleVolumeTest, test4)
     ASSERT_TRUE(c2 != nullptr);
 
      checkVolume(*c2,
-                4096,
+                 Lba(4096),
                  4096,
                  "b");
     checkVolume(*c2,
-                0,
+                Lba(0),
                 4096,
                 "a");
 
 
     writeToVolume(*c2,
-                  2*4096,
+                  Lba(2*4096),
                   4096,
                   "c");
     checkVolume(*c2,
-                2*4096,
+                Lba(2*4096),
                 4096,
                 "c");
 
@@ -527,25 +527,25 @@ TEST_P(SimpleVolumeTest, test4)
     ASSERT_TRUE(c3 != nullptr);
 
     checkVolume(*c3,
-                0,
+                Lba(0),
                 4096,
                 "a");
 
     checkVolume(*c3,
-                4096,
+                Lba(4096),
                 4096,
                 "b");
     checkVolume(*c3,
-                2*4096,
+                Lba(2*4096),
                 4096,
                 "c");
     writeToVolume(*c3,
-                  3*4096,
+                  Lba(3*4096),
                   4096,
                   "d");
 
     checkVolume(*c3,
-                3*4096,
+                Lba(3*4096),
                 4096,
                 "d");
 
@@ -582,13 +582,13 @@ TEST_P(SimpleVolumeTest, switchTLog)
     uint64_t clusters = VolManager::get()->number_of_scos_in_tlog.value() *  v->getSCOMultiplier();
 
     for(unsigned i = 0; i < clusters - 1; ++i) {
-        writeToVolume(*v, 0, 4096, &v1[0]);
+        writeToVolume(*v, Lba(0), 4096, &v1[0]);
     }
 
     ASSERT_EQ(init_tlog,
               v->getSnapshotManagement().getCurrentTLogId());
 
-    writeToVolume(*v, 0, 4096, &v1[0]);
+    writeToVolume(*v, Lba(0), 4096, &v1[0]);
 
     ASSERT_NE(init_tlog,
               v->getSnapshotManagement().getCurrentTLogId());
@@ -609,19 +609,18 @@ TEST_P(SimpleVolumeTest, restoreSnapshot)
     const std::string snapshotName1("nikon");
     const std::string snapshotName2("canon");
 
+    writeToVolume(*v, Lba(0), count, snapshotName1);
+    writeToVolume(*v, Lba(0), count, snapshotName2);
 
-    writeToVolume(*v, 0, count, snapshotName1);
-    writeToVolume(*v, 0, count, snapshotName2);
-
-    checkVolume(*v, 0, count, snapshotName2);
+    checkVolume(*v, Lba(0), count, snapshotName2);
 
     {
         SCOPED_BLOCK_BACKEND(*v);
         ASSERT_NO_THROW(createSnapshot(*v, snapshotName1));
-        writeToVolume(*v, 0, count, snapshotName1);
+        writeToVolume(*v, Lba(0), count, snapshotName1);
 
         EXPECT_THROW(createSnapshot(*v, snapshotName2), PreviousSnapshotNotOnBackendException);
-        writeToVolume(*v,0, count,"bbbbb");
+        writeToVolume(*v, Lba(0), count,"bbbbb");
 
         EXPECT_THROW(restoreSnapshot(*v, snapshotName1), fungi::IOException);
 
@@ -632,7 +631,7 @@ TEST_P(SimpleVolumeTest, restoreSnapshot)
     {
         SCOPED_BLOCK_BACKEND(*v);
         ASSERT_NO_THROW(createSnapshot(*v, snapshotName2));
-        writeToVolume(*v,0, count,"ccccc");
+        writeToVolume(*v, Lba(0), count,"ccccc");
     }
     waitForThisBackendWrite(*v);
 
@@ -640,12 +639,12 @@ TEST_P(SimpleVolumeTest, restoreSnapshot)
     EXPECT_NO_THROW(restoreSnapshot(*v, snapshotName1));
 
 
-    checkVolume(*v,0,count,snapshotName2);
+    checkVolume(*v, Lba(0),count,snapshotName2);
 
     // we should be able to rewrite now:
-    writeToVolume(*v,0, count,"aaaaa");
+    writeToVolume(*v, Lba(0), count,"aaaaa");
 
-    checkVolume(*v,0,count,"aaaaa");
+    checkVolume(*v, Lba(0),count,"aaaaa");
 
     // make sure tlogs are not leaked
     waitForThisBackendWrite(*v);
@@ -695,10 +694,10 @@ TEST_P(SimpleVolumeTest, restoreSnapshot2)
     EXPECT_TRUE(v->isCacheOnRead());
     EXPECT_FALSE(v->isCacheOnWrite());
 
-    writeToVolume(*v, 0, count, snapshotName1);
-    writeToVolume(*v, 0, count, snapshotName2);
+    writeToVolume(*v, Lba(0), count, snapshotName1);
+    writeToVolume(*v, Lba(0), count, snapshotName2);
 
-    checkVolume(*v, 0, count, snapshotName2);
+    checkVolume(*v, Lba(0), count, snapshotName2);
 
     {
         SCOPED_BLOCK_BACKEND(*v);
@@ -710,10 +709,10 @@ TEST_P(SimpleVolumeTest, restoreSnapshot2)
         EXPECT_TRUE(v->isCacheOnRead());
         EXPECT_FALSE(v->isCacheOnWrite());
 
-        writeToVolume(*v, 0, count, snapshotName1);
+        writeToVolume(*v, Lba(0), count, snapshotName1);
 
         EXPECT_THROW(createSnapshot(*v, snapshotName2), PreviousSnapshotNotOnBackendException);
-        writeToVolume(*v,0, count,"cnanakos1");
+        writeToVolume(*v, Lba(0), count,"cnanakos1");
 
         EXPECT_THROW(restoreSnapshot(*v, snapshotName1), fungi::IOException);
     }
@@ -733,7 +732,7 @@ TEST_P(SimpleVolumeTest, restoreSnapshot2)
         EXPECT_TRUE(v->isCacheOnRead());
         EXPECT_FALSE(v->isCacheOnWrite());
 
-        writeToVolume(*v,0, count,"cnanakos2");
+        writeToVolume(*v, Lba(0), count,"cnanakos2");
     }
 
     waitForThisBackendWrite(*v);
@@ -748,11 +747,11 @@ TEST_P(SimpleVolumeTest, restoreSnapshot2)
     EXPECT_TRUE(v->isCacheOnRead());
     EXPECT_FALSE(v->isCacheOnWrite());
 
-    checkVolume(*v,0,count,snapshotName2);
+    checkVolume(*v, Lba(0),count,snapshotName2);
 
-    writeToVolume(*v,0, count,"cnanakos4");
+    writeToVolume(*v, Lba(0), count,"cnanakos4");
 
-    checkVolume(*v,0,count,"cnanakos4");
+    checkVolume(*v, Lba(0),count,"cnanakos4");
 
     waitForThisBackendWrite(*v);
 
@@ -800,7 +799,7 @@ TEST_P(SimpleVolumeTest, restoreSnapshotWithFuckedUpTLogs)
 
     const std::string snapshotName1("nikon1");
 
-    writeToVolume(*v, 0, count, snapshotName1);
+    writeToVolume(*v, Lba(0), count, snapshotName1);
 
     createSnapshot(*v, snapshotName1);
     waitForThisBackendWrite(*v);
@@ -809,7 +808,7 @@ TEST_P(SimpleVolumeTest, restoreSnapshotWithFuckedUpTLogs)
     for (uint32_t i = 0 ; i < 5 * clustersInSco * scosInTlog; i++)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       count,
                       "there are no rules without exceptions, so there are rules without exceptions");
     }
@@ -819,7 +818,7 @@ TEST_P(SimpleVolumeTest, restoreSnapshotWithFuckedUpTLogs)
     for (uint32_t i = 0 ; i < 5 * clustersInSco * scosInTlog; i++)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       count,
                       "there are no rules without exceptions, so there are rules without exceptions");
     }
@@ -832,7 +831,7 @@ TEST_P(SimpleVolumeTest, restoreSnapshotWithFuckedUpTLogs)
     v->getBackendInterface()->remove(boost::lexical_cast<std::string>(tlog_id));
 
     ASSERT_NO_THROW(restoreSnapshot(*v, snapshotName1));
-    checkVolume(*v,0,count,snapshotName1);
+    checkVolume(*v, Lba(0),count,snapshotName1);
 }
 
 TEST_P(SimpleVolumeTest, restoreSnapshotWithFuckedUpNeededTLogs)
@@ -856,21 +855,21 @@ TEST_P(SimpleVolumeTest, restoreSnapshotWithFuckedUpNeededTLogs)
 
     //make sure we delete some tlog in the middle, not just the first one
     for (uint32_t i = 0 ; i < 5 * clustersInSco * scosInTlog; i++) {
-        writeToVolume(*v, 0, count, "should be overwritten");
+        writeToVolume(*v, Lba(0), count, "should be overwritten");
     }
 
     const TLogId tlog_id = v->getSnapshotManagement().getCurrentTLogId();
 
     for (uint32_t i = 0 ; i < 5 * clustersInSco * scosInTlog; i++)
     {
-        writeToVolume(*v, 0, count, "should be overwritten");
+        writeToVolume(*v, Lba(0), count, "should be overwritten");
     }
 
-    writeToVolume(*v, 0, count, snapshotName1);
+    writeToVolume(*v, Lba(0), count, snapshotName1);
 
     for (uint32_t i = 0 ; i < 5 * clustersInSco * scosInTlog; i++)
     {
-        writeToVolume(*v, 0, count, "there are no rules without exceptions, so there are rules without exceptions");
+        writeToVolume(*v, Lba(0), count, "there are no rules without exceptions, so there are rules without exceptions");
     }
 
     createSnapshot(*v, snapshotName1);
@@ -900,13 +899,13 @@ TEST_P(SimpleVolumeTest, dontLeakStorageOnSnapshotRollback)
     const int size = v->getClusterSize();
 
     const std::string pattern1 = "sco1";
-    writeToVolume(*v, 0, size, pattern1);
+    writeToVolume(*v, Lba(0), size, pattern1);
     createSnapshot(*v, "snap1");
 
     waitForThisBackendWrite(*v);
 
     const std::string pattern2 = "sco2";
-    writeToVolume(*v, 0, size, pattern2);
+    writeToVolume(*v, Lba(0), size, pattern2);
     createSnapshot(*v, "snap2");
 
     waitForThisBackendWrite(*v);
@@ -1090,7 +1089,7 @@ TEST_P(SimpleVolumeTest, LocalRestartClone)
     for(int i = 0; i < 10; i++)
     {
         writeToVolume(*v1,
-                      0,
+                      Lba(0),
                       4096,
                       "immanuel");
     }
@@ -1120,7 +1119,7 @@ TEST_P(SimpleVolumeTest, LocalRestartClone)
     ASSERT_TRUE(c != nullptr);
 
     checkVolume(*c,
-                0,
+                Lba(0),
                 4096,
                 "immanuel");
 }
@@ -1140,7 +1139,7 @@ TEST_P(SimpleVolumeTest, RollBackClone)
     {
 
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "immanuel");
     }
@@ -1173,15 +1172,15 @@ TEST_P(SimpleVolumeTest, RollBackClone)
     for(int i = 50; i < 100; i++)
     {
         writeToVolume(*v2,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "arne");
         writeToVolume(*v3,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "arne");
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "arne");
     }
@@ -1195,7 +1194,7 @@ TEST_P(SimpleVolumeTest, RollBackClone)
     for(int i = 50; i < 100; i++)
     {
         writeToVolume(*v2,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "kristaf");
     }
@@ -1448,7 +1447,7 @@ TEST_P(SimpleVolumeTest, consistency)
     {
 
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "kristaf");
     }
@@ -1479,7 +1478,7 @@ TEST_P(SimpleVolumeTest, consistencyClone)
     {
 
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "kristaf");
     }
@@ -1500,12 +1499,12 @@ TEST_P(SimpleVolumeTest, consistencyClone)
     for(int i = 0; i < (1024 ); i++)
     {
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "kristaf");
 
         writeToVolume(*v2,
-                      i*mult + 20,
+                      Lba(i*mult + 20),
                       v2->getClusterSize(),
                       "kristaf");
     }
@@ -1540,7 +1539,7 @@ TEST_P(SimpleVolumeTest,  readCacheHits)
     SharedVolumePtr v1 = newVolume(VolumeId("volume1"),
                            ns1);
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   v1->getClusterSize(),
                   "kristafke");
 
@@ -1549,13 +1548,13 @@ TEST_P(SimpleVolumeTest,  readCacheHits)
     uint64_t  misses =  api::getClusterCacheMisses(VolumeId("volume1"));
     EXPECT_EQ(0U, hits);
     EXPECT_EQ(0U, misses);
-    checkVolume(*v1,0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     hits =  api::getClusterCacheHits(VolumeId("volume1"));
     misses =  api::getClusterCacheMisses(VolumeId("volume1"));
     EXPECT_EQ(0U, hits);
     EXPECT_EQ(1U, misses);
 
-    checkVolume(*v1,0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     hits =  api::getClusterCacheHits(VolumeId("volume1"));
     misses =  api::getClusterCacheMisses(VolumeId("volume1"));
 #ifdef ENABLE_MD5_HASH
@@ -1566,7 +1565,7 @@ TEST_P(SimpleVolumeTest,  readCacheHits)
     EXPECT_EQ(2U, misses);
 #endif
 
-    checkVolume(*v1,0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     hits =  api::getClusterCacheHits(VolumeId("volume1"));
     misses =  api::getClusterCacheMisses(VolumeId("volume1"));
 #ifdef ENABLE_MD5_HASH
@@ -1577,7 +1576,7 @@ TEST_P(SimpleVolumeTest,  readCacheHits)
     EXPECT_EQ(3U, misses);
 #endif
 
-    checkVolume(*v1,0, v1->getClusterSize(), "kristafke");
+    checkVolume(*v1, Lba(0), v1->getClusterSize(), "kristafke");
     hits =  api::getClusterCacheHits(VolumeId("volume1"));
     misses =  api::getClusterCacheMisses(VolumeId("volume1"));
 #ifdef ENABLE_MD5_HASH
@@ -1603,7 +1602,7 @@ TEST_P(SimpleVolumeTest, backendSize)
     {
 
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "kristaf");
     }
@@ -1634,7 +1633,7 @@ TEST_P(SimpleVolumeTest, backendSize)
     for(int i = 0; i < 1024 ; i++)
     {
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "kristaf");
     }
@@ -1675,7 +1674,7 @@ TEST_P(SimpleVolumeTest, backendSize2)
     for(int i = 0; i < 1024 ; i++)
     {
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "kristaf");
     }
@@ -1699,7 +1698,7 @@ TEST_P(SimpleVolumeTest, backendSize3)
     {
 
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "kristaf");
     }
@@ -1724,7 +1723,7 @@ TEST_P(SimpleVolumeTest, backendSize3)
     {
 
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "joost");
     }
@@ -1805,8 +1804,8 @@ TEST_P(SimpleVolumeTest, readActivity)
 
     for(int i = 0; i < 128; ++i)
     {
-        v1->read(0, buf.data(), buf.size() / 2);
-        v2->read(0, buf.data(), buf.size());
+        v1->read(Lba(0), buf.data(), buf.size() / 2);
+        v2->read(Lba(0), buf.data(), buf.size());
     }
 
     boost::this_thread::sleep_for(boost::chrono::seconds(1));
@@ -1851,7 +1850,7 @@ TEST_P(SimpleVolumeTest, prefetch)
     const uint64_t size = cfg.lba_size_ * cfg.cluster_mult_ * cfg.sco_mult_ * num_scos;
     const std::string pattern("prefetchin'");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   size,
                   pattern);
 
@@ -1861,7 +1860,7 @@ TEST_P(SimpleVolumeTest, prefetch)
     for(int i =0 ; i< 64; ++i)
     {
 
-        v->read(0, &buf[0], size);
+        v->read(Lba(0), &buf[0], size);
     }
 
     v->scheduleBackendSync();
@@ -1914,7 +1913,7 @@ TEST_P(SimpleVolumeTest, prefetch)
     EXPECT_LT(0U, vm->readActivity());
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 size,
                 pattern);
 
@@ -1941,7 +1940,7 @@ TEST_P(SimpleVolumeTest, startPrefetch)
     const uint64_t size = cfg.lba_size_ * cfg.cluster_mult_ * cfg.sco_mult_ * num_scos;
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   size,
                   pattern);
 
@@ -1981,7 +1980,7 @@ TEST_P(SimpleVolumeTest, clusteredWriteTLogConsistency)
     ASSERT_TRUE(v != nullptr);
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getClusterSize(),
                   "abcd");
 
@@ -1989,7 +1988,7 @@ TEST_P(SimpleVolumeTest, clusteredWriteTLogConsistency)
     sleep(1);
 
     writeToVolume(*v,
-                  v->getClusterSize() / v->getLBASize(),
+                  Lba(v->getClusterSize() / v->getLBASize()),
                   v->getClusterSize() * v->getSCOMultiplier(),
                   "defg");
 
@@ -2039,12 +2038,12 @@ TEST_P(SimpleVolumeTest, zero_sized_volume)
 
     uint8_t pattern = 0xab;
     const std::vector<uint8_t> wbuf(v->getClusterSize(), pattern);
-    EXPECT_THROW(v->write(0, &wbuf[0], wbuf.size()),
+    EXPECT_THROW(v->write(Lba(0), &wbuf[0], wbuf.size()),
                  std::exception);
 
     ++pattern;
     std::vector<uint8_t> rbuf(v->getClusterSize(), pattern);
-    EXPECT_THROW(v->read(0, &rbuf[0], rbuf.size()),
+    EXPECT_THROW(v->read(Lba(0), &rbuf[0], rbuf.size()),
                  std::exception);
 
     for (const auto& b : rbuf)
@@ -2099,7 +2098,7 @@ TEST_P(SimpleVolumeTest, grow)
     EXPECT_EQ(nclusters * csize, v->getSize());
 
     const std::string pattern("extended play");
-    uint64_t lba((nclusters - 1) * csize / v->getLBASize());
+    const Lba lba((nclusters - 1) * csize / v->getLBASize());
 
     writeToVolume(*v, lba, csize, pattern);
     checkVolume(*v, lba, csize, pattern);
@@ -2155,7 +2154,7 @@ TEST_P(SimpleVolumeTest, tlog_entries)
 
     for (unsigned i = 0; i < sco_mult; ++i)
     {
-        writeToVolume(*v, 0, csize, "not of any importance");
+        writeToVolume(*v, Lba(0), csize, "not of any importance");
     }
 
     // should not have any impact.
@@ -2166,7 +2165,7 @@ TEST_P(SimpleVolumeTest, tlog_entries)
     for (unsigned i = sco_mult; i < tlog_entries; ++i)
     {
         EXPECT_EQ(tlog1, sm.getCurrentTLogPath());
-        writeToVolume(*v, 0, csize, "neither of importance");
+        writeToVolume(*v, Lba(0), csize, "neither of importance");
     }
 
     // tlog should've rolled over by now:
@@ -2241,7 +2240,7 @@ TEST_P(SimpleVolumeTest, simple_backend_restart)
 
     const std::string pattern("Hullo?");
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   pattern);
 
@@ -2260,7 +2259,7 @@ TEST_P(SimpleVolumeTest, simple_backend_restart)
     v = getVolume(id);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 pattern);
 }
@@ -2311,7 +2310,7 @@ TEST_P(SimpleVolumeTest, clones_and_location_based_caching)
 
     const std::string pattern("written-to-parent");
     writeToVolume(*parent,
-                  0,
+                  Lba(0),
                   4096,
                   pattern);
 
@@ -2334,7 +2333,7 @@ TEST_P(SimpleVolumeTest, clones_and_location_based_caching)
               clone->effective_cluster_cache_behaviour());
 
     checkVolume(*clone,
-                0,
+                Lba(0),
                 4096,
                 pattern);
 }
@@ -2484,7 +2483,7 @@ TEST_P(SimpleVolumeTest, sco_multiplier_updates)
                            ds.getRemainingSCOCapacity());
 
                  writeToVolume(*v,
-                               0,
+                               Lba(0),
                                v->getClusterSize() * (sm.t - 1),
                                pattern);
 
@@ -2502,7 +2501,7 @@ TEST_P(SimpleVolumeTest, sco_multiplier_updates)
     EXPECT_LT(sco_num2, sco_num3);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 v->getClusterSize() * 2047,
                 "three");
 }
@@ -2524,7 +2523,7 @@ TEST_P(SimpleVolumeTest, synchronous_foc)
     const std::string s("a single cluster");
     const size_t csize = v->getClusterSize();
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   csize,
                   s);
 
@@ -2597,7 +2596,7 @@ TEST_P(SimpleVolumeTest, metadata_cache_capacity)
     const size_t csize = v->getClusterSize();
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   csize,
                   fst);
 
@@ -2605,7 +2604,7 @@ TEST_P(SimpleVolumeTest, metadata_cache_capacity)
 
     const std::string snd("second");
     writeToVolume(*v,
-                  csize,
+                  Lba(csize),
                   csize,
                   snd);
 
@@ -2617,12 +2616,12 @@ TEST_P(SimpleVolumeTest, metadata_cache_capacity)
                    check_cap(cap);
 
                    checkVolume(*v,
-                               0,
+                               Lba(0),
                                csize,
                                fst);
 
                    checkVolume(*v,
-                               csize,
+                               Lba(csize),
                                csize,
                                snd);
                });
@@ -2673,12 +2672,12 @@ TEST_P(SimpleVolumeTest, dtl_queue_depth_and_large_requests)
     const std::string pattern("not that interesting, really");
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   size,
                   pattern);
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 size,
                 pattern);
 }
@@ -2689,7 +2688,7 @@ TEST_P(SimpleVolumeTest, partial_read_counters)
     SharedVolumePtr v = newVolume(*wrns);
 
     const std::string pattern("testing partial read counters");
-    writeToVolume(*v, 0, v->getClusterSize(), pattern);
+    writeToVolume(*v, Lba(0), v->getClusterSize(), pattern);
 
     {
         const be::PartialReadCounter prc(v->getDataStore()->partial_read_counter());
@@ -2709,7 +2708,7 @@ TEST_P(SimpleVolumeTest, partial_read_counters)
     v = getVolume(cfg.id_);
     ASSERT_NE(nullptr, v);
 
-    checkVolume(*v, 0, v->getClusterSize(), pattern);
+    checkVolume(*v, Lba(0), v->getClusterSize(), pattern);
 
     const be::PartialReadCounter prc(v->getDataStore()->partial_read_counter());
     EXPECT_LT(0UL, prc.fast + prc.slow);

--- a/src/volumedriver/test/SnapshotManagementTest.cpp
+++ b/src/volumedriver/test/SnapshotManagementTest.cpp
@@ -257,7 +257,7 @@ TEST_P(SnapshotManagementTest, backendSizeBetweenSnapshots)
 
     for(size_t i = 0; i < 10; ++i)
     {
-        writeToVolume(*vol_, 0,  4096,"blue");
+        writeToVolume(*vol_, Lba(0),  4096,"blue");
         waitForThisBackendWrite(*vol_);
         vol_->createSnapshot(boost::lexical_cast<SnapshotName>(i));
     }
@@ -341,7 +341,7 @@ TEST_P(SnapshotManagementTest, test2)
     //c->setMaxTLogEntries(4);
     for(size_t i = 0; i < 10; ++i)
     {
-        writeToVolume(*vol_,0,4096,"blue");
+        writeToVolume(*vol_, Lba(0),4096,"blue");
     }
     const SnapshotName snapname("snap1");
     createSnapshot(c,snapname);
@@ -378,7 +378,7 @@ TEST_P(SnapshotManagementTest, test3)
     //c->setMaxTLogEntries(4);
     for(size_t i = 0; i < 10; ++i)
     {
-        writeToVolume(*vol_, 0, 4096, "wartdebever");
+        writeToVolume(*vol_, Lba(0), 4096, "wartdebever");
     }
 
     const SnapshotName snapname("snap1");
@@ -407,7 +407,7 @@ TEST_P(SnapshotManagementTest, test4)
     //c->setMaxTLogEntries(4);
     for(size_t i = 0; i < 10; ++i)
     {
-        writeToVolume(*vol_,0,4096,"dartbewever");
+        writeToVolume(*vol_, Lba(0),4096,"dartbewever");
     }
 
     const SnapshotName snapname("snap1");
@@ -430,7 +430,7 @@ TEST_P(SnapshotManagementTest, test5)
     //gc->setMaxTLogEntries(4);
     for(size_t i = 0; i < 10; ++i)
     {
-        writeToVolume(*vol_,0,4096,"drtdwvraee");
+        writeToVolume(*vol_, Lba(0),4096,"drtdwvraee");
 
     }
     const SnapshotName snapname("snap1");
@@ -438,7 +438,7 @@ TEST_P(SnapshotManagementTest, test5)
     //SnapshotNum num1 = c.getSnapshotNumberByName(snapname);
     for(size_t i = 0; i < 10; ++i)
     {
-        writeToVolume(*vol_,0,4096,"eearvwdtrd");
+        writeToVolume(*vol_, Lba(0),4096,"eearvwdtrd");
     }
     const SnapshotName snapname2("snap2");
     createSnapshot(c,snapname2);
@@ -446,7 +446,7 @@ TEST_P(SnapshotManagementTest, test5)
 
     for(size_t i = 0; i < 10; ++i)
     {
-        writeToVolume(*vol_,0,4096,"help");
+        writeToVolume(*vol_, Lba(0),4096,"help");
     }
     const SnapshotName snapname3("snap3");
     createSnapshot(c,snapname3);
@@ -620,13 +620,13 @@ TEST_P(SnapshotManagementTest, dontLeakTLogCheckSumsOnRestore)
 {
     const SnapshotName snap1("snap1");
 
-    writeToVolume(*vol_, 0, vol_->getClusterSize(), snap1);
+    writeToVolume(*vol_, Lba(0), vol_->getClusterSize(), snap1);
     VolManagerTestSetup::createSnapshot(*vol_, snap1);
 
     waitForThisBackendWrite(*vol_);
 
     const SnapshotName snap2("snap2");
-    writeToVolume(*vol_, 0, vol_->getClusterSize(), snap2);
+    writeToVolume(*vol_, Lba(0), vol_->getClusterSize(), snap2);
     vol_->sync();
 
     const OrderedTLogIds tlogpaths(getSnapshotManagement(*vol_)->getCurrentTLogs());
@@ -654,7 +654,7 @@ TEST_P(SnapshotManagementTest, dontLeakTLogCheckSumsOnRestore)
     //                  CheckSumStoreException);
     // }
 
-    checkVolume(*vol_, 0, vol_->getClusterSize(), snap1);
+    checkVolume(*vol_, Lba(0), vol_->getClusterSize(), snap1);
 }
 
 INSTANTIATE_TEST(SnapshotManagementTest);

--- a/src/volumedriver/test/SnapshotRestoreTest.cpp
+++ b/src/volumedriver/test/SnapshotRestoreTest.cpp
@@ -36,40 +36,40 @@ TEST_P(SnapshotRestoreTest, SimpleRestore)
 
     const std::string pattern1("Frederik");
 
-    writeToVolume(*v, 0, 4096, pattern1);
+    writeToVolume(*v, Lba(0), 4096, pattern1);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snap1"));
 
     const std::string pattern2("Frederik");
 
-    writeToVolume(*v, 0, 4096, pattern2);
+    writeToVolume(*v, Lba(0), 4096, pattern2);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snap2"));
 
 
     const std::string pattern3("Arne");
 
-    writeToVolume(*v, 0, 4096, pattern3);
+    writeToVolume(*v, Lba(0), 4096, pattern3);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snap3"));
 
     const std::string pattern4("Bart");
 
-    writeToVolume(*v, 0, 4096, pattern4);
+    writeToVolume(*v, Lba(0), 4096, pattern4);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snap4"));
 
     const std::string pattern5("Wouter");
-    writeToVolume(*v, 0, 4096, pattern5);
+    writeToVolume(*v, Lba(0), 4096, pattern5);
 
-    checkVolume(*v,0,4096,pattern5);
+    checkVolume(*v, Lba(0),4096,pattern5);
     waitForThisBackendWrite(*v);
 
     EXPECT_NO_THROW(restoreSnapshot(*v,
                                     "snap4"));
 
-    checkVolume(*v,0,4096,pattern4);
-    writeToVolume(*v, 0, 4096, "Bollocks");
+    checkVolume(*v, Lba(0),4096,pattern4);
+    writeToVolume(*v, Lba(0), 4096, "Bollocks");
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snapper"));
     waitForThisBackendWrite(*v);
@@ -77,8 +77,8 @@ TEST_P(SnapshotRestoreTest, SimpleRestore)
     EXPECT_NO_THROW(restoreSnapshot(*v,
                                     "snap3"));
 
-    checkVolume(*v,0,4096,pattern3);
-    writeToVolume(*v, 0, 4096, "Bollocks");
+    checkVolume(*v, Lba(0),4096,pattern3);
+    writeToVolume(*v, Lba(0), 4096, "Bollocks");
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snapper"));
     waitForThisBackendWrite(*v);
@@ -86,8 +86,8 @@ TEST_P(SnapshotRestoreTest, SimpleRestore)
     EXPECT_NO_THROW(restoreSnapshot(*v,
                                     "snap2"));
 
-    checkVolume(*v,0,4096,pattern2);
-    writeToVolume(*v, 0, 4096, "Bollocks");
+    checkVolume(*v, Lba(0),4096,pattern2);
+    writeToVolume(*v, Lba(0), 4096, "Bollocks");
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snapper"));
     waitForThisBackendWrite(*v);
@@ -95,8 +95,8 @@ TEST_P(SnapshotRestoreTest, SimpleRestore)
     EXPECT_NO_THROW(restoreSnapshot(*v,
                                     "snap1"));
 
-    checkVolume(*v,0,4096,pattern1);
-    writeToVolume(*v, 0, 4096, "Bollocks");
+    checkVolume(*v, Lba(0),4096,pattern1);
+    writeToVolume(*v, Lba(0), 4096, "Bollocks");
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snapper"));
     waitForThisBackendWrite(*v);
@@ -111,7 +111,7 @@ TEST_P(SnapshotRestoreTest, NoSCOGap)
 
     const std::string pattern1("Frederik");
 
-    writeToVolume(*v, 0, 4096, pattern1);
+    writeToVolume(*v, Lba(0), 4096, pattern1);
     ASSERT_TRUE(getCurrentSCO(*v)->getSCO().number() == 1);
 
     waitForThisBackendWrite(*v);
@@ -119,34 +119,34 @@ TEST_P(SnapshotRestoreTest, NoSCOGap)
 
     const std::string pattern2("Frederik");
 
-    writeToVolume(*v, 0, 4096, pattern2);
+    writeToVolume(*v, Lba(0), 4096, pattern2);
     ASSERT_TRUE(getCurrentSCO(*v)->getSCO().number() == 2);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snap2"));
 
     const std::string pattern3("Arne");
 
-    writeToVolume(*v, 0, 4096, pattern3);
+    writeToVolume(*v, Lba(0), 4096, pattern3);
     ASSERT_TRUE(getCurrentSCO(*v)->getSCO().number() == 3);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snap3"));
 
     const std::string pattern4("Bart");
 
-    writeToVolume(*v, 0, 4096, pattern4);
+    writeToVolume(*v, Lba(0), 4096, pattern4);
     ASSERT_TRUE(getCurrentSCO(*v)->getSCO().number() == 4);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snap4"));
 
     const std::string pattern5("Wouter");
-    writeToVolume(*v, 0, 4096, pattern5);
+    writeToVolume(*v, Lba(0), 4096, pattern5);
     ASSERT_TRUE(getCurrentSCO(*v)->getSCO().number() == 5);
 
     waitForThisBackendWrite(*v);
     EXPECT_NO_THROW(restoreSnapshot(*v,"snap4"));
 
-    checkVolume(*v,0,4096,pattern4);
-    writeToVolume(*v, 0, 4096, "Bollocks");
+    checkVolume(*v, Lba(0),4096,pattern4);
+    writeToVolume(*v, Lba(0), 4096, "Bollocks");
     ASSERT_TRUE(getCurrentSCO(*v)->getSCO().number() == 5);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snapper"));
@@ -154,8 +154,8 @@ TEST_P(SnapshotRestoreTest, NoSCOGap)
 
     EXPECT_NO_THROW(restoreSnapshot(*v, "snap3"));
 
-    checkVolume(*v,0,4096,pattern3);
-    writeToVolume(*v, 0, 4096, "Bollocks");
+    checkVolume(*v, Lba(0),4096,pattern3);
+    writeToVolume(*v, Lba(0), 4096, "Bollocks");
     ASSERT_TRUE(getCurrentSCO(*v)->getSCO().number() == 4);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snapper"));
@@ -163,8 +163,8 @@ TEST_P(SnapshotRestoreTest, NoSCOGap)
 
     EXPECT_NO_THROW(restoreSnapshot(*v, "snap2"));
 
-    checkVolume(*v,0,4096,pattern2);
-    writeToVolume(*v, 0, 4096, "Bollocks");
+    checkVolume(*v, Lba(0),4096,pattern2);
+    writeToVolume(*v, Lba(0), 4096, "Bollocks");
     ASSERT_TRUE(getCurrentSCO(*v)->getSCO().number() == 3);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snapper"));
@@ -172,8 +172,8 @@ TEST_P(SnapshotRestoreTest, NoSCOGap)
 
     EXPECT_NO_THROW(restoreSnapshot(*v,"snap1"));
 
-    checkVolume(*v,0,4096,pattern1);
-    writeToVolume(*v, 0, 4096, "Bollocks");
+    checkVolume(*v, Lba(0),4096,pattern1);
+    writeToVolume(*v, Lba(0), 4096, "Bollocks");
     ASSERT_TRUE(getCurrentSCO(*v)->getSCO().number() == 2);
     waitForThisBackendWrite(*v);
     v->createSnapshot(SnapshotName("snapper"));
@@ -194,12 +194,12 @@ TEST_P(SnapshotRestoreTest, RestoreAndWriteAgain1)
     v->createSnapshot(SnapshotName("snap1"));
     waitForThisBackendWrite(*v);
 
-    writeToVolume(*v, 0, 5 * 4096, pattern);
+    writeToVolume(*v, Lba(0), 5 * 4096, pattern);
     waitForThisBackendWrite(*v);
 
     restoreSnapshot(*v,"snap1");
 
-    writeToVolume(*v, 0, 4*4096, pattern);
+    writeToVolume(*v, Lba(0), 4*4096, pattern);
     waitForThisBackendWrite(*v);
     checkCurrentBackendSize(*v);
 }
@@ -217,13 +217,13 @@ TEST_P(SnapshotRestoreTest, RestoreAndWriteAgain2)
     v->createSnapshot(SnapshotName("snap1"));
     waitForThisBackendWrite(*v);
 
-    writeToVolume(*v, 0, 5 * 4096, pattern);
+    writeToVolume(*v, Lba(0), 5 * 4096, pattern);
     v->createSnapshot(SnapshotName("snap2"));
     waitForThisBackendWrite(*v);
 
     restoreSnapshot(*v,"snap1");
 
-    writeToVolume(*v, 0, 10*4096, pattern);
+    writeToVolume(*v, Lba(0), 10*4096, pattern);
     waitForThisBackendWrite(*v);
     checkCurrentBackendSize(*v);
 }
@@ -245,7 +245,7 @@ TEST_P(SnapshotRestoreTest, TestFailOver)
     for(int i = 0; i < 5; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "a");
     }
@@ -257,7 +257,7 @@ TEST_P(SnapshotRestoreTest, TestFailOver)
     for(int i = 0; i < 7; ++i)
     {
         writeToVolume(*v,
-                      8,
+                      Lba(8),
                       4096,
                       "d");
     }
@@ -274,8 +274,8 @@ TEST_P(SnapshotRestoreTest, TestFailOver)
     v1 = getVolume(VolumeId("volume1"));
 
     ASSERT_TRUE(v1 != nullptr);
-    checkVolume(*v1,0,4096, "\0");
-    checkVolume(*v1,8,4096, "d");
+    checkVolume(*v1, Lba(0), 4096, "\0");
+    checkVolume(*v1, Lba(8), 4096, "d");
     checkCurrentBackendSize(*v1);
 }
 
@@ -289,7 +289,7 @@ TEST_P(SnapshotRestoreTest, HaltOnError)
 
     const TLogId tlog_id(v->getSnapshotManagement().getCurrentTLogId());
 
-    writeToVolume(*v, 0, 4096, pattern1);
+    writeToVolume(*v, Lba(0), 4096, pattern1);
     v->createSnapshot(SnapshotName("snap1"));
     waitForThisBackendWrite(*v);
 
@@ -314,7 +314,7 @@ TEST_P(SnapshotRestoreTest, snapshot_restoration_on_a_clone)
     const std::string pattern1("before-parent-snapshot");
 
     writeToVolume(*parent,
-                  0,
+                  Lba(0),
                   parent->getClusterSize(),
                   pattern1);
 
@@ -334,7 +334,7 @@ TEST_P(SnapshotRestoreTest, snapshot_restoration_on_a_clone)
     const std::string pattern2("before-clone-snapshot");
 
     writeToVolume(*clone,
-                  0,
+                  Lba(0),
                   clone->getClusterSize(),
                   pattern2);
 
@@ -346,12 +346,12 @@ TEST_P(SnapshotRestoreTest, snapshot_restoration_on_a_clone)
     const std::string pattern3("after-clone-snapshot");
 
     writeToVolume(*clone,
-                  0,
+                  Lba(0),
                   clone->getClusterSize(),
                   pattern3);
 
     checkVolume(*clone,
-                0,
+                Lba(0),
                 clone->getClusterSize(),
                 pattern3);
 
@@ -359,7 +359,7 @@ TEST_P(SnapshotRestoreTest, snapshot_restoration_on_a_clone)
                     clone_snap);
 
     checkVolume(*clone,
-                0,
+                Lba(0),
                 clone->getClusterSize(),
                 pattern2);
 }

--- a/src/volumedriver/test/StatusWriterTest.cpp
+++ b/src/volumedriver/test/StatusWriterTest.cpp
@@ -57,7 +57,7 @@ TEST_P(StatusWriterTest, write_a_bunch_of_crap)
         t.add_kept(cluster_size);
 
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       cluster_size,
                       "immanuel");
 

--- a/src/volumedriver/test/TemplateVolumeTest.cpp
+++ b/src/volumedriver/test/TemplateVolumeTest.cpp
@@ -58,7 +58,7 @@ TEST_P(TemplateVolumeTest, forbidden_actions)
     EXPECT_TRUE(T(v->isVolumeTemplate()));
 
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                               "blah"),
                  VolumeIsTemplateException);
@@ -98,7 +98,7 @@ TEST_P(TemplateVolumeTest, set_template_no_data_no_snapshot)
     v->listSnapshots(snapshots);
     EXPECT_EQ(1U, snapshots.size());
 
-    checkVolume(*v, 0, 4096, std::string(1, 0));
+    checkVolume(*v, Lba(0), 4096, std::string(1, 0));
 }
 
 TEST_P(TemplateVolumeTest, idempotency)
@@ -109,14 +109,14 @@ TEST_P(TemplateVolumeTest, idempotency)
     SharedVolumePtr v = newVolume(vid1,
                           ns1);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah");
 
     EXPECT_NO_THROW(set_as_template(vid1));
     EXPECT_TRUE(T(v->isVolumeTemplate()));
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -124,7 +124,7 @@ TEST_P(TemplateVolumeTest, idempotency)
     EXPECT_NO_THROW(set_as_template(vid1));
     EXPECT_TRUE(T(v->isVolumeTemplate()));
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -135,7 +135,7 @@ TEST_P(TemplateVolumeTest, idempotency)
 
     EXPECT_TRUE(T(v->isVolumeTemplate()));
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -150,7 +150,7 @@ TEST_P(TemplateVolumeTest, set_template_data_no_snapshot)
     SharedVolumePtr v = newVolume(vid1,
                           ns1);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah");
 
@@ -160,7 +160,7 @@ TEST_P(TemplateVolumeTest, set_template_data_no_snapshot)
     std::list<SnapshotName> snapshots;
     v->listSnapshots(snapshots);
     EXPECT_EQ(1U, snapshots.size());
-    checkVolume(*v, 0, 4096, "blah");
+    checkVolume(*v, Lba(0), 4096, "blah");
 }
 
 TEST_P(TemplateVolumeTest, set_template_with_last_snapshot)
@@ -171,7 +171,7 @@ TEST_P(TemplateVolumeTest, set_template_with_last_snapshot)
     SharedVolumePtr v = newVolume(vid1,
                           ns1);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah1");
 
@@ -179,7 +179,7 @@ TEST_P(TemplateVolumeTest, set_template_with_last_snapshot)
 
     v->createSnapshot(first_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah2");
     waitForThisBackendWrite(*v);
@@ -195,7 +195,7 @@ TEST_P(TemplateVolumeTest, set_template_with_last_snapshot)
     EXPECT_EQ(1U, snapshots.size());
     EXPECT_EQ(snapshots.front(), second_snap);
 
-    checkVolume(*v, 0, 4096, "blah2");
+    checkVolume(*v, Lba(0), 4096, "blah2");
 }
 
 TEST_P(TemplateVolumeTest, set_template_with_data_beyond_last_snapshot)
@@ -206,14 +206,14 @@ TEST_P(TemplateVolumeTest, set_template_with_data_beyond_last_snapshot)
     SharedVolumePtr v = newVolume(vid1,
                           ns1);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blaha");
     const SnapshotName first_snap("first_snap");
 
     v->createSnapshot(first_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah2");
     waitForThisBackendWrite(*v);
@@ -221,7 +221,7 @@ TEST_P(TemplateVolumeTest, set_template_with_data_beyond_last_snapshot)
 
     v->createSnapshot(second_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah3");
     waitForThisBackendWrite(*v);
@@ -229,7 +229,7 @@ TEST_P(TemplateVolumeTest, set_template_with_data_beyond_last_snapshot)
 
     v->createSnapshot(third_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah4");
 
@@ -241,7 +241,7 @@ TEST_P(TemplateVolumeTest, set_template_with_data_beyond_last_snapshot)
     EXPECT_NE(snapshots.front(), first_snap);
     EXPECT_NE(snapshots.front(), second_snap);
     EXPECT_NE(snapshots.front(), third_snap);
-    checkVolume(*v, 0, 4096, "blah4");
+    checkVolume(*v, Lba(0), 4096, "blah4");
 }
 
 TEST_P(TemplateVolumeTest, localrestart)
@@ -252,14 +252,14 @@ TEST_P(TemplateVolumeTest, localrestart)
     SharedVolumePtr v = newVolume(vid1,
                           ns1);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blaha");
     const SnapshotName first_snap("first_snap");
 
     v->createSnapshot(first_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah2");
     waitForThisBackendWrite(*v);
@@ -267,7 +267,7 @@ TEST_P(TemplateVolumeTest, localrestart)
 
     v->createSnapshot(second_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah3");
 
@@ -276,7 +276,7 @@ TEST_P(TemplateVolumeTest, localrestart)
 
     v->createSnapshot(third_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah4");
 
@@ -284,7 +284,7 @@ TEST_P(TemplateVolumeTest, localrestart)
 
     EXPECT_TRUE(T(v->isVolumeTemplate()));
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -299,9 +299,9 @@ TEST_P(TemplateVolumeTest, localrestart)
     ASSERT_TRUE(v != nullptr);
 
     EXPECT_TRUE(T(v->isVolumeTemplate()));
-    checkVolume(*v, 0, 4096, "blah4");
+    checkVolume(*v, Lba(0), 4096, "blah4");
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -309,9 +309,9 @@ TEST_P(TemplateVolumeTest, localrestart)
     EXPECT_NO_THROW(set_as_template(vid1));
 
     EXPECT_TRUE(T(v->isVolumeTemplate()));
-    checkVolume(*v, 0, 4096, "blah4");
+    checkVolume(*v, Lba(0), 4096, "blah4");
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -328,14 +328,14 @@ TEST_P(TemplateVolumeTest, backend_restart)
     SharedVolumePtr v = newVolume(vid1,
                           ns1);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blaha");
     const SnapshotName first_snap("first_snap");
 
     v->createSnapshot(first_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah2");
     waitForThisBackendWrite(*v);
@@ -343,7 +343,7 @@ TEST_P(TemplateVolumeTest, backend_restart)
 
     v->createSnapshot(second_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah3");
     waitForThisBackendWrite(*v);
@@ -351,7 +351,7 @@ TEST_P(TemplateVolumeTest, backend_restart)
 
     v->createSnapshot(third_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah4");
 
@@ -359,7 +359,7 @@ TEST_P(TemplateVolumeTest, backend_restart)
 
     EXPECT_TRUE(T(v->isVolumeTemplate()));
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -376,9 +376,9 @@ TEST_P(TemplateVolumeTest, backend_restart)
     ASSERT_TRUE(v != nullptr);
 
     EXPECT_TRUE(T(v->isVolumeTemplate()));
-    checkVolume(*v, 0, 4096, "blah4");
+    checkVolume(*v, Lba(0), 4096, "blah4");
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -386,9 +386,9 @@ TEST_P(TemplateVolumeTest, backend_restart)
     EXPECT_NO_THROW(set_as_template(vid1));
 
     EXPECT_TRUE(T(v->isVolumeTemplate()));
-    checkVolume(*v, 0, 4096, "blah4");
+    checkVolume(*v, Lba(0), 4096, "blah4");
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -405,14 +405,14 @@ TEST_P(TemplateVolumeTest, cloneTemplatedVolume)
     SharedVolumePtr v = newVolume(vid1,
                           ns1);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blaha");
     const SnapshotName first_snap("first_snap");
 
     v->createSnapshot(first_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah2");
     waitForThisBackendWrite(*v);
@@ -420,7 +420,7 @@ TEST_P(TemplateVolumeTest, cloneTemplatedVolume)
 
     v->createSnapshot(second_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah3");
     waitForThisBackendWrite(*v);
@@ -428,7 +428,7 @@ TEST_P(TemplateVolumeTest, cloneTemplatedVolume)
 
     v->createSnapshot(third_snap);
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "blah4");
 
@@ -436,7 +436,7 @@ TEST_P(TemplateVolumeTest, cloneTemplatedVolume)
 
     EXPECT_TRUE(T(v->isVolumeTemplate()));
     EXPECT_THROW(writeToVolume(*v,
-                               0,
+                               Lba(0),
                                4096,
                                "blah"),
                  VolumeIsTemplateException);
@@ -457,7 +457,7 @@ TEST_P(TemplateVolumeTest, cloneTemplatedVolume)
                                      ns2,
                                      ns1,
                                      boost::none));
-    checkVolume(*c1, 0, 4096, "blah4");
+    checkVolume(*c1, Lba(0), 4096, "blah4");
     EXPECT_FALSE(T(c1->isVolumeTemplate()));
 }
 

--- a/src/volumedriver/test/TestMetadataErrors.cpp
+++ b/src/volumedriver/test/TestMetadataErrors.cpp
@@ -40,14 +40,14 @@ TEST_P(TestMetadataErrors, testHaltingVolumeWhenWritingToSnapshotsFailsInMgmtPat
                                                 ns);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   4096,
                   "kutmetperen");
 
     ASSERT_NO_THROW(v1->createSnapshot(SnapshotName("snap1")));
     waitForThisBackendWrite(*v1);
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   4096,
                   "kutmetperen");
 
@@ -75,7 +75,7 @@ TEST_P(TestMetadataErrors, testHaltingVolumeWhenWritingToSnapshotsFailsInIOPath)
                                                 ns);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   4096,
                   "kutmetperen");
 
@@ -96,10 +96,10 @@ TEST_P(TestMetadataErrors, testHaltingVolumeWhenWritingToSnapshotsFailsInIOPath)
 
     for(unsigned i = 0; i < (tlog_rollover_size - 1); ++i)
     {
-        writeToVolume(*v1, 0, 4096, "kutmetperen");
+        writeToVolume(*v1, Lba(0), 4096, "kutmetperen");
     }
 
-    ASSERT_THROW(writeToVolume(*v1,0, 4096, "kutmetperen"),
+    ASSERT_THROW(writeToVolume(*v1, Lba(0), 4096, "kutmetperen"),
                  youtils::SerializationFlushException);
     ASSERT_TRUE(v1->is_halted());
 }
@@ -114,14 +114,14 @@ TEST_P(TestMetadataErrors, testHaltingVolumeWhenWritingToTlogFailsInMgmtPath)
                                                 ns);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   4096,
                   "kutmetperen");
 
     ASSERT_NO_THROW(v1->createSnapshot(SnapshotName("snap1")));
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   4096,
                   "kutmetperen");
     waitForThisBackendWrite(*v1);
@@ -156,14 +156,14 @@ TEST_P(TestMetadataErrors, testHaltingVolumeWhenWritingToTlogFailsInIOPath)
                                                 ns);
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   4096,
                   "kutmetperen");
 
     ASSERT_NO_THROW(v1->createSnapshot(SnapshotName("snap1")));
 
     writeToVolume(*v1,
-                  0,
+                  Lba(0),
                   4096,
                   "kutmetperen");
     waitForThisBackendWrite(*v1);
@@ -183,11 +183,10 @@ TEST_P(TestMetadataErrors, testHaltingVolumeWhenWritingToTlogFailsInIOPath)
 
     try
     {
-
        for(unsigned i = 0; i < tlog_rollover_size; ++i)
        {
-            writeToVolume(*v1, 0, 4096, "kutmetperen");
-        }
+           writeToVolume(*v1, Lba(0), 4096, "kutmetperen");
+       }
     }
     catch(youtils::FileDescriptorException& e)
     {

--- a/src/volumedriver/test/ThrottlingTest.cpp
+++ b/src/volumedriver/test/ThrottlingTest.cpp
@@ -42,7 +42,7 @@ public:
 
     uint64_t
     timedWrite(SharedVolumePtr v,
-               uint64_t lba,
+               const Lba lba,
                size_t size,
                const std::string& pattern)
     {
@@ -64,7 +64,7 @@ public:
             unsigned expected_delay)
     {
         uint64_t t = timedWrite(v,
-                                0,
+                                Lba(0),
                                 num_clusters * v->getClusterSize(),
                                 "12345678");
 
@@ -73,7 +73,7 @@ public:
         throttle(true);
 
         t = timedWrite(v,
-                       num_clusters * v->getClusterSize() / v->getLBASize(),
+                       Lba(num_clusters * v->getClusterSize() / v->getLBASize()),
                        num_clusters * v->getClusterSize(),
                        "abcdefgh");
 

--- a/src/volumedriver/test/ToolCutTest.cpp
+++ b/src/volumedriver/test/ToolCutTest.cpp
@@ -77,7 +77,7 @@ TEST_P(ToolCutTest, DISABLED_toolcut_create_volume)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 

--- a/src/volumedriver/test/VolManagerTLogSCOWrapTest.cpp
+++ b/src/volumedriver/test/VolManagerTLogSCOWrapTest.cpp
@@ -75,13 +75,13 @@ TEST_P(VolManagerTLogSCOWrapTest, DISABLED_one)
 			  backend::Namespace());
     //setTLogMaxEntries(v, 3);
 
-    writeToVolume(*v, 0, 4096, "g");
-    checkVolume(*v, 0, 4096, "g");
+    writeToVolume(*v, Lba(0), 4096, "g");
+    checkVolume(*v, Lba(0), 4096, "g");
 
     EXPECT_TRUE(checkSCO(*v, SCO("00_00000001_00"), false));
     EXPECT_FALSE(checkSCO(*v, SCO("00_00000002_00"), false));
 
-    writeToVolume(*v, 0, 4096, "g");
+    writeToVolume(*v, Lba(0), 4096, "g");
 
     v->sync();
     ::sync();
@@ -118,7 +118,7 @@ TEST_P(VolManagerTLogSCOWrapTest, DISABLED_one)
     EXPECT_TRUE(checkSCO(*v, SCO("00_00000001_00"), true));
     EXPECT_TRUE(checkSCO(*v, SCO("00_00000002_00"), false));
 
-    writeToVolume(*v, 0, 4096, "g");
+    writeToVolume(*v, Lba(0), 4096, "g");
     // expecting new second tlog with a sync2tc and 1 LOC
     // also expecting a second container to be started
     v->sync();

--- a/src/volumedriver/test/VolManagerTestSetup.h
+++ b/src/volumedriver/test/VolManagerTestSetup.h
@@ -271,7 +271,7 @@ public:
     {
         for (uint64_t i = 0; i < number_of_clusters; i++)
         {
-            uint64_t lba = (i * vol.getClusterMultiplier()) % vol.getLBACount();
+            const Lba lba((i * vol.getClusterMultiplier()) % vol.getLBACount());
             std::stringstream ss;
             ss << basepattern << ( pattern_period ? i % pattern_period : i);
             writeToVolume(vol, lba, vol.getClusterSize(), ss.str());
@@ -302,7 +302,7 @@ public:
     {
         for (uint64_t i = offset; i < number_of_clusters + offset; i++)
         {
-            uint64_t lba = (i * vol.getClusterMultiplier()) % vol.getLBACount();
+            const Lba lba((i * vol.getClusterMultiplier()) % vol.getLBACount());
             std::stringstream ss;
             ss << basepattern << ( pattern_period ? i % pattern_period : i);
             checkVolume(vol, lba, vol.getClusterSize(), ss.str());
@@ -318,14 +318,14 @@ public:
     {
         for (size_t i = 0; i < vol.getSize(); i += blocksize)
         {
-            writeToVolume(vol, i / vol.getLBASize(), blocksize, pattern, retries);
+            writeToVolume(vol, Lba(i / vol.getLBASize()), blocksize, pattern, retries);
         }
     }
 
     template<typename T>
     static void
     writeToVolume(T& volume,
-                  uint64_t lba,
+                  const Lba lba,
                   uint64_t size,
                   const std::string& pattern,
                   unsigned retries=5)
@@ -349,7 +349,7 @@ public:
     template<typename T>
     static void
     writeToVolume(T& volume,
-                  uint64_t lba,
+                  const Lba lba,
                   uint64_t size,
                   const uint8_t *buf,
                   unsigned retries = 5)
@@ -499,7 +499,7 @@ public:
 
     static void
     checkVolume(Volume& volume,
-                uint64_t lba,
+                const Lba,
                 uint64_t block_size,
                 const std::string& pattern = "",
                 unsigned retries = 10);
@@ -742,8 +742,8 @@ private:
     redi::ipstream pstream_;
 
     static void
-    readVolume_(Volume& vol,
-                uint64_t lba,
+    readVolume_(Volume&,
+                const Lba,
                 uint64_t block_size,
                 const std::string* const pattern,
                 unsigned retries);

--- a/src/volumedriver/test/VolManagerThreadTest.cpp
+++ b/src/volumedriver/test/VolManagerThreadTest.cpp
@@ -45,7 +45,7 @@ TEST_P(VolManagerThreadTest, test1)
     for(int i = 0; i < 1024; ++i)
     {
         writeToVolume(*v1,
-                      0,
+                      Lba(0),
                       4096,
                       "test");
     }

--- a/src/volumedriver/test/VolManagerVolumeDestroy.cpp
+++ b/src/volumedriver/test/VolManagerVolumeDestroy.cpp
@@ -46,9 +46,9 @@ TEST_P(VolManagerVolumeDestroy, one)
 			  ns1);
     //setTLogMaxEntries(v, 3);
 
-    writeToVolume(*v, 0, 4096, "g");
-    writeToVolume(*v, 0, 4096, "g");
-    writeToVolume(*v, 0, 4096, "g");
+    writeToVolume(*v, Lba(0), 4096, "g");
+    writeToVolume(*v, Lba(0), 4096, "g");
+    writeToVolume(*v, Lba(0), 4096, "g");
 
     v->sync();
     ::sync();

--- a/src/volumedriver/test/VolumeBackupTest.cpp
+++ b/src/volumedriver/test/VolumeBackupTest.cpp
@@ -514,7 +514,7 @@ TEST_P(VolumeBackupTest, simple_backup_restore)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 
@@ -559,7 +559,7 @@ TEST_P(VolumeBackupTest, simple_backup_restore)
     v1 = restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "immanuel");
+    checkVolume(*v1, Lba(0), 4096, "immanuel");
     removeVolumeCompletely(v1);
 }
 
@@ -573,7 +573,7 @@ TEST_P(VolumeBackupTest, report_threshold)
 
     for(unsigned i = 0; i < 32; ++i)
     {
-        writeToVolume(*v, 0, 4096,"immanuel");
+        writeToVolume(*v, Lba(0), 4096,"immanuel");
     }
 
     const SnapshotName snap1("snap1");
@@ -622,7 +622,7 @@ TEST_P(VolumeBackupTest, report_threshold)
     v1 = restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "immanuel");
+    checkVolume(*v1, Lba(0), 4096, "immanuel");
     removeVolumeCompletely(v1);
 }
 
@@ -634,7 +634,7 @@ TEST_P(VolumeBackupTest, backup_backup)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 
@@ -683,7 +683,7 @@ TEST_P(VolumeBackupTest, backup_backup)
     v1 = restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "immanuel");
+    checkVolume(*v1, Lba(0), 4096, "immanuel");
     removeVolumeCompletely(v1);
 }
 
@@ -695,13 +695,13 @@ TEST_P(VolumeBackupTest, backup_backup2)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 
     v->createSnapshot(snap1);
 
-    writeToVolume(*v, 0, 8192,"bartdv");
+    writeToVolume(*v, Lba(0), 8192,"bartdv");
     waitForThisBackendWrite(*v);
 
     const SnapshotName snap2("snap2");
@@ -793,7 +793,7 @@ TEST_P(VolumeBackupTest, backup_backup2)
     v1 = restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "bartdv");
+    checkVolume(*v1, Lba(0), 4096, "bartdv");
     removeVolumeCompletely(v1);
 }
 
@@ -805,15 +805,15 @@ TEST_P(VolumeBackupTest, delete_snapshot)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
     const SnapshotName snap1("snap1");
     v->createSnapshot(snap1);
     waitForThisBackendWrite(*v);
-    writeToVolume(*v, 8, 4096,"arne");
+    writeToVolume(*v, Lba(8), 4096,"arne");
     const SnapshotName snap2("snap2");
     v->createSnapshot(snap2);
     waitForThisBackendWrite(*v);
-    writeToVolume(*v, 0, 2*4096,"bart");
+    writeToVolume(*v, Lba(0), 2*4096,"bart");
 
     Namespace ns2;
     ensure_target_namespace(ns2);
@@ -853,8 +853,8 @@ TEST_P(VolumeBackupTest, delete_snapshot)
     v1=restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "immanuel");
-    checkVolume(*v1,8, 4096, "arne");
+    checkVolume(*v1, Lba(0), 4096, "immanuel");
+    checkVolume(*v1, Lba(8), 4096, "arne");
     removeVolumeCompletely(v1);
     restore_to_ptr.reset();
 
@@ -880,15 +880,15 @@ TEST_P(VolumeBackupTest, delete_snapshot_has_no_influence_on_restore)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
     const SnapshotName snap1("snap1");
     v->createSnapshot(snap1);
     waitForThisBackendWrite(*v);
-    writeToVolume(*v, 8, 4096,"arne");
+    writeToVolume(*v, Lba(8), 4096,"arne");
     const SnapshotName snap2("snap2");
     v->createSnapshot(snap2);
     waitForThisBackendWrite(*v);
-    writeToVolume(*v, 0, 2*4096,"bart");
+    writeToVolume(*v, Lba(0), 2*4096,"bart");
 
     Namespace ns2;
     ensure_target_namespace(ns2);
@@ -936,8 +936,8 @@ TEST_P(VolumeBackupTest, delete_snapshot_has_no_influence_on_restore)
     v1=restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "immanuel");
-    checkVolume(*v1,8, 4096, "arne");
+    checkVolume(*v1, Lba(0), 4096, "immanuel");
+    checkVolume(*v1, Lba(8), 4096, "arne");
     removeVolumeCompletely(v1);
 }
 
@@ -949,7 +949,7 @@ TEST_P(VolumeBackupTest, start_and_end_snap_are_the_same)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
     v->createSnapshot(snap1);
@@ -982,7 +982,7 @@ TEST_P(VolumeBackupTest, start_and_end_snap_are_the_same)
                                       4096));
 
     // Do an incremental backup to ns2
-    writeToVolume(*v, 0, 4096,"bart");
+    writeToVolume(*v, Lba(0), 4096,"bart");
 
     const SnapshotName snap2("snap2");
 
@@ -1021,7 +1021,7 @@ TEST_P(VolumeBackupTest, start_and_end_snap_are_the_same)
 
     SharedVolumePtr v1 = 0;
     v1 = restartVolumeFromBackup(restore_to);
-    checkVolume(*v1,0, 4096, "bart");
+    checkVolume(*v1, Lba(0), 4096, "bart");
     removeVolumeCompletely(v1);
 }
 
@@ -1033,7 +1033,7 @@ TEST_P(VolumeBackupTest, end_snapshot_negotiation)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 
@@ -1041,7 +1041,7 @@ TEST_P(VolumeBackupTest, end_snapshot_negotiation)
 
     waitForThisBackendWrite(*v);
 
-    writeToVolume(*v, 0, 4096,"bart");
+    writeToVolume(*v, Lba(0), 4096,"bart");
 
     const SnapshotName snap2("snap2");
 
@@ -1075,7 +1075,7 @@ TEST_P(VolumeBackupTest, end_snapshot_negotiation)
     v1 = restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "bart");
+    checkVolume(*v1, Lba(0), 4096, "bart");
     removeVolumeCompletely(v1);
 }
 
@@ -1087,7 +1087,7 @@ TEST_P(VolumeBackupTest, restore_to_backup)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 
@@ -1128,7 +1128,7 @@ TEST_P(VolumeBackupTest, backup_fails_when_guids_do_not_match)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 
@@ -1151,7 +1151,7 @@ TEST_P(VolumeBackupTest, backup_fails_when_guids_do_not_match)
     v->createSnapshot(snap1);
     waitForThisBackendWrite(*v);
 
-    writeToVolume(*v,0, 4096,"arne");
+    writeToVolume(*v, Lba(0), 4096,"arne");
     const SnapshotName snap2("snap2");
     v->createSnapshot(snap2);
     waitForThisBackendWrite(*v);
@@ -1177,7 +1177,7 @@ TEST_P(VolumeBackupTest, change_name_and_test_no_restore_from_incremental)
     VolumeConfig cfg = v->get_config();
 
     (void)v;
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 
@@ -1256,10 +1256,10 @@ TEST_P(VolumeBackupTest, incremental_with_snapshot_negotiation)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           source_ns);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     v->createSnapshot(SnapshotName("snap1"));
-    writeToVolume(*v, 0, 4096,"arne");
+    writeToVolume(*v, Lba(0), 4096,"arne");
     waitForThisBackendWrite(*v);
 
     Namespace backup_ns;
@@ -1284,12 +1284,12 @@ TEST_P(VolumeBackupTest, incremental_with_snapshot_negotiation)
 
         SharedVolumePtr v1 = restartVolumeFromBackup(restore_ns);
         ASSERT_TRUE(v1 != nullptr);
-        checkVolume(*v1,0, 4096, "immanuel");
+        checkVolume(*v1, Lba(0), 4096, "immanuel");
         removeVolumeCompletely(v1);
     }
 
     v->createSnapshot(SnapshotName("snap2"));
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
     waitForThisBackendWrite(*v);
 
     create_backup_config(backup_ns,
@@ -1311,7 +1311,7 @@ TEST_P(VolumeBackupTest, incremental_with_snapshot_negotiation)
 
         SharedVolumePtr v1 = restartVolumeFromBackup(restore_ns);
         ASSERT_TRUE(v1 != nullptr);
-        checkVolume(*v1,0, 4096, "arne");
+        checkVolume(*v1, Lba(0), 4096, "arne");
         removeVolumeCompletely(v1);
     }
 }
@@ -1326,7 +1326,7 @@ TEST_P(VolumeBackupTest, incremental_with_faulty_snapshot)
 
 
     (void)v;
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     v->createSnapshot(SnapshotName("snap1"));
 
@@ -1354,7 +1354,7 @@ TEST_P(VolumeBackupTest, incremental_with_faulty_snapshot)
 
     SharedVolumePtr v1 = restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
-    checkVolume(*v1,0, 4096, "immanuel");
+    checkVolume(*v1, Lba(0), 4096, "immanuel");
     removeVolumeCompletely(v1);
     v1 = 0;
 
@@ -1362,9 +1362,9 @@ TEST_P(VolumeBackupTest, incremental_with_faulty_snapshot)
     v->createSnapshot(SnapshotName("snap1"));
     waitForThisBackendWrite(*v);
 
-    writeToVolume(*v, 0, 4096,"arne");
+    writeToVolume(*v, Lba(0), 4096,"arne");
     v->createSnapshot(SnapshotName("snap2"));
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
     waitForThisBackendWrite(*v);
 
     restore_to_ptr = make_random_namespace();
@@ -1384,7 +1384,7 @@ TEST_P(VolumeBackupTest, incremental_with_faulty_snapshot)
 
     v1 = restartVolumeFromBackup(restore_to_2);
     ASSERT_TRUE(v1 != nullptr);
-    checkVolume(*v1,0, 4096, "immanuel");
+    checkVolume(*v1, Lba(0), 4096, "immanuel");
     removeVolumeCompletely(v1);
 }
 
@@ -1396,14 +1396,14 @@ TEST_P(VolumeBackupTest, string_of_incremental_backup_restore)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           source_ns);
 
-    writeToVolume(*v, 0, 4096, "immanuel");
+    writeToVolume(*v, Lba(0), 4096, "immanuel");
 
     const SnapshotName snap1("snap1");
     v->createSnapshot(snap1);
 
     waitForThisBackendWrite(*v);
 
-    writeToVolume(*v,0, 4096, "arne");
+    writeToVolume(*v, Lba(0), 4096, "arne");
 
     Namespace backup_ns;
     create_backup_config(backup_ns,
@@ -1429,12 +1429,12 @@ TEST_P(VolumeBackupTest, string_of_incremental_backup_restore)
         SharedVolumePtr v1 = restartVolumeFromBackup(restore_ns);
         ASSERT_TRUE(v1 != nullptr);
 
-        checkVolume(*v1, 0, 4096, "immanuel");
+        checkVolume(*v1, Lba(0), 4096, "immanuel");
         removeVolumeCompletely(v1);
     }
 
-    writeToVolume(*v, 0, 4096, "arne");
-    writeToVolume(*v, 8, 4096, "bart");
+    writeToVolume(*v, Lba(0), 4096, "arne");
+    writeToVolume(*v, Lba(8), 4096, "bart");
 
     const SnapshotName snap2("snap2");
     v->createSnapshot(snap2);
@@ -1461,8 +1461,8 @@ TEST_P(VolumeBackupTest, string_of_incremental_backup_restore)
 
         SharedVolumePtr v1 = restartVolumeFromBackup(restore_ns);
         ASSERT_TRUE(v1 != nullptr);
-        checkVolume(*v1, 0, 4096, "arne");
-        checkVolume(*v1, 8, 4096, "bart");
+        checkVolume(*v1, Lba(0), 4096, "arne");
+        checkVolume(*v1, Lba(8), 4096, "bart");
         removeVolumeCompletely(v1);
     }
 }
@@ -1475,15 +1475,15 @@ TEST_P(VolumeBackupTest, simple_incremental_and_apply)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
     const SnapshotName snap1("snap1");
     v->createSnapshot(snap1);
     waitForThisBackendWrite(*v);
-    writeToVolume(*v, 8, 4096,"arne");
+    writeToVolume(*v, Lba(8), 4096,"arne");
     const SnapshotName snap2("snap2");
     v->createSnapshot(snap2);
     waitForThisBackendWrite(*v);
-    writeToVolume(*v, 0, 2*4096,"bart");
+    writeToVolume(*v, Lba(0), 2*4096,"bart");
     Namespace ns2;
     create_backup_config(ns2,
                          ns1,
@@ -1530,8 +1530,8 @@ TEST_P(VolumeBackupTest, simple_incremental_and_apply)
     v1=restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "immanuel");
-    checkVolume(*v1,8, 4096, "arne");
+    checkVolume(*v1, Lba(0), 4096, "immanuel");
+    checkVolume(*v1, Lba(8), 4096, "arne");
     removeVolumeCompletely(v1);
 }
 
@@ -1543,7 +1543,7 @@ TEST_P(VolumeBackupTest, simple_backup_restore_with_clones)
     SharedVolumePtr v = newVolume(VolumeId("volume1"),
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 
@@ -1558,7 +1558,7 @@ TEST_P(VolumeBackupTest, simple_backup_restore_with_clones)
                      ns1,
                      snap1);
 
-    writeToVolume(*c1, 8, 4096, "arne");
+    writeToVolume(*c1, Lba(8), 4096, "arne");
     c1->createSnapshot(snap1);
     waitForThisBackendWrite(*c1);
     auto ns3_ptr = make_random_namespace();
@@ -1570,7 +1570,7 @@ TEST_P(VolumeBackupTest, simple_backup_restore_with_clones)
                      clone_ns1,
                      snap1);
 
-    writeToVolume(*c2, 16, 4096,"bart");
+    writeToVolume(*c2, Lba(16), 4096,"bart");
     c2->createSnapshot(snap1);
     waitForThisBackendWrite(*c2);
 
@@ -1600,9 +1600,9 @@ TEST_P(VolumeBackupTest, simple_backup_restore_with_clones)
     SharedVolumePtr v1 = restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "immanuel");
-    checkVolume(*v1,8, 4096, "arne");
-    checkVolume(*v1,16, 4096, "bart");
+    checkVolume(*v1, Lba(0), 4096, "immanuel");
+    checkVolume(*v1, Lba(8), 4096, "arne");
+    checkVolume(*v1, Lba(16), 4096, "bart");
     removeVolumeCompletely(v1);
 }
 
@@ -1616,7 +1616,7 @@ TEST_P(VolumeBackupTest, impotence_test)
     SharedVolumePtr v = newVolume(vid1,
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 
@@ -1639,7 +1639,7 @@ TEST_P(VolumeBackupTest, impotence_test)
     ASSERT_NO_THROW(check_backup_info(ns2,
                                       0));
 
-    writeToVolume(*v, 0, 4096,"bart");
+    writeToVolume(*v, Lba(0), 4096,"bart");
 
     const SnapshotName snap2("snap2");
 
@@ -1671,7 +1671,7 @@ TEST_P(VolumeBackupTest, impotence_test)
     v1 = restartVolumeFromBackup(restore_to);
     ASSERT_TRUE(v1 != nullptr);
 
-    checkVolume(*v1,0, 4096, "bart");
+    checkVolume(*v1, Lba(0), 4096, "bart");
     removeVolumeCompletely(v1);
 }
 
@@ -1685,7 +1685,7 @@ TEST_P(VolumeBackupTest, fix_backend)
     SharedVolumePtr v = newVolume(vid1,
                           ns1);
 
-    writeToVolume(*v, 0, 4096,"immanuel");
+    writeToVolume(*v, Lba(0), 4096,"immanuel");
 
     const SnapshotName snap1("snap1");
 

--- a/src/volumedriver/test/VolumeDriverConfigurationTest.cpp
+++ b/src/volumedriver/test/VolumeDriverConfigurationTest.cpp
@@ -334,12 +334,12 @@ TEST_P(VolumeDriverConfigurationTest, mount_points)
         EXPECT_EQ(0U, hits);
         EXPECT_EQ(0U, misses);
 
-        writeToVolume(*v, 0, 4096, pattern);
+        writeToVolume(*v, Lba(0), 4096, pattern);
         const uint64_t test_times = 5;
 
         for(unsigned i = 0; i < test_times; ++i)
         {
-            checkVolume(*v, 0, 4096, pattern);
+            checkVolume(*v, Lba(0), 4096, pattern);
         }
 
         VolManager::get()->getClusterCache().get_stats(hits, misses, entries);
@@ -383,7 +383,7 @@ TEST_P(VolumeDriverConfigurationTest, mount_points)
 
         for(unsigned i = 0; i < test_times; ++i)
         {
-            checkVolume(*v, 0, 4096, pattern);
+            checkVolume(*v, Lba(0), 4096, pattern);
         }
 
         VolManager::get()->getClusterCache().get_stats(hits, misses, entries);
@@ -408,7 +408,7 @@ TEST_P(VolumeDriverConfigurationTest, mount_points)
         }
         for(unsigned i = 0; i < test_times; ++i)
         {
-            checkVolume(*v, 0, 4096, pattern);
+            checkVolume(*v, Lba(0), 4096, pattern);
         }
 
         VolManager::get()->getClusterCache().get_stats(hits, misses, entries);

--- a/src/volumedriver/test/VolumeStateManagementTest.cpp
+++ b/src/volumedriver/test/VolumeStateManagementTest.cpp
@@ -39,12 +39,12 @@ TEST_P(VolumeStateManagementTest, test1)
               v->getVolumeFailOverState());
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "xyz");
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 
@@ -71,12 +71,12 @@ TEST_P(VolumeStateManagementTest, NoCache)
               v->getVolumeFailOverState());
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   "xyz");
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "xyz");
 
@@ -108,7 +108,7 @@ TEST_P(VolumeStateManagementTest, test2)
         for(int i =0; i < 32; ++i)
         {
             writeToVolume(*v,
-                          0,
+                          Lba(0),
                           4096,
                           "xyz");
         }
@@ -117,7 +117,7 @@ TEST_P(VolumeStateManagementTest, test2)
     for(int i = 0; i < 32; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       4096,
                       "abc");
     }
@@ -128,7 +128,7 @@ TEST_P(VolumeStateManagementTest, test2)
               v->getVolumeFailOverState());
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 4096,
                 "abc");
 
@@ -180,7 +180,7 @@ TEST_P(VolumeStateManagementTest, CreateVolumeWithRemoteCache)
         {
             SCOPED_BLOCK_BACKEND(*v);
 
-            writeToVolume(*v,0,4096,"bart");
+            writeToVolume(*v, Lba(0),4096,"bart");
             EXPECT_NO_THROW(v->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode())));
             EXPECT_EQ(VolumeFailOverState::KETCHUP,
                       v->getVolumeFailOverState());
@@ -254,7 +254,7 @@ TEST_P(VolumeStateManagementTest, CreateVolumeStandaloneLocalRestart)
     SharedVolumePtr v = newVolume("vol1",
 			  ns1);
 
-    writeToVolume (*v, 0, 4096, "bart");
+    writeToVolume(*v, Lba(0), 4096, "bart");
     v->sync();
 
     EXPECT_EQ(VolumeFailOverState::OK_STANDALONE,
@@ -266,7 +266,7 @@ TEST_P(VolumeStateManagementTest, CreateVolumeStandaloneLocalRestart)
 
     ASSERT_NO_THROW(v = localRestart(ns1));
 
-    checkVolume(*v,0,4096, "bart");
+    checkVolume(*v, Lba(0), 4096, "bart");
     EXPECT_EQ(VolumeFailOverState::OK_STANDALONE,
               v->getVolumeFailOverState());
     destroyVolume(v,
@@ -288,7 +288,7 @@ TEST_P(VolumeStateManagementTest, CreateVolumeWithFailoverLocalRestart)
 
     ASSERT_NO_THROW(v->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode())));
 
-    writeToVolume(*v, 0, 4096, "bart");
+    writeToVolume(*v, Lba(0), 4096, "bart");
     EXPECT_EQ(VolumeFailOverState::OK_SYNC,
               v->getVolumeFailOverState());
     destroyVolume(v,
@@ -296,7 +296,7 @@ TEST_P(VolumeStateManagementTest, CreateVolumeWithFailoverLocalRestart)
                   RemoveVolumeCompletely::F);
     ASSERT_NO_THROW(v = localRestart(ns1));
 
-    checkVolume(*v,0,4096, "bart");
+    checkVolume(*v, Lba(0),4096, "bart");
     EXPECT_EQ(VolumeFailOverState::OK_SYNC,
               v->getVolumeFailOverState());
     destroyVolume(v,
@@ -320,7 +320,7 @@ TEST_P(VolumeStateManagementTest, CreateVolumeWithFailoverLocalRestart2)
 
         ASSERT_NO_THROW(v->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode())));
 
-        writeToVolume(*v, 0, 4096, "bart");
+        writeToVolume(*v, Lba(0), 4096, "bart");
         EXPECT_EQ(VolumeFailOverState::OK_SYNC,
                   v->getVolumeFailOverState());
     }
@@ -330,7 +330,7 @@ TEST_P(VolumeStateManagementTest, CreateVolumeWithFailoverLocalRestart2)
                   RemoveVolumeCompletely::F);
     ASSERT_NO_THROW(v = localRestart(ns1));
 
-    checkVolume(*v,0,4096, "bart");
+    checkVolume(*v,Lba(0),4096, "bart");
     EXPECT_EQ(VolumeFailOverState::DEGRADED,
               v->getVolumeFailOverState());
     destroyVolume(v,
@@ -367,7 +367,7 @@ TEST_P(VolumeStateManagementTest, DISABLED_CreateVolumeStandaloneLocalRestartWit
         SCOPED_DESTROY_VOLUME_UNBLOCK_BACKEND(v,1,
                                               DeleteLocalData::F,
                                               RemoveVolumeCompletely::F);
-        writeToVolume(*v, 0, 4096, "bart");
+        writeToVolume(*v, Lba(0), 4096, "bart");
     }
     TODO("AR: how is this supposed to work - v is destroyed and afterwards the backend queue shall be blocked?")
     auto foc_ctx(start_one_foc());
@@ -379,7 +379,7 @@ TEST_P(VolumeStateManagementTest, DISABLED_CreateVolumeStandaloneLocalRestartWit
         ASSERT_NO_THROW(v = localRestart(ns1));
         v->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode()));
 
-        checkVolume(*v,0,4096, "bart");
+        checkVolume(*v,Lba(0),4096, "bart");
     }
     checkReachesState(v, VolumeFailOverState::OK_SYNC, 20);
     destroyVolume(v,
@@ -598,7 +598,7 @@ TEST_P(VolumeStateManagementTest, events)
     const std::string s("some data");
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   4096,
                   s);
 

--- a/src/volumedriver/test/VolumeTest.cpp
+++ b/src/volumedriver/test/VolumeTest.cpp
@@ -103,8 +103,12 @@ protected:
         }
     }
 
-    void readLBAs(Lba lba, uint64_t count, uint32_t pattern,
-                  bool verify=true, SharedVolumePtr vol = nullptr, int retries = 7)
+    void readLBAs(Lba lba,
+                  uint64_t count,
+                  uint32_t pattern,
+                  bool verify=true,
+                  SharedVolumePtr vol = nullptr,
+                  int retries = 7)
     {
         bool fail = true;
         if (vol == 0) {

--- a/src/volumedriver/test/WriteOnlyVolumeTest.cpp
+++ b/src/volumedriver/test/WriteOnlyVolumeTest.cpp
@@ -46,7 +46,7 @@ TEST_P(WriteOnlyVolumeTest, test1)
 
     const std::string pattern("blah");
     const std::string pattern2("halb");
-    writeToVolume(*v, 0, 4096, pattern);
+    writeToVolume(*v, Lba(0), 4096, pattern);
     v->scheduleBackendSync();
     waitForThisBackendWrite(*v);
 
@@ -60,7 +60,7 @@ TEST_P(WriteOnlyVolumeTest, test1)
 
     ASSERT_TRUE(vol != nullptr);
 
-    checkVolume(*vol, 0, 4096, pattern);
+    checkVolume(*vol, Lba(0), 4096, pattern);
 
     destroyVolume(vol,
                   DeleteLocalData::T,
@@ -69,7 +69,7 @@ TEST_P(WriteOnlyVolumeTest, test1)
 
     setVolumeRole(ns, VolumeConfig::WanBackupVolumeRole::WanBackupBase);
     v = restartWriteOnlyVolume(vCfg);
-    writeToVolume(*v, 8, 4096, pattern2);
+    writeToVolume(*v, Lba(8), 4096, pattern2);
     v->scheduleBackendSync();
     waitForThisBackendWrite(*v);
 
@@ -84,8 +84,8 @@ TEST_P(WriteOnlyVolumeTest, test1)
 
     ASSERT_TRUE(vol != nullptr);
 
-    checkVolume(*vol, 0, 4096, pattern);
-    checkVolume(*vol, 8, 4096, pattern2);
+    checkVolume(*vol, Lba(0), 4096, pattern);
+    checkVolume(*vol, Lba(8), 4096, pattern2);
     destroyVolume(vol,
                   DeleteLocalData::T,
                   RemoveVolumeCompletely::F);
@@ -106,7 +106,7 @@ TEST_P(WriteOnlyVolumeTest, no_restart_from_incremental_volume)
 
     const std::string pattern("blah");
     const std::string pattern2("halb");
-    writeToVolume(*v, 0, 4096, pattern);
+    writeToVolume(*v, Lba(0), 4096, pattern);
     v->scheduleBackendSync();
     waitForThisBackendWrite(*v);
 
@@ -136,7 +136,7 @@ TEST_P(WriteOnlyVolumeTest, no_clone_from_incremental)
     const VolumeConfig cfg(wov->get_config());
 
     const std::string pattern("All work and no play makes Jack a dull boy.");
-    writeToVolume(*wov, 0, 16384, pattern);
+    writeToVolume(*wov, Lba(0), 16384, pattern);
 
     const SnapshotName snap("snap");
     wov->createSnapshot(snap);
@@ -175,7 +175,7 @@ TEST_P(WriteOnlyVolumeTest, no_restart_from_base_volume)
 
     const std::string pattern("blah");
     const std::string pattern2("halb");
-    writeToVolume(*v, 0, 4096, pattern);
+    writeToVolume(*v, Lba(0), 4096, pattern);
     v->scheduleBackendSync();
     waitForThisBackendWrite(*v);
 
@@ -208,11 +208,11 @@ TEST_P(WriteOnlyVolumeTest, test2)
     {
         std::stringstream ss;
         ss << std::setfill('_') << std::setw(2) << i;
-        writeToVolume(*v, 0, 4096, ss.str());
+        writeToVolume(*v, Lba(0), 4096, ss.str());
         v->createSnapshot(SnapshotName(ss.str()));
         waitForThisBackendWrite(*v);
     }
-    writeToVolume(*v,0, 4096, "blah");
+    writeToVolume(*v, Lba(0), 4096, "blah");
 
     v->scheduleBackendSync();
     destroyVolume(v,
@@ -236,7 +236,7 @@ TEST_P(WriteOnlyVolumeTest, test2)
         restartVolume(vCfg);
         SharedVolumePtr vol = getVolume(vid);
         ASSERT_TRUE(vol != nullptr);
-        checkVolume(*vol, 0, 4096, ss.str());
+        checkVolume(*vol, Lba(0), 4096, ss.str());
         destroyVolume(vol,
                       DeleteLocalData::T,
                       RemoveVolumeCompletely::F);

--- a/src/volumedriver/test/cases.cpp
+++ b/src/volumedriver/test/cases.cpp
@@ -88,7 +88,7 @@ TEST_P(cases, DISABLED_cacheserver1)
 
     for(unsigned i = 0; i < num_writes; i++)
     {
-            writeToVolume(*v1, i*distance, sizew, "X");
+        writeToVolume(*v1, Lba(i*distance), sizew, "X");
     }
     createSnapshot(*v1, "snap1");
     while(not v1->isSyncedToBackend())
@@ -110,7 +110,7 @@ TEST_P(cases, DISABLED_cacheserver1)
     {
         if(i%3 == 1)
         {
-            writeToVolume(*v2, i*distance, sizew, "Y");
+            writeToVolume(*v2, Lba(i*distance), sizew, "Y");
         }
     }
     createSnapshot(*v2, "snap1");
@@ -128,7 +128,7 @@ TEST_P(cases, DISABLED_cacheserver1)
         {
             if(i%3 == 2)
             {
-                writeToVolume(*v2, i*distance, sizew, "Z");
+                writeToVolume(*v2, Lba(i*distance), sizew, "Z");
             }
 
         }
@@ -143,13 +143,13 @@ TEST_P(cases, DISABLED_cacheserver1)
         switch(i %3 )
         {
         case 0:
-            checkVolume(*v2,i*distance, sizew, "X");
+            checkVolume(*v2,Lba(i*distance), sizew, "X");
             break;
         case 1:
-            checkVolume(*v2,i*distance, sizew, "Y");
+            checkVolume(*v2,Lba(i*distance), sizew, "Y");
             break;
         case 2:
-            checkVolume(*v2,i*distance, sizew, "Z");
+            checkVolume(*v2,Lba(i*distance), sizew, "Z");
             break;
         default:
             assert(0=="remarkable");
@@ -341,7 +341,7 @@ TEST_P(cases, DISABLED_restartALittle) // Ev'ry time you go away, I ...
 
     v1->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode()));
 
-    writeToVolume(*v1,0,4096*2048, t);
+    writeToVolume(*v1,Lba(0),4096*2048, t);
     const VolumeConfig vCfg(v1->get_config());
 
     destroyVolume(v1,
@@ -358,12 +358,12 @@ TEST_P(cases, DISABLED_restartALittle) // Ev'ry time you go away, I ...
         ASSERT_TRUE(v1 != nullptr);
         v1->setFailOverCacheConfig(foc_ctx->config(GetParam().foc_mode()));
 
-        checkVolume(*v1,0,4096*2048,t);
+        checkVolume(*v1,Lba(0),4096*2048,t);
 
         std::stringstream ss;
         ss << "bart_" << i;
         t = ss.str();
-        writeToVolume(*v1,0,4096*2048, t);
+        writeToVolume(*v1,Lba(0),4096*2048, t);
         destroyVolume(v1,
                       DeleteLocalData::F,
                       RemoveVolumeCompletely::F);
@@ -490,7 +490,7 @@ TEST_P(cases, test2)
     for(int i = 0; i < 1; ++i)
     {
         writeToVolume(*v,
-                      0,
+                      Lba(0),
                       16384,
                       "abc");
     }
@@ -498,9 +498,9 @@ TEST_P(cases, test2)
     for(int i = 0; i < numwrites; ++i)
     {
         checkVolume(*v,
-                0,
-                4096,
-                "abc");
+                    Lba(0),
+                    4096,
+                    "abc");
     }
 
     destroyVolume(v,
@@ -515,11 +515,11 @@ TEST_P(cases, DISABLED_test3)
                           ns_ptr->ns());
 
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   16384,
                   "abc");
     checkVolume(*v,
-                0,
+                Lba(0),
                 16384,
                 "abc");
     temporarilyStopVolManager();
@@ -528,7 +528,7 @@ TEST_P(cases, DISABLED_test3)
     SharedVolumePtr v1 = getVolume(VolumeId("1volume"));
     ASSERT_TRUE(v1 != nullptr);
     checkVolume(*v1,
-                0,
+                Lba(0),
                 16384,
                 "abc");
     //v1->put();
@@ -561,11 +561,11 @@ TEST_P(cases, DISABLED_bartNonLocalRestart)
     for(int i = 0; i < 1000; i++)
     {
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "immanuel");
         writeToVolume(*v2,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "immanuel");
 
@@ -576,11 +576,11 @@ TEST_P(cases, DISABLED_bartNonLocalRestart)
     for(int i = 0; i < 100; i++)
     {
         writeToVolume(*v1,
-                      i*mult,
+                      Lba(i*mult),
                       v1->getClusterSize(),
                       "bart");
         writeToVolume(*v2,
-                      i*mult,
+                      Lba(i*mult),
                       v2->getClusterSize(),
                       "bart");
 
@@ -924,7 +924,7 @@ TEST_P(cases, DISABLED_weirdSnapshotsFile)
 
     const std::string pattern1 = "11111111";
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getClusterSize(),
                   pattern1);
 
@@ -935,7 +935,7 @@ TEST_P(cases, DISABLED_weirdSnapshotsFile)
 
     const std::string pattern2 = "22222222";
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getClusterSize(),
                   pattern2);
 
@@ -943,7 +943,7 @@ TEST_P(cases, DISABLED_weirdSnapshotsFile)
 
     const std::string pattern3 = "33333333";
     writeToVolume(*v,
-                  0,
+                  Lba(0),
                   v->getClusterSize(),
                   pattern3);
 
@@ -954,7 +954,7 @@ TEST_P(cases, DISABLED_weirdSnapshotsFile)
     v->restoreSnapshot(SnapshotName("snap1"));
 
     checkVolume(*v,
-                0,
+                Lba(0),
                 v->getClusterSize(),
                 pattern1);
 


### PR DESCRIPTION
In which new read/write interfaces are introduced to the volumedriver core to allow addressing at byte level (in addition to LBA granularity), so the conversion from byte addresses to LBAs can be removed from `LocalNode` and be done in a single place.

Addresses #302 .