### PR TITLE
VolumeDriver keepalive mechanism

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -22,11 +22,14 @@ service ovs-volumedriver-vpool_name restart
 | volume_router | vrouter_id | --- | no | the vrouter_id of this node of the cluster. Must be one of the vrouter_id's s specified in the vrouter_cluster_nodes section |
 | volume_router | vrouter_sco_multiplier | "1024" | no | number of clusters in a sco |
 | volume_router | vrouter_routing_retries | "30" | yes | number of times the routing shall be retried in case the volume is not found (exponential backoff inbetween retries!) |
-| volume_router | vrouter_min_workers | "4" | yes | minimum number of worker threads to handle redirected requests |
-| volume_router | vrouter_max_workers | "16" | yes | maximum number of worker threads to handle redirected requests |
+| volume_router | vrouter_min_workers | "4" | no | minimum number of worker threads to handle redirected requests |
+| volume_router | vrouter_max_workers | "16" | no | maximum number of worker threads to handle redirected requests |
 | volume_router | vrouter_registry_cache_capacity | "1024" | no | number of ObjectRegistrations to keep cached |
 | volume_router | vrouter_use_fencing | "0" | yes | whether to use fencing support if it is available |
 | volume_router | vrouter_send_sync_response | "1" | yes | whether to send extended response data on sync requests |
+| volume_router | vrouter_keepalive_time_secs | "60" | yes | time between two keepalive probe cycles in seconds (0 switches keepalive off) |
+| volume_router | vrouter_keepalive_interval_secs | "10" | yes | time (seconds) between probes of a cycle if the previous one was unacknowledged |
+| volume_router | vrouter_keepalive_retries | "5" | yes | number of unacknowledged probes before considering the other side dead |
 | volume_router_cluster | vrouter_cluster_id | --- | no | cluster_id of the volumeroutercluster this node belongs to |
 | fuse | fuse_min_workers | "8" | yes | minimum number of FUSE worker threads |
 | fuse | fuse_max_workers | "8" | yes | maximum number of FUSE worker threads |

--- a/src/filesystem/FileSystemParameters.cpp
+++ b/src/filesystem/FileSystemParameters.cpp
@@ -180,6 +180,27 @@ DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_send_sync_response,
                                       ShowDocumentation::T,
                                       true);
 
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_keepalive_time_secs,
+                                      volumerouter_component_name,
+                                      "vrouter_keepalive_time_secs",
+                                      "time between two keepalive probe cycles in seconds (0 switches keepalive off)",
+                                      ShowDocumentation::T,
+                                      60);
+
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_keepalive_interval_secs,
+                                      volumerouter_component_name,
+                                      "vrouter_keepalive_interval_secs",
+                                      "time (seconds) between probes of a cycle if the previous one was unacknowledged",
+                                      ShowDocumentation::T,
+                                      10);
+
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_keepalive_retries,
+                                      volumerouter_component_name,
+                                      "vrouter_keepalive_retries",
+                                      "number of unacknowledged probes before considering the other side dead",
+                                      ShowDocumentation::T,
+                                      5);
+
 // ObjectRouterCluster
 const char volumeroutercluster_component_name[] = "volume_router_cluster";
 

--- a/src/filesystem/FileSystemParameters.h
+++ b/src/filesystem/FileSystemParameters.h
@@ -76,6 +76,13 @@ DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_use_fencing,
                                                   bool);
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_send_sync_response,
                                                   bool);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_keepalive_time_secs,
+                                                  std::atomic<uint32_t>);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_keepalive_interval_secs,
+                                                  std::atomic<uint32_t>);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_keepalive_retries,
+                                                  std::atomic<uint32_t>);
+
 DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_min_workers,
                                        uint16_t);
 DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_max_workers,

--- a/src/filesystem/FileSystemParameters.h
+++ b/src/filesystem/FileSystemParameters.h
@@ -76,10 +76,10 @@ DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_use_fencing,
                                                   bool);
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_send_sync_response,
                                                   bool);
-DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_min_workers,
-                                                  uint16_t);
-DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_max_workers,
-                                                  uint16_t);
+DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_min_workers,
+                                       uint16_t);
+DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(vrouter_max_workers,
+                                       uint16_t);
 
 DECLARE_INITIALIZED_PARAM(vrouter_id,
                           std::string);

--- a/src/filesystem/ObjectRouter.cpp
+++ b/src/filesystem/ObjectRouter.cpp
@@ -1809,31 +1809,8 @@ ObjectRouter::update(const bpt::ptree& pt,
     U(vrouter_xmlrpc_client_timeout_ms);
     U(vrouter_use_fencing);
     U(vrouter_send_sync_response);
-
-    ip::PARAMETER_TYPE(vrouter_min_workers) min(pt);
-    ip::PARAMETER_TYPE(vrouter_min_workers) max(pt);
-
-    try
-    {
-        if (min.value() != vrouter_min_workers.value() or
-            max.value() != vrouter_max_workers.value())
-        {
-            worker_pool_->resize(min.value(),
-                                 max.value());
-        }
-
-        U(vrouter_min_workers);
-        U(vrouter_max_workers);
-    }
-    CATCH_STD_ALL_EWHAT({
-            LOG_ERROR("Failed to resize worker pool: " << EWHAT);
-            rep.no_update(min.name(),
-                          vrouter_min_workers.value(),
-                          min.value());
-            rep.no_update(max.name(),
-                          vrouter_max_workers.value(),
-                          max.value());
-        });
+    U(vrouter_min_workers);
+    U(vrouter_max_workers);
 
 #undef U
 

--- a/src/filesystem/ObjectRouter.cpp
+++ b/src/filesystem/ObjectRouter.cpp
@@ -563,10 +563,10 @@ ObjectRouter::maybe_steal_(Ret (ClusterNode::*fn)(const Object&,
             ClusterNode& cn = *node;
             return (cn.*fn)(obj, std::forward<Args>(args)...);
         }
-        catch (RequestTimeoutException&)
+        catch (ClusterNodeNotReachableException&)
         {
             VERIFY(remote == IsRemoteNode::T);
-            LOG_ERROR(id << ": remote node " << owner_id << " timed out");
+            LOG_ERROR(id << ": remote node " << owner_id << " not reachable");
 
             if (cluster_registry_->get_node_status(owner_id).state ==
                 ClusterNodeStatus::State::Online)
@@ -1507,9 +1507,9 @@ ObjectRouter::migrate_(const ObjectRegistration& reg,
 
             LOG_INFO(obj << " successfully migrated from " << from);
         }
-        catch (RequestTimeoutException&)
+        catch (ClusterNodeNotReachableException&)
         {
-            LOG_ERROR(id << ": remote node " << from << " timed out while migrating");
+            LOG_ERROR(id << ": remote node " << from << " not reachable while migrating");
             if (not steal_(reg,
                            only_steal_if_offline,
                            force))

--- a/src/filesystem/ObjectRouter.cpp
+++ b/src/filesystem/ObjectRouter.cpp
@@ -119,12 +119,15 @@ ObjectRouter::ObjectRouter(const bpt::ptree& pt,
     worker_pool_ = std::make_unique<ZWorkerPool>("ObjectRouterWorkerPool",
                                                  *ztx_,
                                                  ncfg.message_uri(),
+                                                 vrouter_max_workers.value(),
                                                  [this](ZWorkerPool::MessageParts parts)
                                                  {
                                                      return redirected_work_(std::move(parts));
                                                  },
-                                                 vrouter_min_workers.value(),
-                                                 vrouter_max_workers.value());
+                                                 [](const ZWorkerPool::MessageParts&)
+                                                 {
+                                                     return yt::DeferExecution::T;
+                                                 });
 }
 
 ObjectRouter::~ObjectRouter()

--- a/src/filesystem/ObjectRouter.h
+++ b/src/filesystem/ObjectRouter.h
@@ -492,7 +492,10 @@ private:
     build_config_(const boost::optional<const boost::property_tree::ptree&>& pt);
 
     ZWorkerPool::MessageParts
-    redirected_work_(ZWorkerPool::MessageParts parts_in);
+    redirected_work_(ZWorkerPool::MessageParts);
+
+    youtils::DeferExecution
+    dispatch_redirected_work_(const ZWorkerPool::MessageParts&);
 
     std::shared_ptr<ClusterNode>
     find_node_(const NodeId&) const;

--- a/src/filesystem/ObjectRouter.h
+++ b/src/filesystem/ObjectRouter.h
@@ -382,6 +382,24 @@ public:
         return boost::chrono::milliseconds(vrouter_migrate_timeout_ms.value());
     }
 
+    boost::chrono::seconds
+    keepalive_time() const
+    {
+        return boost::chrono::seconds(vrouter_keepalive_time_secs.value());
+    }
+
+    boost::chrono::seconds
+    keepalive_interval() const
+    {
+        return boost::chrono::seconds(vrouter_keepalive_interval_secs.value());
+    }
+
+    size_t
+    keepalive_retries() const
+    {
+        return vrouter_keepalive_retries.value();
+    }
+
     MaybeFailOverCacheConfig
     failoverconfig_as_it_should_be() const;
 
@@ -454,6 +472,9 @@ private:
     DECLARE_PARAMETER(vrouter_xmlrpc_client_timeout_ms);
     DECLARE_PARAMETER(vrouter_use_fencing);
     DECLARE_PARAMETER(vrouter_send_sync_response);
+    DECLARE_PARAMETER(vrouter_keepalive_time_secs);
+    DECLARE_PARAMETER(vrouter_keepalive_interval_secs);
+    DECLARE_PARAMETER(vrouter_keepalive_retries);
 
     std::shared_ptr<youtils::LockedArakoon> larakoon_;
     std::shared_ptr<CachedObjectRegistry> object_registry_;

--- a/src/filesystem/ObjectRouter.h
+++ b/src/filesystem/ObjectRouter.h
@@ -108,6 +108,7 @@ MAKE_EXCEPTION(ClusterNodeNotOnlineException, Exception);
 MAKE_EXCEPTION(ClusterNodeNotOfflineException, Exception);
 MAKE_EXCEPTION(CannotSetSelfOfflineException, Exception);
 MAKE_EXCEPTION(ObjectStillHasChildrenException, Exception);
+MAKE_EXCEPTION(ClusterNodeNotReachableException, Exception);
 
 // Distributed volume access - the idea is as follows:
 // (1) ClusterNode running the volume is looked up in the registry

--- a/src/filesystem/RemoteNode.h
+++ b/src/filesystem/RemoteNode.h
@@ -107,6 +107,7 @@ private:
     zmq::context_t& ztx_;
     std::unique_ptr<zmq::socket_t> zock_;
     int event_fd_;
+    int timer_fd_;
     bool stop_;
     boost::thread thread_;
 
@@ -119,11 +120,31 @@ private:
     std::list<WorkItemPtr> queued_work_; // push back / pop front
     std::map<vfsprotocol::Tag, WorkItemPtr> submitted_work_;
 
+    // no locking, only ever accessed from within thread_
+    const vfsprotocol::PingMessage keepalive_probe_;
+    WorkItemPtr keepalive_work_;
+    std::atomic<size_t> missing_keepalive_probes_;
+
+    void
+    close_();
+
     void
     notify_();
 
     void
-    init_zock_();
+    reset_();
+
+    void
+    arm_keepalive_timer_(const boost::chrono::seconds&);
+
+    void
+    keepalive_();
+
+    boost::chrono::seconds
+    check_keepalive_();
+
+    void
+    drop_keepalive_work_();
 
     bool
     send_requests_();

--- a/src/filesystem/RemoteNode.h
+++ b/src/filesystem/RemoteNode.h
@@ -129,6 +129,9 @@ private:
     send_requests_();
 
     void
+    submit_work_(const WorkItemPtr&);
+
+    void
     drop_request_(const WorkItem&);
 
     void
@@ -145,10 +148,10 @@ private:
 
     template<typename Request>
     void
-    handle_(const Request& req,
+    handle_(const Request&,
             const boost::chrono::milliseconds& timeout_ms,
-            ExtraSendFun* send_extra = nullptr,
-            ExtraRecvFun* recv_extra = nullptr);
+            ExtraSendFun = ExtraSendFun(),
+            ExtraRecvFun = ExtraRecvFun());
 };
 
 }

--- a/src/filesystem/ZWorkerPool.cpp
+++ b/src/filesystem/ZWorkerPool.cpp
@@ -16,7 +16,7 @@
 #include "ZUtils.h"
 #include "ZWorkerPool.h"
 
-#include <future>
+#include <sys/eventfd.h>
 
 #include <boost/lexical_cast.hpp>
 
@@ -78,574 +78,326 @@ send_parts(zmq::socket_t& zock, ZWorkerPool::MessageParts& parts)
 
 }
 
-class ZWorker
-{
-    typedef ZWorkerPool::ZWorkerId ZWorkerId;
+#define LOCK_TX()                                               \
+    boost::lock_guard<decltype(tx_mutex_)> lgtx__(tx_mutex_)
 
-public:
-    ZWorker(zmq::context_t& ztx,
-            const ZWorkerId zwid,
-            const std::string pool_addr,
-            ZWorkerPool::WorkerFun& fun)
-        : ztx_(ztx)
-        , pool_addr_(pool_addr)
-        , fun_(fun)
-        , id_(zwid)
-    {
-        std::future<bool> future(initialized_.get_future());
-
-        thread_ = boost::thread([&] { work_(); });
-
-        try
-        {
-            future.get();
-        }
-        CATCH_STD_ALL_EWHAT({
-                LOG_ERROR(id() << ": failed to initialize thread: " << EWHAT);
-                thread_.join();
-                throw;
-            });
-
-        LOG_INFO(id() << ": up and running");
-    }
-
-    ~ZWorker()
-    {
-        try
-        {
-            thread_.join();
-        }
-        CATCH_STD_ALL_LOG_IGNORE(id() << ": failed to join");
-
-        LOG_INFO(id() << ": and that was that");
-    }
-
-    ZWorker(const ZWorker&) = delete;
-
-    ZWorker&
-    operator=(const ZWorker&) = delete;
-
-    ZWorkerId
-    id() const
-    {
-        return id_;
-    }
-
-private:
-    DECLARE_LOGGER("ZWorker");
-
-    boost::thread thread_;
-    zmq::context_t& ztx_;
-    const std::string pool_addr_;
-    ZWorkerPool::WorkerFun& fun_;
-    std::promise<bool> initialized_;
-    const ZWorkerId id_;
-
-    // The socket isn't a member to prevent multithreaded use of it.
-
-    std::unique_ptr<zmq::socket_t>
-    create_socket_()
-    {
-        LOG_TRACE(id() << ": creating new socket");
-
-        std::unique_ptr<zmq::socket_t> zock(new zmq::socket_t(ztx_, ZMQ_REQ));
-        ZUtils::socket_no_linger(*zock);
-
-        const ZWorkerId sock_id = id();
-        zock->setsockopt(ZMQ_IDENTITY, &sock_id, sizeof(sock_id));
-
-        LOG_INFO(id() << ": connecting socket to pool " << pool_addr_);
-        zock->connect(pool_addr_.c_str());
-
-        registerize_(*zock);
-
-        return zock;
-    }
-
-    void
-    registerize_(zmq::socket_t& zock)
-    {
-        LOG_TRACE(id() << ": registering with pool");
-        zmq::message_t msg(0);
-        zock.send(msg, 0);
-    }
-
-    std::unique_ptr<zmq::socket_t>
-    recreate_socket_(std::unique_ptr<zmq::socket_t> zock)
-    {
-        LOG_TRACE(id() << ": recreating socket");
-
-        // returns an error each time anyway
-
-        // try
-        // {
-        //     zock->disconnect(pool_addr_.c_str());
-        // }
-        // CATCH_STD_ALL_LOG_IGNORE(id() << ": failed to disconnect from " << pool_addr_);
-        zock.reset();
-
-        return create_socket_();
-    }
-
-    void
-    work_()
-    {
-        try
-        {
-            do_work_();
-        }
-        CATCH_STD_ALL_EWHAT({
-                LOG_ERROR(id() << ": error in worker: " << EWHAT - " exiting thread");
-            });
-    }
-
-    void
-    do_work_()
-    {
-        LOG_TRACE(id());
-
-        std::unique_ptr<zmq::socket_t> zock;
-
-        try
-        {
-            zock = create_socket_();
-        }
-        CATCH_STD_ALL_EWHAT({
-                LOG_ERROR(id() << ": failed to create socket: " << EWHAT);
-                initialized_.set_exception(std::current_exception());
-                throw;
-            });
-
-        initialized_.set_value(true);
-
-        while (true)
-        {
-            try
-            {
-                zmq::message_t sender_id;
-                zock->recv(&sender_id);
-
-                if (sender_id.size() == 0)
-                {
-                    ZEXPECT_NOTHING_MORE(*zock);
-                    LOG_INFO(id() << ": the pool has asked us to stop");
-                    break;
-                }
-                else
-                {
-                    ZEXPECT_MORE(*zock, "delimiter");
-                    zmq::message_t delimiter;
-                    zock->recv(&delimiter);
-
-                    ZWorkerPool::MessageParts parts_in(recv_parts(*zock));
-                    if (parts_in.empty())
-                    {
-                        LOG_ERROR(id() << ": expected more message parts");
-                        throw fungi::IOException("Expected more message parts",
-                                                 boost::lexical_cast<std::string>(id()).c_str(),
-                                                 EINVAL);
-                    }
-
-                    LOG_TRACE(id() << ": handing off to worker fun");
-
-                    ZWorkerPool::MessageParts parts_out(fun_(std::move(parts_in)));
-                    VERIFY(not parts_out.empty());
-
-                    LOG_TRACE(id() << ": sending reply");
-
-                    zock->send(sender_id, ZMQ_SNDMORE);
-                    zock->send(delimiter, ZMQ_SNDMORE);
-                    send_parts(*zock, parts_out);
-                }
-            }
-            catch (zmq::error_t& e)
-            {
-                if (e.num() == ETERM)
-                {
-                    LOG_INFO(id() << ": termination requested");
-                    break;
-                }
-                else
-                {
-                    LOG_ERROR(id() << ": caught ZMQ exception " << e.what() <<
-                              ", num " << e.num());
-                    zock = recreate_socket_(std::move(zock));
-                }
-            }
-            CATCH_STD_ALL_EWHAT({
-                    LOG_ERROR(id() << ": caught exception: " << EWHAT);
-                    registerize_(*zock);
-                });
-        }
-    }
-};
-
-#define LOCK()                                          \
-    boost::lock_guard<decltype(lock_)> lg__(lock_)
+#define LOCK_RX()                                               \
+    boost::lock_guard<decltype(rx_mutex_)> lgrx__(rx_mutex_)
 
 ZWorkerPool::ZWorkerPool(const std::string& name,
                          zmq::context_t& ztx,
-                         const yt::Uri& pub_uri,
+                         const yt::Uri& uri,
+                         uint16_t num_workers,
                          WorkerFun worker_fun,
-                         uint16_t min_workers,
-                         uint16_t max_workers)
-    : min_(min_workers)
-    , max_(max_workers)
-    , worker_fun_(std::move(worker_fun))
+                         DispatchFun dispatch_fun)
+    : worker_fun_(std::move(worker_fun))
+    , dispatch_fun_(std::move(dispatch_fun))
     , ztx_(ztx)
     , name_(name)
-    , pub_uri_(pub_uri)
+    , uri_(uri)
+    , stop_(false)
 {
-    validate_settings(min_, max_);
+    THROW_UNLESS(num_workers > 0);
 
-    LOG_INFO(name_ << ": ready, min workers " << min_ << ", max workers " << max_);
+    zmq::socket_t zock(ztx_, ZMQ_ROUTER);
+    ZUtils::socket_no_linger(zock);
 
-    std::future<bool> future(initialized_.get_future());
+    const auto addr(boost::lexical_cast<std::string>(uri_));
+    zock.bind(addr.c_str());
+    LOG_INFO("Listening for requests from clients on " << addr);
 
-    router_thread_ = boost::thread([&]{ route_(); });
+    event_fd_ = eventfd(0, EFD_NONBLOCK);
+    if (event_fd_ == -1)
+    {
+        LOG_ERROR(name_ << ": failed to create eventfd: " << strerror(errno));
+        throw fungi::IOException("failed to create eventfd for ZWorkerPool",
+                                 name_.c_str(),
+                                 errno);
+    }
 
     try
     {
-        future.get();
+        for (size_t i = 0; i < num_workers; ++i)
+        {
+            workers_.create_thread(boost::bind(&ZWorkerPool::work_,
+                                               this));
+        }
+
+        // work around boost::bind not working with move semantics /
+        // my inability to convince it:
+        router_ = boost::thread([this,
+                                 z = std::move(zock)]() mutable -> void
+                                {
+                                    ZWorkerPool::route_(std::move(z));
+                                });
     }
     CATCH_STD_ALL_EWHAT({
-            LOG_ERROR(name_ << ": failed to initialize router thread: " << EWHAT);
-            router_thread_.join();
+            LOG_ERROR(name_ << ": failed to create threads: " << EWHAT);
+            close_();
             throw;
         });
+
+    LOG_INFO(name_ << ": ready, " << size() << " workers");
 }
 
 ZWorkerPool::~ZWorkerPool()
 {
     LOG_TRACE(name_ << ": shutting down");
-
-    try
-    {
-        router_thread_.join();
-    }
-    CATCH_STD_ALL_LOG_IGNORE("failed to shut down router thread properly - resources might be leaked");
-
-    busy_ones_.clear();
-    unused_ones_.clear();
+    close_();
 }
 
 void
-ZWorkerPool::validate_settings(uint16_t min,
-                               uint16_t max)
+ZWorkerPool::notify_()
 {
-    // XXX: enforce upper boundaries (which ones?) too?
-    if (min == 0)
+    ASSERT(event_fd_ >= 0);
+    int ret;
+    do
     {
-        LOG_ERROR(name_ << ": minimum number of workers must be > 0");
-        throw fungi::IOException("Minimum number of workers must be > 0",
-                                 name_.c_str(),
-                                 EINVAL);
+        ret = eventfd_write(event_fd_, 1);
     }
+    while (ret < 0 && errno == EINTR);
 
-    if (max < min)
-    {
-        LOG_ERROR(name_ <<
-                  ": maximum number of workers must not be < minimum number of workers");
-        throw fungi::IOException("Maximum number of workers must not be < minimum number of workers",
-                                 name_.c_str(),
-                                 EINVAL);
-    }
-}
-
-std::string
-ZWorkerPool::back_address_() const
-{
-    return "inproc://" + name_ + "-back";
+    VERIFY(ret == 0);
 }
 
 void
-ZWorkerPool::route_()
+ZWorkerPool::reap_notification_()
 {
-    bool up = false;
-    LOG_TRACE("kicking off");
+    eventfd_t n = 0;
 
-    try
+    int ret = 0;
+    do
     {
-        zmq::socket_t front_sock(ztx_, ZMQ_ROUTER);
-        ZUtils::socket_no_linger(front_sock);
-
-        const auto pub_addr(boost::lexical_cast<std::string>(pub_uri_));
-        LOG_INFO("Binding public interface to " << pub_addr);
-        front_sock.bind(pub_addr.c_str());
-        LOG_TRACE("Listening for requests from clients on " << pub_addr);
-
-        zmq::socket_t back_sock(ztx_, ZMQ_ROUTER);
-        ZUtils::socket_no_linger(back_sock);
-
-        LOG_INFO("Binding interface to workers to " << back_address_());
-        back_sock.bind(back_address_().c_str());
-
-        LOG_TRACE("Listening for messages from workers on " << back_address_());
-
-        initialized_.set_value(true);
-        up = true;
-
-        CanMakeProgress can_make_progress = CanMakeProgress::T;
-
-        while (true)
-        {
-            try
-            {
-                std::array<zmq::pollitem_t, 2> pollset;
-                pollset[0].socket = front_sock;
-                pollset[0].events = (can_make_progress == CanMakeProgress::T) ?
-                    ZMQ_POLLIN :
-                    0;
-                pollset[0].revents = 0;
-
-                pollset[1].socket = back_sock;
-                pollset[1].events = ZMQ_POLLIN;
-                pollset[1].revents = 0;
-
-                LOG_TRACE(name_ << ": starting to poll");
-                const int ret = zmq::poll(pollset.data(), pollset.size());
-                if (ret > 0)
-                {
-                    LOG_TRACE(name_ << ": " << ret << " events signalled");
-
-                    if ((pollset[1].revents bitand ZMQ_POLLIN) != 0)
-                    {
-                        handle_back_(front_sock, back_sock);
-                        can_make_progress = CanMakeProgress::T;
-                    }
-
-                    if ((pollset[0].revents bitand ZMQ_POLLIN) != 0)
-                    {
-                        can_make_progress = handle_front_(front_sock, back_sock);
-                    }
-                }
-                else
-                {
-                    LOG_WARN(name_ << ": poll unexpectedly returned " << ret);
-                    can_make_progress = CanMakeProgress::T;
-                }
-            }
-            catch (zmq::error_t& e)
-            {
-                if (e.num() == ETERM)
-                {
-                    LOG_INFO(name_ << ": stop requested, breaking out of the loop");
-                    return;
-                }
-                else
-                {
-                    LOG_ERROR("Caught ZMQ error " << e.what() << ", num " << e.num());
-                    // can we really proceed here, or do we need to reset the sockets?
-                    can_make_progress = CanMakeProgress::T;
-                }
-            }
-        }
+        ret = eventfd_read(event_fd_, &n);
     }
-    CATCH_STD_ALL_EWHAT({
-            if (not up)
-            {
-                initialized_.set_exception(std::current_exception());
-            }
-            LOG_ERROR(name_ << ": " << EWHAT << " - exiting router thread");
-        });
-}
+    while (ret < 0 and errno == EINTR);
 
-CanMakeProgress
-ZWorkerPool::handle_front_(zmq::socket_t& front_sock,
-                           zmq::socket_t& back_sock)
-{
-    LOG_TRACE(name_);
-
-    ZWorkerId id = 0;
-
+    if (ret < 0)
     {
-        LOCK();
-
-        VERIFY(unused_ones_.size() + busy_ones_.size() <= max_);
-
-        if (not unused_ones_.empty())
-        {
-            ZWorkerPtr w(std::move(unused_ones_.front()));
-            LOG_TRACE(name_ << ": using idle zworker " << w->id());
-
-            unused_ones_.pop_front();
-            auto res(busy_ones_.emplace(w->id(), std::move(w)));
-            VERIFY(res.second);
-            id = res.first->first;
-        }
-        else if (busy_ones_.size() == max_)
-        {
-            LOG_WARN(name_ << ": max number of workers " << max_ <<
-                     " reached, we need to wait for one of the existing workers to become available");
-            return CanMakeProgress::F;
-        }
-        else
-        {
-            ZWorkerPtr w(new ZWorker(ztx_,
-                                     next_zworker_id_(),
-                                     back_address_(),
-                                     worker_fun_));
-
-            LOG_INFO(name_ << ": waiting for newly spun up zworker " << w->id());
-
-            auto res(busy_ones_.emplace(w->id(), std::move(w)));
-            VERIFY(res.second);
-
-            return CanMakeProgress::F;
-        }
-    }
-
-    // cf. next_worker_id_()
-    ASSERT(id != 0);
-
-    zmq::message_t recipient(sizeof(id));
-    memcpy(recipient.data(), &id, sizeof(id));
-
-    zmq::message_t delim(0);
-
-    MessageParts parts(recv_parts(front_sock));
-
-    THROW_WHEN(parts.empty());
-    // would clash with our internal protocol and indicate a ZMQ bug
-    VERIFY(parts[0].size() != 0);
-
-    back_sock.send(recipient, ZMQ_SNDMORE);
-    back_sock.send(delim, ZMQ_SNDMORE);
-    send_parts(back_sock, parts);
-
-    return CanMakeProgress::T;
-}
-
-void
-ZWorkerPool::handle_back_(zmq::socket_t& front_sock,
-                          zmq::socket_t& back_sock)
-{
-    LOG_TRACE(name_);
-
-    zmq::message_t worker_id;
-    back_sock.recv(&worker_id);
-
-    VERIFY(worker_id.size() == sizeof(ZWorkerId));
-
-    const ZWorkerId id = *static_cast<ZWorkerId*>(worker_id.data());
-
-    ZEXPECT_MORE(back_sock, "delimiter");
-
-    zmq::message_t delimiter;
-    back_sock.recv(&delimiter);
-
-    MessageParts parts(recv_parts(back_sock));
-    VERIFY(not parts.empty());
-
-    if (parts[0].size() == 0)
-    {
-        LOG_INFO(name_ << ": worker " << id << " reported for duty");
-        worker_ready_(id);
+        VERIFY(errno == EAGAIN);
     }
     else
     {
-        send_parts(front_sock, parts);
-        worker_done_(id, back_sock);
+        VERIFY(ret == 0);
+        VERIFY(n > 0);
     }
 }
 
-ZWorkerPool::ZWorkerId
-ZWorkerPool::next_zworker_id_()
-{
-    // ZMQWorkerTest.{exceptional_work,stress} occasionally got stuck after the socket
-    // was reset and socket identities were based on the object's address. I *suspect*
-    // that this might have been caused by ZMQs destruction scheme (objects are handed
-    // to a reaper thread) leading to conflicts with recycled socket identities.
-    // This simple scheme avoids that for the most part (and the hangs are gone, so
-    // there might be something to my theory); the other piece to the puzzle is *not*
-    // to recreate a socket with the same identity as part of the error handling, but
-    // to simply reuse the existing socket if it's not the source of the exception.
-    const ZWorkerId id = next_id_;
-    next_id_ += 2;
-
-    ASSERT((id % 2) != 0);
-
-    // ZMQ socket identities starting with binary 0 are reserved.
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    VERIFY((id bitand 1ULL) != 0);
-#else
-#error "fix this for big endian platforms"
-#endif
-
-    return id;
-}
-
 void
-ZWorkerPool::worker_ready_(ZWorkerId id)
+ZWorkerPool::close_()
 {
-    LOG_TRACE(name_ << ": worker is ready");
-    LOCK();
-
-    auto it = busy_ones_.find(id);
-    VERIFY(it != busy_ones_.end());
-
-    VERIFY(unused_ones_.size() + busy_ones_.size() <= max_);
-    unused_ones_.emplace_front(std::move(it->second));
-    busy_ones_.erase(it);
-}
-
-void
-ZWorkerPool::worker_done_(ZWorkerId id,
-                          zmq::socket_t& back_sock)
-{
-    LOG_TRACE(name_ << ": worker " << id << " finished");
-
-    LOCK();
-
-    auto it = busy_ones_.find(id);
-    VERIFY(it != busy_ones_.end());
-
-    VERIFY(unused_ones_.size() + busy_ones_.size() <= max_);
-
-    LOG_TRACE(name_ << ": unused " << unused_ones_.size() <<
-              ", busy " << busy_ones_.size());
-
-    if (unused_ones_.size() + busy_ones_.size() <= min_)
+    try
     {
-        LOG_TRACE(name_ << ": returning zworker " << it->second->id() << " to pool");
-        unused_ones_.emplace_front(std::move(it->second));
+        {
+            LOCK_RX();
+            LOCK_TX();
+
+            stop_ = true;
+            rx_cond_.notify_all();
+            notify_();
+        }
+
+        workers_.join_all();
+        router_.join();
+
+        int ret = close(event_fd_);
+        VERIFY(ret == 0);
+    }
+    CATCH_STD_ALL_LOG_IGNORE(name_ << ": failed to close down: " << EWHAT);
+}
+
+void
+ZWorkerPool::route_(zmq::socket_t zock)
+{
+    pthread_setname_np(pthread_self(), "zworker_pool_r");
+
+    {
+        // transfer of ZMQ sockets between threads needs a full barrier
+        LOCK_RX();
+        LOG_INFO(name_ << ": entering event loop");
+    }
+
+    while (true)
+    {
+        try
+        {
+            std::array<zmq::pollitem_t, 2> pollset;
+            pollset[0].socket = zock;
+            pollset[0].events = ZMQ_POLLIN;
+            pollset[0].revents = 0;
+
+            pollset[1].socket = nullptr;
+            pollset[1].fd = event_fd_;
+            pollset[1].events = ZMQ_POLLIN;
+            pollset[1].revents = 0;
+
+            LOG_TRACE(name_ << ": starting to poll");
+            const int ret = zmq::poll(pollset.data(),
+                                      pollset.size());
+            if (ret > 0)
+            {
+                LOG_TRACE(name_ << ": " << ret << " events signalled");
+
+                if ((pollset[1].revents bitand ZMQ_POLLIN) != 0)
+                {
+                    send_(zock);
+                }
+
+                if ((pollset[0].revents bitand ZMQ_POLLIN) != 0)
+                {
+                    recv_(zock);
+                }
+            }
+            else
+            {
+                LOG_WARN(name_ << ": poll unexpectedly returned " << ret);
+            }
+
+            LOCK_RX();
+            if (stop_)
+            {
+                LOG_INFO(name_ << ": stop requested");
+                break;
+            }
+        }
+        catch (zmq::error_t& e)
+        {
+            if (e.num() == ETERM)
+            {
+                LOG_INFO(name_ << ": stop requested, breaking out of the loop");
+                return;
+            }
+            else
+            {
+                LOG_ERROR(name_ << ": caught ZMQ error " << e.what() << ", num " << e.num());
+            }
+        }
+        CATCH_STD_ALL_LOG_IGNORE(name_ << ": caught exception in router thread");
+    }
+}
+
+void
+ZWorkerPool::recv_(zmq::socket_t& zock)
+{
+    LOG_TRACE(name_);
+
+    zmq::message_t sender_id;
+    zock.recv(&sender_id);
+    ZEXPECT_MORE(zock, "delimiter");
+
+    zmq::message_t delim;
+    zock.recv(&delim);
+
+    MessageParts rx_parts(recv_parts(zock));
+
+    const yt::DeferExecution defer = dispatch_fun_(rx_parts);
+    if (defer == yt::DeferExecution::T)
+    {
+        LOG_TRACE(name_ << ": deferring to thread");
+
+        LOCK_RX();
+        rx_queue_.emplace_back(std::move(sender_id),
+                               std::move(rx_parts));
+        rx_cond_.notify_one();
     }
     else
     {
-        LOG_TRACE(name_ << ": stopping zworker " << it->second->id());
-        stop_worker_(id, back_sock);
+        LOG_TRACE(name_ << ": executing immediately");
+
+        MessageParts tx_parts(worker_fun_(std::move(rx_parts)));
+        ASSERT(not tx_parts.empty());
+
+        send_(zock,
+              SenderAndMessage(std::move(sender_id),
+                               std::move(tx_parts)));
     }
-
-    // XXX: this one might take too long as we're waiting for the thread to exit
-    busy_ones_.erase(it);
 }
 
 void
-ZWorkerPool::stop_worker_(ZWorkerId id,
-                          zmq::socket_t& back_sock)
+ZWorkerPool::send_(zmq::socket_t& zock,
+                   SenderAndMessage sam)
 {
-    LOG_INFO(name_ << ": asking worker " << id << " to stop");
-    zmq::message_t worker(sizeof(id));
-    *static_cast<ZWorkerId*>(worker.data()) = id;
+    zmq::message_t& sender = std::get<0>(sam);
+    MessageParts& parts = std::get<1>(sam);
+    ASSERT(not parts.empty());
 
-    back_sock.send(worker, ZMQ_SNDMORE);
+    zock.send(sender, ZMQ_SNDMORE);
 
-    zmq::message_t delimiter(0);
-    back_sock.send(delimiter, ZMQ_SNDMORE);
+    zmq::message_t delim;
+    zock.send(delim, ZMQ_SNDMORE);
 
-    zmq::message_t msg(0);
-    back_sock.send(delimiter, 0);
+    send_parts(zock,
+               parts);
 }
 
 void
-ZWorkerPool::resize(uint16_t min, uint16_t max)
+ZWorkerPool::send_(zmq::socket_t& zock)
 {
-    validate_settings(min, max);
+    LOG_TRACE(name_);
 
-    LOCK();
+    reap_notification_();
 
-    min_ = min;
-    max_ = max;
+    while (true)
+    {
+        SenderAndMessage sam;
+
+        {
+            LOCK_TX();
+            if (stop_ or tx_queue_.empty())
+            {
+                break;
+            }
+
+            sam = std::move(tx_queue_.front());
+            tx_queue_.pop_front();
+        }
+
+        send_(zock,
+              std::move(sam));
+    }
+}
+
+void
+ZWorkerPool::work_()
+{
+    pthread_setname_np(pthread_self(), "zworker_pool_w");
+
+    while (true)
+    {
+        try
+        {
+            SenderAndMessage rx_sam;
+
+            {
+                boost::unique_lock<decltype(rx_mutex_)> u(rx_mutex_);
+                rx_cond_.wait(u,
+                              [&]() -> bool
+                              {
+                                  return not rx_queue_.empty() or stop_;
+                              });
+
+                if (stop_)
+                {
+                    LOG_INFO(name_ << ": stop requested, breaking out of loop");
+                    break;
+                }
+
+                VERIFY(not rx_queue_.empty());
+                rx_sam = std::move(rx_queue_.front());
+                rx_queue_.pop_front();
+            }
+
+            MessageParts tx_parts(worker_fun_(std::move(std::get<1>(rx_sam))));
+            ASSERT(not tx_parts.empty());
+
+            LOCK_TX();
+
+            tx_queue_.emplace_back(std::move(std::get<0>(rx_sam)),
+                                   std::move(tx_parts));
+            notify_();
+        }
+        CATCH_STD_ALL_LOG_IGNORE(name_ << ": exception in worker");
+    }
 }
 
 }

--- a/src/filesystem/ZWorkerPool.h
+++ b/src/filesystem/ZWorkerPool.h
@@ -18,7 +18,6 @@
 
 #include <deque>
 #include <functional>
-#include <future>
 #include <map>
 #include <vector>
 
@@ -26,64 +25,31 @@
 
 #include <cppzmq/zmq.hpp>
 
+#include <youtils/DeferExecution.h>
 #include <youtils/BooleanEnum.h>
 #include <youtils/Logging.h>
 #include <youtils/Uri.h>
 
-// Design:
 // * ZWorkerPool binds to a public address
 // * internally it will dispatch requests to that address to a pool of worker threads
-//   using a ZMQ router socket
-// * this pool is elastic, i.e. it will spawn off a new thread (up to max_workers) if
-//   all other threads are busy; these extra threads are then terminated again after doing
-//   their work (only min_workers are kept alive)
-// * requests are not dispatched round-robin to the workers (as a DEALER would do, but
-//   that doesn't work nicely with newly added workers, cf.
-//   ZMQTest.elastic_worker_pool_based_on_dealer) but are directed to a specific worker
-//   from the set of unused ones
-// * a worker is considered busy once a request has been sent off to to it until a
-//   response from it is seen or until it (re)registers
-//
-// With that we have:
-// * a front(end) ROUTER socket: recv requests from clients, forward responses
-//   to clients
-// * a back(end) ROUTER socket: forward requests from clients, recv responses from
-//   workers
-// . These sockets are not class members to prevent access from multiple threads, but are
-// owned by the aforementioned internal router thread.
-//
-// Workers are pretty simple creatures built around a REQ socket:
-// * on startup they register with the pool (by sending an empty request)
-// * client requests are mapped to responses to the REQ socket, (client) responses are
-//   sent back as a new request from the REQ socket
-// * if the pool sends an empty reply the worker exits
-//
-// Workers are identified by a ZWorkerId which is allocated by the pool to ensure that
-// these identifies are not reused (cf. comment in next_zworker_id_()).
-//
 // The pool is torn down when the ZMQ context is terminated.
-//
-// TODO: push to youtils?
-
-VD_BOOLEAN_ENUM(CanMakeProgress);
-
+// TODO: push to youtils? If so, ZUtils will have to follow suit.
 namespace volumedriverfs
 {
-
-struct ZWorker;
 
 class ZWorkerPool
 {
 public:
-    typedef std::vector<zmq::message_t> MessageParts;
-    typedef std::function<MessageParts(MessageParts)> WorkerFun;
+    using MessageParts = std::vector<zmq::message_t>;
+    using WorkerFun = std::function<MessageParts(MessageParts)>;
+    using DispatchFun = std::function<youtils::DeferExecution(const MessageParts&)>;
 
     ZWorkerPool(const std::string& name,
-                zmq::context_t& ztx,
-                const youtils::Uri& pub_uri,
-                WorkerFun worker_fun,
-                uint16_t min_workers,
-                uint16_t max_workers = 128);
+                zmq::context_t&,
+                const youtils::Uri&,
+                uint16_t num_workers,
+                WorkerFun,
+                DispatchFun);
 
     ~ZWorkerPool();
 
@@ -95,70 +61,59 @@ public:
     size_t
     size() const
     {
-        boost::lock_guard<decltype(lock_)> g(lock_);
-        return unused_ones_.size() + busy_ones_.size();
+        return workers_.size();
     }
 
-    void
-    resize(uint16_t min, uint16_t max);
-
-    void
-    validate_settings(uint16_t min, uint16_t max);
-
-    typedef uint64_t ZWorkerId;
-
 private:
-    typedef std::unique_ptr<ZWorker> ZWorkerPtr;
-
     DECLARE_LOGGER("ZWorkerPool");
 
-    uint16_t min_;
-    uint16_t max_;
     WorkerFun worker_fun_;
+    DispatchFun dispatch_fun_;
+
     zmq::context_t& ztx_;
-    ZWorkerId next_id_ = 1;
-
-    // We could ditch the lock if we ditch size() - every other access to unused_ones_
-    // and busy_ones_ happens in the router_thread_
-    mutable boost::mutex lock_;
-
-    std::deque<ZWorkerPtr> unused_ones_;
-    std::map<ZWorkerId, ZWorkerPtr> busy_ones_;
-
     const std::string name_;
-    const youtils::Uri pub_uri_;
+    const youtils::Uri uri_;
 
-    boost::thread router_thread_;
+    bool stop_;
+    int event_fd_;
 
-    std::promise<bool> initialized_;
+    mutable boost::mutex rx_mutex_;
+    boost::condition_variable rx_cond_;
 
-    std::string
-    back_address_() const;
+    using SenderAndMessage = std::tuple<zmq::message_t, MessageParts>;
 
-    void
-    route_();
+    std::deque<SenderAndMessage> rx_queue_;
 
-    CanMakeProgress
-    handle_front_(zmq::socket_t& front_sock,
-                  zmq::socket_t& back_sock);
+    mutable boost::mutex tx_mutex_;
+    std::deque<SenderAndMessage> tx_queue_;
 
-    void
-    handle_back_(zmq::socket_t& front_sock,
-                 zmq::socket_t& back_sock);
+    boost::thread router_;
+    boost::thread_group workers_;
 
     void
-    worker_ready_(ZWorkerId id);
+    route_(zmq::socket_t);
 
     void
-    worker_done_(ZWorkerId id,
-                 zmq::socket_t& back_sock);
+    recv_(zmq::socket_t&);
 
     void
-    stop_worker_(ZWorkerId id,
-                 zmq::socket_t& back_sock);
+    send_(zmq::socket_t&);
 
-    ZWorkerId
-    next_zworker_id_();
+    void
+    send_(zmq::socket_t&,
+          SenderAndMessage);
+
+    void
+    work_();
+
+    void
+    close_();
+
+    void
+    notify_();
+
+    void
+    reap_notification_();
 };
 
 }

--- a/src/filesystem/test/FileSystemTestSetup.cpp
+++ b/src/filesystem/test/FileSystemTestSetup.cpp
@@ -82,6 +82,9 @@ FileSystemTestSetup::FileSystemTestSetup(const FileSystemTestSetupParameters& pa
     , scrub_manager_interval_secs_(params.scrub_manager_interval_secs_)
     , use_fencing_(params.use_fencing_)
     , send_sync_response_(params.send_sync_response_)
+    , keepalive_time_(params.keepalive_time_)
+    , keepalive_interval_(params.keepalive_interval_)
+    , keepalive_retries_(params.keepalive_retries_)
     , dtl_config_mode_(params.dtl_config_mode_)
     , dtl_mode_(params.dtl_mode_)
     , fdriver_namespace_("ovs-fdnspc-fstest-"s + yt::UUID().str())
@@ -384,6 +387,9 @@ FileSystemTestSetup::make_config_(bpt::ptree& pt,
         ip::PARAMETER_TYPE(scrub_manager_interval)(scrub_manager_interval_secs_).persist(pt);
         ip::PARAMETER_TYPE(vrouter_use_fencing)(use_fencing_).persist(pt);
         ip::PARAMETER_TYPE(vrouter_send_sync_response)(send_sync_response_).persist(pt);
+        ip::PARAMETER_TYPE(vrouter_keepalive_time_secs)(keepalive_time_.count()).persist(pt);
+        ip::PARAMETER_TYPE(vrouter_keepalive_interval_secs)(keepalive_interval_.count()).persist(pt);
+        ip::PARAMETER_TYPE(vrouter_keepalive_retries)(keepalive_retries_).persist(pt);
     }
 
     // volume_router_cluster

--- a/src/filesystem/test/FileSystemTestSetup.h
+++ b/src/filesystem/test/FileSystemTestSetup.h
@@ -18,9 +18,12 @@
 
 #include "FailOverCacheTestHelper.h"
 
+#include <gtest/gtest.h>
+
+#include <boost/chrono.hpp>
+
 #include <youtils/ArakoonTestSetup.h>
 #include <youtils/Logging.h>
-#include <gtest/gtest.h>
 
 #include <backend/BackendTestSetup.h>
 
@@ -88,6 +91,9 @@ struct FileSystemTestSetupParameters
         volumedriver::FailOverCacheMode::Asynchronous;
     PARAM(bool, use_fencing) = false;
     PARAM(bool, send_sync_response) = true;
+    PARAM(boost::chrono::seconds, keepalive_time) = boost::chrono::seconds(2);
+    PARAM(boost::chrono::seconds, keepalive_interval) = boost::chrono::seconds(1);
+    PARAM(size_t, keepalive_retries) = 3;
 
 #undef PARAM
 };
@@ -353,6 +359,9 @@ protected:
     uint64_t scrub_manager_interval_secs_;
     bool use_fencing_;
     bool send_sync_response_;
+    boost::chrono::seconds keepalive_time_;
+    boost::chrono::seconds keepalive_interval_;
+    size_t keepalive_retries_;
 
     volumedriverfs::FailOverCacheConfigMode dtl_config_mode_;
     volumedriver::FailOverCacheMode dtl_mode_;

--- a/src/filesystem/test/RemoteTest.cpp
+++ b/src/filesystem/test/RemoteTest.cpp
@@ -666,7 +666,7 @@ TEST_F(RemoteTest, ping)
     umount_remote();
 
     EXPECT_THROW(vrouter.ping(remote_node_id()),
-                 RequestTimeoutException);
+                 ClusterNodeNotReachableException);
 
     mount_remote();
     EXPECT_NO_THROW(vrouter.ping(remote_node_id()));

--- a/src/filesystem/test/ZWorkerPoolTest.cpp
+++ b/src/filesystem/test/ZWorkerPoolTest.cpp
@@ -13,19 +13,19 @@
 // Open vStorage is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY of any kind.
 
-#include <boost/scope_exit.hpp>
+#include "../ZUtils.h"
+#include "../ZWorkerPool.h"
+
 #include <boost/thread.hpp>
 
 #include <cppzmq/zmq.hpp>
 
+#include <gtest/gtest.h>
+
 #include <youtils/Logging.h>
 #include <youtils/System.h>
-#include <gtest/gtest.h>
 #include <youtils/UUID.h>
 #include <youtils/wall_timer.h>
-
-#include "../ZUtils.h"
-#include "../ZWorkerPool.h"
 
 namespace volumedriverfstest
 {
@@ -33,6 +33,22 @@ namespace volumedriverfstest
 namespace vfs = volumedriverfs;
 namespace yt = youtils;
 using namespace std::literals::string_literals;
+
+namespace
+{
+
+vfs::ZWorkerPool::WorkerFun
+reflect_work([](vfs::ZWorkerPool::MessageParts parts) -> vfs::ZWorkerPool::MessageParts
+             {
+                 return parts;
+             });
+
+vfs::ZWorkerPool::DispatchFun
+dispatch_to_thread([](const vfs::ZWorkerPool::MessageParts&) -> yt::DeferExecution
+                   {
+                       return yt::DeferExecution::T;
+                   });
+}
 
 class ZWorkerPoolTest
     : public testing::Test
@@ -44,7 +60,7 @@ protected:
     {}
 
     vfs::ZWorkerPool::MessageParts
-    sleeping_worker(vfs::ZWorkerPool::MessageParts&& parts_in)
+    sleeping_worker(vfs::ZWorkerPool::MessageParts parts_in)
     {
         EXPECT_EQ(1U, parts_in.size());
         EXPECT_EQ(sizeof(uint32_t), parts_in[0].size());
@@ -56,7 +72,7 @@ protected:
 
         boost::this_thread::sleep_for(boost::chrono::seconds(timeout_secs));
 
-        std::vector<zmq::message_t> parts_out;
+        vfs::ZWorkerPool::MessageParts parts_out;
         parts_out.reserve(1);
         parts_out.emplace_back(std::move(parts_in[0]));
 
@@ -84,83 +100,42 @@ TEST_F(ZWorkerPoolTest, construction)
     EXPECT_THROW(vfs::ZWorkerPool("MinSizeZero",
                                   ztx_,
                                   uri_,
-                                  [&](std::vector<zmq::message_t>&& parts)
-                                  -> std::vector<zmq::message_t>
-                                  {
-                                      return std::move(parts);
-                                  },
                                   0,
-                                  1),
-                 std::exception);
-
-    EXPECT_THROW(vfs::ZWorkerPool("MaxLessThanMin",
-                                  ztx_,
-                                  uri_,
-                                  [&](std::vector<zmq::message_t>&& parts)
-                                  -> std::vector<zmq::message_t>
-                                  {
-                                      return std::move(parts);
-                                  },
-                                  2,
-                                  1),
+                                  reflect_work,
+                                  dispatch_to_thread),
                  std::exception);
 
     vfs::ZWorkerPool zwpool("TestZWorkerPool1",
                             ztx_,
                             uri_,
-                            [&](std::vector<zmq::message_t>&& parts)
-                            -> std::vector<zmq::message_t>
-                            {
-                                return std::move(parts);
-                            },
                             1,
-                            1);
-    ztx_.close();
+                            reflect_work,
+                            dispatch_to_thread);
 }
 
 TEST_F(ZWorkerPoolTest, address_conflict)
 {
-    const uint16_t min_workers = 1;
-    const uint16_t max_workers = 1;
-
     vfs::ZWorkerPool zwpool("TestZWorkerPool1",
                             ztx_,
                             uri_,
-                            [&](std::vector<zmq::message_t>&& parts)
-                            -> std::vector<zmq::message_t>
-                            {
-                                return std::move(parts);
-                            },
-                            min_workers,
-                            max_workers);
+                            1,
+                            reflect_work,
+                            dispatch_to_thread);
 
-    {
-        BOOST_SCOPE_EXIT((&ztx_))
-        {
-            ztx_.close();
-        }
-        BOOST_SCOPE_EXIT_END;
-
-        EXPECT_THROW(vfs::ZWorkerPool("TestZWorkerPool2",
-                                      ztx_,
-                                      uri_,
-                                      [&](std::vector<zmq::message_t>&& parts)
-                                      -> std::vector<zmq::message_t>
-                                      {
-                                          return std::move(parts);
-                                      },
-                                      min_workers,
-                                      max_workers),
-                     std::exception);
-    }
+    EXPECT_THROW(vfs::ZWorkerPool("TestZWorkerPool2",
+                                  ztx_,
+                                  uri_,
+                                  1,
+                                  reflect_work,
+                                  dispatch_to_thread),
+                 std::exception);
 }
 
 TEST_F(ZWorkerPoolTest, basics)
 {
-    const uint16_t min_workers = 2;
-    const uint16_t max_workers = 4;
+    const uint16_t num_workers = 4;
 
-    auto fun([&](std::vector<zmq::message_t>&& parts_in) -> std::vector<zmq::message_t>
+    auto fun([&](vfs::ZWorkerPool::MessageParts parts_in) -> vfs::ZWorkerPool::MessageParts
              {
                  return sleeping_worker(std::move(parts_in));
              });
@@ -168,60 +143,51 @@ TEST_F(ZWorkerPoolTest, basics)
     vfs::ZWorkerPool zwpool("TestZWorkerPool",
                             ztx_,
                             uri_,
+                            num_workers,
                             std::move(fun),
-                            min_workers,
-                            max_workers);
+                            dispatch_to_thread);
+
+    std::vector<zmq::socket_t> socks;
+    socks.reserve(num_workers);
+
+    const uint32_t timeout_secs = 2;
+    yt::wall_timer wt;
+
+    LOG_TRACE("starting to send");
+
+    for (uint16_t i = 0; i < num_workers; ++i)
     {
-        BOOST_SCOPE_EXIT((&ztx_))
-        {
-            ztx_.close();
-        }
-        BOOST_SCOPE_EXIT_END;
+        LOG_TRACE("sending on sock " << i);
 
-        std::vector<zmq::socket_t> socks;
-        socks.reserve(max_workers);
+        zmq::socket_t sock(create_client_socket());
+        zmq::message_t msg(sizeof(timeout_secs));
+        *static_cast<uint32_t*>(msg.data()) = timeout_secs;
 
-        const uint32_t timeout_secs = 10;
-
-        yt::wall_timer wt;
-
-        LOG_TRACE("starting to send");
-
-        for (uint16_t i = 0; i < max_workers; ++i)
-        {
-            LOG_TRACE("sending on sock " << i);
-
-            zmq::socket_t sock(create_client_socket());
-            zmq::message_t msg(sizeof(timeout_secs));
-            *static_cast<uint32_t*>(msg.data()) = timeout_secs;
-
-            sock.send(msg, 0);
-            socks.emplace_back(std::move(sock));
-        }
-
-        LOG_TRACE("sending done, starting to receive");
-
-        for (auto& s : socks)
-        {
-            zmq::message_t msg;
-            s.recv(&msg);
-
-            ASSERT_FALSE(vfs::ZUtils::more_message_parts(s));
-        }
-
-        LOG_TRACE("receiving done");
-
-        ASSERT_LT(timeout_secs, wt.elapsed());
-        ASSERT_GT(timeout_secs * 2, wt.elapsed());
+        sock.send(msg, 0);
+        socks.emplace_back(std::move(sock));
     }
+
+    LOG_TRACE("sending done, starting to receive");
+
+    for (auto& s : socks)
+    {
+        zmq::message_t msg;
+        s.recv(&msg);
+
+        ASSERT_FALSE(vfs::ZUtils::more_message_parts(s));
+    }
+
+    LOG_TRACE("receiving done");
+
+    ASSERT_LT(timeout_secs, wt.elapsed());
+    ASSERT_GT(timeout_secs * 2, wt.elapsed());
 }
 
 TEST_F(ZWorkerPoolTest, maxed_out)
 {
-    const uint16_t min_workers = 1;
-    const uint16_t max_workers = 1;
+    const uint16_t num_workers = 1;
 
-    auto fun([&](std::vector<zmq::message_t>&& parts_in) -> std::vector<zmq::message_t>
+    auto fun([&](vfs::ZWorkerPool::MessageParts parts_in) -> vfs::ZWorkerPool::MessageParts
              {
                  return sleeping_worker(std::move(parts_in));
              });
@@ -229,61 +195,51 @@ TEST_F(ZWorkerPoolTest, maxed_out)
     vfs::ZWorkerPool zwpool("TestZWorkerPool",
                             ztx_,
                             uri_,
+                            num_workers,
                             std::move(fun),
-                            min_workers,
-                            max_workers);
+                            dispatch_to_thread);
 
+    const uint32_t timeout_secs = 2;
+
+    std::vector<zmq::socket_t> socks;
+    socks.reserve(num_workers + 1);
+
+    yt::wall_timer wt;
+
+    for (uint16_t i = 0; i < num_workers + 1; ++i)
     {
-        BOOST_SCOPE_EXIT((&ztx_))
-        {
-            ztx_.close();
-        }
-        BOOST_SCOPE_EXIT_END;
+        LOG_TRACE("sending on sock " << i);
 
+        zmq::socket_t sock(create_client_socket());
+        zmq::message_t msg(sizeof(timeout_secs));
+        *static_cast<uint32_t*>(msg.data()) = timeout_secs;
 
-        const uint32_t timeout_secs = 10;
-
-        std::vector<zmq::socket_t> socks;
-        socks.reserve(max_workers + 1);
-
-        yt::wall_timer wt;
-
-        for (uint16_t i = 0; i < max_workers + 1; ++i)
-        {
-            LOG_TRACE("sending on sock " << i);
-
-            zmq::socket_t sock(create_client_socket());
-            zmq::message_t msg(sizeof(timeout_secs));
-            *static_cast<uint32_t*>(msg.data()) = timeout_secs;
-
-            sock.send(msg, 0);
-            socks.emplace_back(std::move(sock));
-        }
-
-        for (auto& s : socks)
-        {
-            zmq::message_t msg;
-            s.recv(&msg);
-
-            ASSERT_FALSE(vfs::ZUtils::more_message_parts(s));
-        }
-
-        ASSERT_LT(timeout_secs * 2, wt.elapsed());
-        ASSERT_GT(timeout_secs * 3, wt.elapsed());
+        sock.send(msg, 0);
+        socks.emplace_back(std::move(sock));
     }
+
+    for (auto& s : socks)
+    {
+        zmq::message_t msg;
+        s.recv(&msg);
+
+        ASSERT_FALSE(vfs::ZUtils::more_message_parts(s));
+    }
+
+    ASSERT_LT(timeout_secs * 2, wt.elapsed());
+    ASSERT_GT(timeout_secs * 3, wt.elapsed());
 }
 
 TEST_F(ZWorkerPoolTest, exceptional_work)
 {
-    const uint16_t min_workers = 1;
-    const uint16_t max_workers = 1;
+    const uint16_t num_workers = 1;
 
     unsigned count = 0;
 
     std::promise<bool> promise;
     std::future<bool> future(promise.get_future());
 
-    auto fun([&](std::vector<zmq::message_t>&& parts_in) -> std::vector<zmq::message_t>
+    auto fun([&](vfs::ZWorkerPool::MessageParts parts_in) -> vfs::ZWorkerPool::MessageParts
              {
                  if (count++ == 0)
                  {
@@ -293,115 +249,176 @@ TEST_F(ZWorkerPoolTest, exceptional_work)
                      throw fungi::IOException("Just pretending");
                  }
 
-                 return std::move(parts_in);
+                 return parts_in;
              });
 
     vfs::ZWorkerPool zwpool("TestZWorkerPool",
                             ztx_,
                             uri_,
+                            num_workers,
                             std::move(fun),
-                            min_workers,
-                            max_workers);
+                            dispatch_to_thread);
+
+    const std::string cmd("echo");
+
+    zmq::socket_t sock(create_client_socket());
 
     {
-        BOOST_SCOPE_EXIT((&ztx_))
-        {
-            ztx_.close();
-        }
-        BOOST_SCOPE_EXIT_END;
+        zmq::message_t msg(cmd.size());
+        memcpy(msg.data(), cmd.data(), msg.size());
+        sock.send(msg, 0);
+    }
 
-        {
-            const std::string cmd("echo");
+    EXPECT_TRUE(future.get());
 
-            zmq::socket_t sock(create_client_socket());
+    zmq::socket_t sock2(create_client_socket());
 
-            {
-                zmq::message_t msg(cmd.size());
-                memcpy(msg.data(), cmd.data(), msg.size());
-                sock.send(msg, 0);
-            }
+    {
+        zmq::message_t msg(cmd.size());
+        memcpy(msg.data(), cmd.data(), msg.size());
+        sock2.send(msg, 0);
+    }
 
-            EXPECT_TRUE(future.get());
-
-            zmq::socket_t sock2(create_client_socket());
-
-            {
-                zmq::message_t msg(cmd.size());
-                memcpy(msg.data(), cmd.data(), msg.size());
-                sock2.send(msg, 0);
-            }
-
-            {
-                zmq::message_t msg;
-                sock2.recv(&msg);
-                const std::string s(static_cast<const char*>(msg.data()),
-                                    msg.size());
-                EXPECT_EQ(cmd, s);
-            }
-        }
+    {
+        zmq::message_t msg;
+        sock2.recv(&msg);
+        const std::string s(static_cast<const char*>(msg.data()),
+                            msg.size());
+        EXPECT_EQ(cmd, s);
     }
 }
 
 TEST_F(ZWorkerPoolTest, stress)
 {
-    const uint16_t min_workers = 2;
-    const uint16_t max_workers = 4;
+    const uint16_t num_workers = 4;
 
     const size_t iterations = yt::System::get_env_with_default("ITERATIONS", 1000UL);
-
-    auto fun([&](std::vector<zmq::message_t>&& parts_in) -> std::vector<zmq::message_t>
-             {
-                 return std::move(parts_in);
-             });
 
     vfs::ZWorkerPool zwpool("TestZWorkerPool",
                             ztx_,
                             uri_,
-                            std::move(fun),
-                            min_workers,
-                            max_workers);
+                            num_workers,
+                            reflect_work,
+                            dispatch_to_thread);
+
+    std::vector<zmq::socket_t> socks;
+    socks.reserve(num_workers);
+
+    for (uint16_t i = 0; i < num_workers; ++i)
     {
-        BOOST_SCOPE_EXIT((&ztx_))
+        socks.emplace_back(create_client_socket());
+    }
+
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        for (uint16_t j = 0; j < num_workers; ++j)
         {
-            ztx_.close();
+            zmq::message_t msg1(sizeof(i));
+            *static_cast<size_t*>(msg1.data()) = i;
+            socks[j].send(msg1, ZMQ_SNDMORE);
+
+            zmq::message_t msg2(sizeof(j));
+            *static_cast<uint16_t*>(msg2.data()) = j;
+            socks[j].send(msg2, 0);
         }
-        BOOST_SCOPE_EXIT_END;
 
-        std::vector<zmq::socket_t> socks;
-        socks.reserve(max_workers);
-
-        for (uint16_t i = 0; i < max_workers; ++i)
+        for (uint16_t j = 0; j < num_workers; ++j)
         {
-            socks.emplace_back(create_client_socket());
-        }
+            zmq::message_t msg1(sizeof(i));
+            socks[j].recv(&msg1);
 
-        for (size_t i = 0; i < iterations; ++i)
-        {
-            for (uint16_t j = 0; j < max_workers; ++j)
-            {
-                zmq::message_t msg1(sizeof(i));
-                *static_cast<size_t*>(msg1.data()) = i;
-                socks[j].send(msg1, ZMQ_SNDMORE);
+            EXPECT_EQ(i, *static_cast<size_t*>(msg1.data()));
 
-                zmq::message_t msg2(sizeof(j));
-                *static_cast<uint16_t*>(msg2.data()) = j;
-                socks[j].send(msg2, 0);
-            }
+            zmq::message_t msg2(sizeof(j));
+            socks[j].recv(&msg2);
 
-            for (uint16_t j = 0; j < max_workers; ++j)
-            {
-                zmq::message_t msg1(sizeof(i));
-                socks[j].recv(&msg1);
-
-                EXPECT_EQ(i, *static_cast<size_t*>(msg1.data()));
-
-                zmq::message_t msg2(sizeof(j));
-                socks[j].recv(&msg2);
-
-                EXPECT_EQ(j, *static_cast<uint16_t*>(msg2.data()));
-            }
+            EXPECT_EQ(j, *static_cast<uint16_t*>(msg2.data()));
         }
     }
+}
+
+TEST_F(ZWorkerPoolTest, deferred_vs_direct)
+{
+    enum class RequestType
+        : uint32_t
+    {
+        Fast,
+        Slow
+    };
+
+    auto client([&](zmq::socket_t& sock, const RequestType req_type)
+                {
+                    {
+                        zmq::message_t msg(sizeof(RequestType));
+                        *reinterpret_cast<RequestType*>(msg.data()) = req_type;
+                        sock.send(msg, 0);
+                    }
+
+                    zmq::message_t msg;
+                    sock.recv(&msg);
+                    EXPECT_EQ(req_type,
+                              *reinterpret_cast<RequestType*>(msg.data()));
+                });
+
+    const size_t max_fast = 10000;
+    std::atomic<size_t> num_fast(0);
+
+    auto work([&](vfs::ZWorkerPool::MessageParts parts) -> vfs::ZWorkerPool::MessageParts
+              {
+                  EXPECT_EQ(1, parts.size());
+                  const RequestType req_type =
+                      *reinterpret_cast<RequestType*>(parts[0].data());
+                  switch (req_type)
+                  {
+                  case RequestType::Fast:
+                      ++num_fast;
+                      break;
+                  case RequestType::Slow:
+                      {
+                          zmq::socket_t sock(create_client_socket());
+                          for (size_t i = 0; i < max_fast; ++i)
+                          {
+                              client(sock, RequestType::Fast);
+                          }
+                          break;
+                      }
+                  }
+                  return parts;
+              });
+
+    auto dispatch([](const vfs::ZWorkerPool::MessageParts& parts) -> yt::DeferExecution
+                  {
+                      EXPECT_EQ(1, parts.size());
+                      const RequestType req_type =
+                          *reinterpret_cast<const RequestType*>(parts[0].data());
+                      switch (req_type)
+                      {
+                      case RequestType::Fast:
+                          return yt::DeferExecution::F;
+                      case RequestType::Slow:
+                          return yt::DeferExecution::T;
+                      }
+
+                      UNREACHABLE;
+                  });
+
+    const uint16_t num_workers = 1;
+    vfs::ZWorkerPool pool("TestZWorkerPool",
+                          ztx_,
+                          uri_,
+                          num_workers,
+                          std::move(work),
+                          std::move(dispatch));
+
+    ASSERT_EQ(num_workers,
+              pool.size());
+
+    zmq::socket_t sock(create_client_socket());
+    client(sock,
+           RequestType::Slow);
+
+    EXPECT_EQ(max_fast,
+              num_fast);
 }
 
 }

--- a/src/volumedriver/metadata-server/ServerNG.cpp
+++ b/src/volumedriver/metadata-server/ServerNG.cpp
@@ -289,19 +289,19 @@ ServerNG::dispatch_(const std::shared_ptr<C>& conn,
 
     switch (hdr->request_type)
     {
-        CASE(Open, open_, DeferExecution::F);
-        CASE(Drop, drop_, DeferExecution::F);
-        CASE(Clear, clear_, DeferExecution::F);
-        CASE(MultiGet, multiget_, DeferExecution::F);
-        CASE(MultiSet, multiset_, DeferExecution::F);
-        CASE(SetRole, set_role_, DeferExecution::T);
-        CASE(GetRole, get_role_, DeferExecution::F);
-        CASE(List, list_namespaces_, DeferExecution::F);
-        CASE(Ping, ping_, DeferExecution::F);
-        CASE(ApplyRelocationLogs, apply_relocation_logs_, DeferExecution::T);
-        CASE(CatchUp, catch_up_, DeferExecution::T);
-        CASE(GetTableCounters, get_table_counters_, DeferExecution::F);
-        CASE(GetOwnerTag, get_owner_tag_, DeferExecution::F);
+        CASE(Open, open_, yt::DeferExecution::F);
+        CASE(Drop, drop_, yt::DeferExecution::F);
+        CASE(Clear, clear_, yt::DeferExecution::F);
+        CASE(MultiGet, multiget_, yt::DeferExecution::F);
+        CASE(MultiSet, multiset_, yt::DeferExecution::F);
+        CASE(SetRole, set_role_, yt::DeferExecution::T);
+        CASE(GetRole, get_role_, yt::DeferExecution::F);
+        CASE(List, list_namespaces_, yt::DeferExecution::F);
+        CASE(Ping, ping_, yt::DeferExecution::F);
+        CASE(ApplyRelocationLogs, apply_relocation_logs_, yt::DeferExecution::T);
+        CASE(CatchUp, catch_up_, yt::DeferExecution::T);
+        CASE(GetTableCounters, get_table_counters_, yt::DeferExecution::F);
+        CASE(GetOwnerTag, get_owner_tag_, yt::DeferExecution::F);
     }
 
 #undef CASE
@@ -324,7 +324,7 @@ ServerNG::handle_(const std::shared_ptr<C>& conn,
                   ConnectionStatePtr state,
                   const HeaderPtr& hdr,
                   const DataSourcePtr& data,
-                  const DeferExecution defer,
+                  const yt::DeferExecution defer,
                   const MessageReaderPtr& reader,
                   void (ServerNG::*mem_fn)(typename Traits::Params::Reader& reader,
                                            typename Traits::Results::Builder& builder))
@@ -395,7 +395,7 @@ ServerNG::handle_shmem_(const std::shared_ptr<C>& conn,
                         ConnectionStatePtr state,
                         const HeaderPtr& hdr,
                         const DataSourcePtr& data,
-                        const DeferExecution defer,
+                        const yt::DeferExecution defer,
                         const MessageReaderPtr& reader,
                         void (ServerNG::*mem_fn)(typename Traits::Params::Reader&,
                                                  typename Traits::Results::Builder&))
@@ -444,13 +444,13 @@ ServerNG::do_handle_(const std::shared_ptr<C>& conn,
                      ConnectionStatePtr state,
                      const HeaderPtr& hdr,
                      const DataSourcePtr& data,
-                     const DeferExecution defer,
+                     const yt::DeferExecution defer,
                      const MessageBuilderPtr& builder,
                      const MessageReaderPtr& reader,
                      void (ServerNG::*mem_fn)(typename Traits::Params::Reader&,
                                               typename Traits::Results::Builder&))
 {
-    if (defer == DeferExecution::T)
+    if (defer == yt::DeferExecution::T)
     {
         // keep the shared_ptrs alive
         auto fun([c = conn,

--- a/src/volumedriver/metadata-server/ServerNG.h
+++ b/src/volumedriver/metadata-server/ServerNG.h
@@ -26,14 +26,12 @@
 
 #include <capnp/message.h>
 
-#include <youtils/BooleanEnum.h>
+#include <youtils/DeferExecution.h>
 #include <youtils/LocORemServer.h>
 #include <youtils/Logging.h>
 
 namespace metadata_server
 {
-
-VD_BOOLEAN_ENUM(DeferExecution);
 
 class ServerNG
 {
@@ -155,7 +153,7 @@ private:
             ConnectionStatePtr,
             const HeaderPtr&,
             const DataSourcePtr&,
-            const DeferExecution,
+            const youtils::DeferExecution,
             const MessageReaderPtr&,
             void (ServerNG::*mem_fn)(typename Traits::Params::Reader&,
                                      typename Traits::Results::Builder&));
@@ -168,7 +166,7 @@ private:
                   ConnectionStatePtr,
                   const HeaderPtr&,
                   const DataSourcePtr&,
-                  const DeferExecution,
+                  const youtils::DeferExecution,
                   const MessageReaderPtr&,
                   void (ServerNG::*mem_fn)(typename Traits::Params::Reader&,
                                            typename Traits::Results::Builder&));
@@ -181,7 +179,7 @@ private:
                ConnectionStatePtr,
                const HeaderPtr&,
                const DataSourcePtr&,
-               const DeferExecution,
+               const youtils::DeferExecution,
                const MessageBuilderPtr&,
                const MessageReaderPtr&,
                void (ServerNG::*mem_fn)(typename Traits::Params::Reader&,

--- a/src/youtils/DeferExecution.h
+++ b/src/youtils/DeferExecution.h
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 iNuron NV
+//
+// This file is part of Open vStorage Open Source Edition (OSE),
+// as available from
+//
+//      http://www.openvstorage.org and
+//      http://www.openvstorage.com.
+//
+// This file is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+// as published by the Free Software Foundation, in version 3 as it comes in
+// the LICENSE.txt file of the Open vStorage OSE distribution.
+// Open vStorage is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY of any kind.
+
+#ifndef YT_DEFER_EXECUTION_H_
+#define YT_DEFER_EXECUTION_H_
+
+#include "BooleanEnum.h"
+
+namespace youtils
+{
+
+VD_BOOLEAN_ENUM(DeferExecution);
+
+}
+
+#endif // !YT_DEFER_EXECUTION_H_


### PR DESCRIPTION
CC @khenderick

This addresses #139 : currently a timed out redirected request (`vrouter_redirect_timeout_ms`) can trigger volume stealing which is undesirable in situations where e.g. a request to the backend takes longer than expected (for these situations we want a higher timeout, but this requires a framework change).
This PR introduces a keepalive mechanism: a ping request is sent every `vrouter_keepalive_time_secs` seconds (dynamically reconfigurable, default: 60) after the last successful probe. After `vrouter_keepalive_interval_secs` it is checked whether an acknowledgement has arrived. If there was no acknowledgement, this is retried `vrouter_keepalive_retries` times before aborting all requests submitted to the node (which possibly triggers stealing).