### PR TITLE
Support for new "block cache counter" introduced by alba client lib

### DIFF
--- a/src/backend/Alba_Connection.cpp
+++ b/src/backend/Alba_Connection.cpp
@@ -370,6 +370,7 @@ Connection::partial_read_(const Namespace& ns,
 
             prc.fast += rora_counter.fast_path;
             prc.slow += rora_counter.slow_path;
+            prc.block_cache += rora_counter.block_path;
         });
 
     return true;

--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -1317,6 +1317,7 @@ BOOST_PYTHON_MODULE(storagerouterclient)
         DEF_READONLY_PROP_(stored)
         DEF_READONLY_PROP_(partial_read_fast)
         DEF_READONLY_PROP_(partial_read_slow)
+        DEF_READONLY_PROP_(partial_read_block_cache)
         DEF_READONLY_PROP_(performance_counters)
         .def_pickle(XMLRPCStatisticsPickleSuite())
         ;

--- a/src/filesystem/XMLRPCStructs.h
+++ b/src/filesystem/XMLRPCStructs.h
@@ -349,6 +349,7 @@ struct XMLRPCStatistics
         , stored(old.stored)
         , partial_read_fast(0)
         , partial_read_slow(0)
+        , partial_read_block_cache(0)
         , performance_counters(static_cast<volumedriver::PerformanceCounters>(old.performance_counters))
     {}
 
@@ -364,6 +365,7 @@ struct XMLRPCStatistics
     uint64_t stored = 0;
     uint64_t partial_read_fast = 0;
     uint64_t partial_read_slow = 0;
+    uint64_t partial_read_block_cache = 0;
 
     volumedriver::PerformanceCounters performance_counters;
 
@@ -382,7 +384,8 @@ struct XMLRPCStatistics
             EQ(stored) and
             EQ(performance_counters) and
             EQ(partial_read_fast) and
-            EQ(partial_read_slow)
+            EQ(partial_read_slow) and
+            EQ(partial_read_block_cache)
             ;
 #undef EQ
     }
@@ -408,6 +411,11 @@ struct XMLRPCStatistics
         {
             ar & BOOST_SERIALIZATION_NVP(partial_read_fast);
             ar & BOOST_SERIALIZATION_NVP(partial_read_slow);
+        }
+
+        if (version > 3)
+        {
+            ar & BOOST_SERIALIZATION_NVP(partial_read_block_cache);
         }
     }
 
@@ -555,7 +563,7 @@ struct XMLRPCClusterCacheHandleInfo
 
 BOOST_CLASS_VERSION(volumedriverfs::XMLRPCVolumeInfo, 2);
 BOOST_CLASS_VERSION(volumedriverfs::XMLRPCStatisticsV2, 2);
-BOOST_CLASS_VERSION(volumedriverfs::XMLRPCStatistics, 3);
+BOOST_CLASS_VERSION(volumedriverfs::XMLRPCStatistics, 4);
 BOOST_CLASS_VERSION(volumedriverfs::XMLRPCSnapshotInfo, 2);
 BOOST_CLASS_VERSION(volumedriverfs::XMLRPCClusterCacheHandleInfo, 1);
 


### PR DESCRIPTION
Part of https://github.com/openvstorage/volumedriver/issues/311

CC @khenderick, @jeroenmaelbrancke : this exposes a new counter introduced by the alba client lib:
```
In [5]: stats = client.statistics_volume(v)

In [6]: stats.partial_read_block_cache
Out[6]: 0
```