### PR TITLE
VolumeFactory: remove overzealous SnapshotPersistor cork check on local restart

### DIFF
--- a/src/volumedriver/VolumeFactory.cpp
+++ b/src/volumedriver/VolumeFactory.cpp
@@ -449,8 +449,6 @@ try
 
         if (not tlogs_to_replay_now.empty())
         {
-            VERIFY(sp_cork != boost::none);
-
             CloneTLogs clone_tlogs_to_replay;
             clone_tlogs_to_replay.emplace_back(SCOCloneID(0),
                                                tlogs_to_replay_now);


### PR DESCRIPTION
The VERIFY(sp_cork != boost::none) is not necessary in this place as the
TLogs to replay are determined based on the cork ID of the metadata
store, i.e.
* get latest cork of the metadata store
* based on that, get the list of subsequent TLogs that are marked as on
  the backend and replay those onto the metadata store
* afterwards replay local tlogs
.

Addresses https://github.com/openvstorage/volumedriver/issues/329