### PR TITLE
Feature/mds reconfig limit tlogs to replay

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -96,6 +96,7 @@ service ovs-volumedriver-vpool_name restart
 | volume_manager | non_disposable_scos_factor | "1.5" | no | Factor to multiply number_of_scos_in_tlog with to determine the amount of non-disposable data permitted per volume |
 | volume_manager | default_cluster_size | "4096" | no | size of a cluster in bytes |
 | volume_manager | metadata_cache_capacity | "8192" | no | number of metadata pages to keep cached |
+| volume_manager | metadata_mds_slave_max_tlogs_behind | "4294967295" | yes | max number of TLogs a slave is allowed to run behind to still permit a failover to it |
 | volume_manager | debug_metadata_path | "/opt/OpenvStorage/var/lib/volumedriver/evidence" | no | place to store evidence when a volume is halted. |
 | volume_manager | arakoon_metadata_sequence_size | "10" | no | Size of Arakoon sequences used to send metadata pages to Arakoon |
 | scocache | trigger_gap | --- | no | scocache-mountpoint freespace threshold below which scocache-cleaner is triggered |

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,7 @@ service ovs-volumedriver-vpool_name restart
 | filesystem | fs_metadata_backend_mds_nodes | "[]" | yes | an array of MDS node configurations for the volume metadata, each containing host and port |
 | filesystem | fs_metadata_backend_mds_apply_relocations_to_slaves | "1" | yes | an bool indicating whether to apply relocations to slave MDS tables |
 | filesystem | fs_metadata_backend_mds_timeout_secs | "20" | yes | timeout (in seconds) for calls to MDS servers |
+| filesystem | fs_metadata_backend_mds_slave_max_tlogs_behind | "4294967295" | yes | max number of TLogs a slave is allowed to run behind to still permit a failover to it |
 | filesystem | fs_cache_dentries | "0" | no | whether to cache directory entries locally |
 | filesystem | fs_dtl_config_mode | "Automatic" | no | Configuration mode : Automatic | Manual |
 | filesystem | fs_dtl_host | "" | yes | DTL host |

--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -1433,6 +1433,8 @@ BOOST_PYTHON_MODULE(storagerouterclient)
         .value("T", vd::ApplyRelocationsToSlaves::T)
         ;
 
+    using MaybeUInt32T = boost::optional<uint32_t>;
+
     bpy::class_<vd::MDSMetaDataBackendConfig,
                 bpy::bases<vd::MetaDataBackendConfig>,
                 boost::shared_ptr<vd::MDSMetaDataBackendConfig>>
@@ -1440,13 +1442,16 @@ BOOST_PYTHON_MODULE(storagerouterclient)
          "MDS metadata backend configuration",
          bpy::init<const std::vector<vd::MDSNodeConfig>&,
                    vd::ApplyRelocationsToSlaves,
-                   unsigned>((bpy::args("mds_node_configs"),
-                              bpy::args("apply_relocations_to_slaves") = vd::ApplyRelocationsToSlaves::T,
-                              bpy::args("timeout_secs") = vd::MDSMetaDataBackendConfig::default_timeout_secs_),
-                             "Create an MDSMetaDataBackendConfig\n"
-                             "@param mds_node_configs: list of MDSNodeConfigs\n"
-                             "@param apply_relocations_to_slaves: ApplyRelocationsToSlaves boolean enum\n"
-                             "@param timeout_secs: unsigned, timeout for remote MDS calls in seconds"))
+                   unsigned,
+                   MaybeUInt32T>((bpy::args("mds_node_configs"),
+                                  bpy::args("apply_relocations_to_slaves") = vd::ApplyRelocationsToSlaves::T,
+                                  bpy::args("timeout_secs") = vd::MDSMetaDataBackendConfig::default_timeout_secs_,
+                                  bpy::args("max_tlogs_behind") = MaybeUInt32T()),
+                                 "Create an MDSMetaDataBackendConfig\n"
+                                 "@param mds_node_configs: list of MDSNodeConfigs\n"
+                                 "@param apply_relocations_to_slaves: ApplyRelocationsToSlaves boolean enum\n"
+                                 "@param timeout_secs: unsigned, timeout for remote MDS calls in seconds\n"
+                                 "@param max_tlogs_behind: optional uint32, max number of TLogs a slave might be behind\n"))
         .def("node_configs",
              &vd::MDSMetaDataBackendConfig::node_configs,
              bpy::return_value_policy<bpy::copy_const_reference>())
@@ -1454,6 +1459,8 @@ BOOST_PYTHON_MODULE(storagerouterclient)
              &vd::MDSMetaDataBackendConfig::apply_relocations_to_slaves)
         .def("timeout_secs",
              &mds_mdb_config_timeout_secs)
+        .def("max_tlogs_behind",
+             &vd::MDSMetaDataBackendConfig::max_tlogs_behind)
         ;
 
     REGISTER_ITERABLE_CONVERTER(std::vector<std::string>);

--- a/src/filesystem/FileSystem.cpp
+++ b/src/filesystem/FileSystem.cpp
@@ -152,6 +152,7 @@ FileSystem::FileSystem(const bpt::ptree& pt,
     , fs_metadata_backend_mds_nodes(pt)
     , fs_metadata_backend_mds_apply_relocations_to_slaves(pt)
     , fs_metadata_backend_mds_timeout_secs(pt)
+    , fs_metadata_backend_mds_slave_max_tlogs_behind(pt)
     , fs_cache_dentries(pt)
     , fs_nullio(pt)
     , fs_dtl_config_mode(pt)
@@ -284,6 +285,7 @@ FileSystem::update(const bpt::ptree& pt,
     U(fs_metadata_backend_mds_nodes);
     U(fs_metadata_backend_mds_apply_relocations_to_slaves);
     U(fs_metadata_backend_mds_timeout_secs);
+    U(fs_metadata_backend_mds_slave_max_tlogs_behind);
     U(fs_cache_dentries);
     U(fs_nullio);
 
@@ -313,6 +315,7 @@ FileSystem::persist(bpt::ptree& pt,
     P(fs_metadata_backend_mds_nodes);
     P(fs_metadata_backend_mds_apply_relocations_to_slaves);
     P(fs_metadata_backend_mds_timeout_secs);
+    P(fs_metadata_backend_mds_slave_max_tlogs_behind);
     P(fs_cache_dentries);
     P(fs_nullio);
     P(fs_dtl_config_mode);
@@ -716,9 +719,16 @@ FileSystem::make_metadata_backend_config()
                 apply_relocs(fs_metadata_backend_mds_apply_relocations_to_slaves.value() ?
                              vd::ApplyRelocationsToSlaves::T :
                              vd::ApplyRelocationsToSlaves::F);
+            boost::optional<uint32_t> max_tlogs_behind;
+            if (fs_metadata_backend_mds_slave_max_tlogs_behind.value() != std::numeric_limits<uint32_t>::max())
+            {
+                max_tlogs_behind = fs_metadata_backend_mds_slave_max_tlogs_behind.value();
+            }
+
             mdb.reset(new vd::MDSMetaDataBackendConfig(configv,
                                                        apply_relocs,
-                                                       fs_metadata_backend_mds_timeout_secs.value()));
+                                                       fs_metadata_backend_mds_timeout_secs.value(),
+                                                       max_tlogs_behind));
             break;
         }
     case vd::MetaDataBackendType::RocksDB:

--- a/src/filesystem/FileSystem.h
+++ b/src/filesystem/FileSystem.h
@@ -563,6 +563,7 @@ private:
     DECLARE_PARAMETER(fs_metadata_backend_mds_nodes);
     DECLARE_PARAMETER(fs_metadata_backend_mds_apply_relocations_to_slaves);
     DECLARE_PARAMETER(fs_metadata_backend_mds_timeout_secs);
+    DECLARE_PARAMETER(fs_metadata_backend_mds_slave_max_tlogs_behind);
     DECLARE_PARAMETER(fs_cache_dentries);
     DECLARE_PARAMETER(fs_nullio);
     DECLARE_PARAMETER(fs_dtl_config_mode);

--- a/src/filesystem/FileSystemParameters.cpp
+++ b/src/filesystem/FileSystemParameters.cpp
@@ -360,6 +360,13 @@ DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(fs_metadata_backend_mds_timeout_secs,
                                       ShowDocumentation::T,
                                       vd::MDSMetaDataBackendConfig::default_timeout_secs_);
 
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(fs_metadata_backend_mds_slave_max_tlogs_behind,
+                                      filesystem_component_name,
+                                      "fs_metadata_backend_mds_slave_max_tlogs_behind",
+                                      "max number of TLogs a slave is allowed to run behind to still permit a failover to it",
+                                      ShowDocumentation::T,
+                                      std::numeric_limits<uint32_t>::max());
+
 DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(fs_cache_dentries,
                                       filesystem_component_name,
                                       "fs_cache_dentries",

--- a/src/filesystem/FileSystemParameters.h
+++ b/src/filesystem/FileSystemParameters.h
@@ -137,6 +137,9 @@ DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(fs_metadata_backend_mds_apply_
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(fs_metadata_backend_mds_timeout_secs,
                                                   uint32_t);
 
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(fs_metadata_backend_mds_slave_max_tlogs_behind,
+                                                  uint32_t);
+
 DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(fs_cache_dentries,
                                        bool);
 

--- a/src/volumedriver/BackendTasks.cpp
+++ b/src/volumedriver/BackendTasks.cpp
@@ -224,7 +224,7 @@ WriteSnapshot::run(int /*threadID*/)
 {
     try
     {
-        const fs::path tmpfile = volume_->saveSnapshotToTempFile();
+        const fs::path tmpfile = volume_->getSnapshotManagement().saveSnapshotToTempFile();
         CheckSum chk = FileUtils::calculate_checksum(tmpfile);
         ALWAYS_CLEANUP_FILE(tmpfile);
 

--- a/src/volumedriver/MDSMetaDataBackend.h
+++ b/src/volumedriver/MDSMetaDataBackend.h
@@ -24,6 +24,7 @@
 
 #include <boost/optional.hpp>
 
+#include <youtils/BooleanEnum.h>
 #include <youtils/Logging.h>
 
 #include <backend/Namespace.h>
@@ -35,6 +36,8 @@ class MDSVolumeTest;
 
 namespace volumedriver
 {
+
+VD_BOOLEAN_ENUM(UseDirectInterface);
 
 class MDSNodeConfig;
 class VolumeConfig;
@@ -50,7 +53,8 @@ public:
     MDSMetaDataBackend(const MDSNodeConfig&,
                        const backend::Namespace&,
                        const boost::optional<OwnerTag>&,
-                       const boost::optional<std::chrono::seconds>& timeout);
+                       const boost::optional<std::chrono::seconds>& timeout,
+                       const UseDirectInterface = UseDirectInterface::T);
 
     MDSMetaDataBackend(metadata_server::DataBaseInterfacePtr,
                        const backend::Namespace&,

--- a/src/volumedriver/SnapshotManagement.cpp
+++ b/src/volumedriver/SnapshotManagement.cpp
@@ -649,6 +649,14 @@ SnapshotManagement::getLastSnapshotName() const
     return SnapshotName();
 }
 
+SnapshotPersistor
+SnapshotManagement::cloneSnapshotPersistor() const
+{
+    LOCKSNAP;
+    ASSERT(sp);
+    return *sp;
+}
+
 fs::path
 SnapshotManagement::saveSnapshotToTempFile()
 {

--- a/src/volumedriver/SnapshotManagement.h
+++ b/src/volumedriver/SnapshotManagement.h
@@ -66,7 +66,7 @@ public:
     friend class SnapshotWriter;
 
     static bool
-    exists(const boost::filesystem::path& dir);
+    exists(const boost::filesystem::path&);
 
     SnapshotManagement(const VolumeConfig&,
                        const RestartContext);
@@ -76,7 +76,7 @@ public:
     SnapshotManagement& operator=(const SnapshotManagement&) = delete;
 
     void
-    initialize(VolumeInterface* v);
+    initialize(VolumeInterface*);
 
     ~SnapshotManagement();
 
@@ -88,7 +88,7 @@ public:
     }
 
     void
-    listSnapshots(std::list<SnapshotName>& snapshots) const;
+    listSnapshots(std::list<SnapshotName>&) const;
 
     void
     deleteSnapshot(const SnapshotName&);
@@ -122,7 +122,7 @@ public:
     }
 
     void
-    getTLogsWrittenToBackend(OrderedTLogIds& out) const;
+    getTLogsWrittenToBackend(OrderedTLogIds&) const;
 
     OrderedTLogIds
     getTLogsWrittenToBackend() const
@@ -133,19 +133,19 @@ public:
     }
 
     bool
-    isTLogWrittenToBackend(const TLogId& name) const;
+    isTLogWrittenToBackend(const TLogId&) const;
 
     bool
-    snapshotExists(SnapshotNum num) const;
+    snapshotExists(SnapshotNum) const;
 
     bool
-    snapshotExists(const SnapshotName& name) const;
+    snapshotExists(const SnapshotName&) const;
 
     void
-    eraseSnapshotsAndTLogsAfterSnapshot(SnapshotNum num);
+    eraseSnapshotsAndTLogsAfterSnapshot(SnapshotNum);
 
     uint64_t
-    getSnapshotBackendSize(const SnapshotName& name) const;
+    getSnapshotBackendSize(const SnapshotName&) const;
 
     uint64_t
     getCurrentBackendSize() const;
@@ -170,10 +170,11 @@ public:
     }
 
     static std::unique_ptr<SnapshotPersistor>
-    createSnapshotPersistor(BackendInterfacePtr bi);
+    createSnapshotPersistor(BackendInterfacePtr);
 
     static void
-    writeSnapshotPersistor(const SnapshotPersistor&, BackendInterfacePtr bi);
+    writeSnapshotPersistor(const SnapshotPersistor&,
+                           BackendInterfacePtr);
 
     void
     destroy(const DeleteLocalData delete_snaps);
@@ -185,20 +186,20 @@ public:
     sync(const MaybeCheckSum& maybe_sco_crc);
 
     void
-    addClusterEntry(const ClusterAddress address,
-                    const ClusterLocationAndHash& location_and_hash);
+    addClusterEntry(const ClusterAddress,
+                    const ClusterLocationAndHash&);
 
     void
     addSCOCRC(const CheckSum& t);
 
     ScrubId
-    replaceTLogsWithScrubbedOnes(const OrderedTLogIds& /*in*/,
-                                 const std::vector<TLog>& /*out*/,
-                                 SnapshotNum /*relatedSnapshot*/);
+    replaceTLogsWithScrubbedOnes(const OrderedTLogIds& in,
+                                 const std::vector<TLog>& out,
+                                 SnapshotNum);
 
     void
     tlogWrittenToBackendCallback(const TLogId& tlogcounter,
-                             const SCO sconame);
+                                 const SCO sconame);
 
     const MaybeParentConfig&
     parent() const
@@ -207,7 +208,7 @@ public:
     }
 
     bool
-    isSnapshotInBackend(const SnapshotNum num) const;
+    isSnapshotInBackend(const SnapshotNum) const;
 
     bool
     lastSnapshotOnBackend() const;
@@ -242,12 +243,8 @@ public:
     OrderedTLogIds
     getTLogsAfterSnapshot(SnapshotNum) const;
 
-    // Don't use this. You probably want to enrich the snapshotmanagement api
-    const SnapshotPersistor&
-    getSnapshotPersistor() const
-    {
-        return *sp;
-    }
+    SnapshotPersistor
+    cloneSnapshotPersistor() const;
 
     boost::filesystem::path
     saveSnapshotToTempFile();
@@ -255,7 +252,7 @@ public:
     void
     getSnapshotScrubbingWork(const boost::optional<SnapshotName>& start_snap,
                              const boost::optional<SnapshotName>& end_snap,
-                             SnapshotWork& out) const;
+                             SnapshotWork&) const;
 
     void
     scheduleWriteSnapshotToBackend();
@@ -279,7 +276,7 @@ public:
     }
 
     const youtils::UUID&
-    getSnapshotCork(const SnapshotName& snapshot_name) const;
+    getSnapshotCork(const SnapshotName&) const;
 
     void
     setAsTemplate(const MaybeCheckSum& maybe_sco_crc);
@@ -330,7 +327,7 @@ private:
     syncTLog_(const MaybeCheckSum& maybe_sco_crc);
 
     CheckSum
-    closeTLog_(const boost::filesystem::path* pth = 0);
+    closeTLog_(const boost::filesystem::path* = 0);
 
     void
     maybeCloseTLog_();
@@ -351,9 +348,9 @@ private:
     getTLogSizes(const OrderedTLogIds&);
 
     void
-    createSnapshot(const SnapshotName& name,
+    createSnapshot(const SnapshotName&,
                    const MaybeCheckSum& maybe_sco_crc,
-                   const SnapshotMetaData& metadata = SnapshotMetaData(),
+                   const SnapshotMetaData& = SnapshotMetaData(),
                    const UUID& = UUID(),
                    const bool set_scrubbed = false);
 
@@ -372,8 +369,8 @@ private:
     maybe_switch_tlog_();
 
     void
-    set_max_tlog_entries(const boost::optional<TLogMultiplier>& tm,
-                         SCOMultiplier sm);
+    set_max_tlog_entries(const boost::optional<TLogMultiplier>&,
+                         SCOMultiplier);
 };
 
 }

--- a/src/volumedriver/SnapshotManagement.h
+++ b/src/volumedriver/SnapshotManagement.h
@@ -163,6 +163,8 @@ public:
          const SnapshotName& snap_name = SnapshotName(),
          SCOCloneID start = SCOCloneID(0)) const
     {
+        boost::lock_guard<decltype(snapshot_lock_)> g(snapshot_lock_);
+
         return sp->vold(accumulator,
                         std::move(bi),
                         snap_name,

--- a/src/volumedriver/VolManager.cpp
+++ b/src/volumedriver/VolManager.cpp
@@ -154,6 +154,7 @@ try
           , non_disposable_scos_factor(pt)
           , default_cluster_size(pt)
           , metadata_cache_capacity(pt)
+          , metadata_mds_slave_max_tlogs_behind(pt)
           , debug_metadata_path(pt)
           , arakoon_metadata_sequence_size(pt)
           , allow_inconsistent_partial_reads(pt)
@@ -1794,6 +1795,7 @@ VolManager::update(const boost::property_tree::ptree& pt,
     non_disposable_scos_factor.update(pt, report);
     default_cluster_size.update(pt, report);
     metadata_cache_capacity.update(pt, report);
+    metadata_mds_slave_max_tlogs_behind.update(pt, report);
     debug_metadata_path.update(pt, report);
     arakoon_metadata_sequence_size.update(pt, report);
     allow_inconsistent_partial_reads.update(pt, report);
@@ -1828,6 +1830,7 @@ VolManager::persist(boost::property_tree::ptree& pt,
     non_disposable_scos_factor.persist(pt, reportDefault);
     default_cluster_size.persist(pt, reportDefault);
     metadata_cache_capacity.persist(pt, reportDefault);
+    metadata_mds_slave_max_tlogs_behind.persist(pt, reportDefault);
     debug_metadata_path.persist(pt, reportDefault);
     arakoon_metadata_sequence_size.persist(pt, reportDefault);
     allow_inconsistent_partial_reads.persist(pt, reportDefault);
@@ -1864,6 +1867,20 @@ SCOWrittenToBackendAction
 VolManager::get_sco_written_to_backend_action() const
 {
     return sco_written_to_backend_action.value();
+}
+
+boost::optional<uint32_t>
+VolManager::mds_slave_max_tlogs_behind() const
+{
+    size_t v = metadata_mds_slave_max_tlogs_behind.value();
+    if (v == std::numeric_limits<uint32_t>::max())
+    {
+        return boost::none;
+    }
+    else
+    {
+        return v;
+    }
 }
 
 }

--- a/src/volumedriver/VolManager.h
+++ b/src/volumedriver/VolManager.h
@@ -468,6 +468,9 @@ public:
     size_t
     effective_metadata_cache_capacity(const VolumeConfig&) const;
 
+    boost::optional<uint32_t>
+    mds_slave_max_tlogs_behind() const;
+
     boost::optional<boost::chrono::milliseconds>
     dtl_connect_timeout() const
     {
@@ -580,6 +583,9 @@ public:
     DECLARE_PARAMETER(non_disposable_scos_factor);
     DECLARE_PARAMETER(default_cluster_size);
     DECLARE_PARAMETER(metadata_cache_capacity);
+private:
+    DECLARE_PARAMETER(metadata_mds_slave_max_tlogs_behind);
+public:
     DECLARE_PARAMETER(debug_metadata_path);
     DECLARE_PARAMETER(arakoon_metadata_sequence_size);
     DECLARE_PARAMETER(allow_inconsistent_partial_reads);

--- a/src/volumedriver/Volume.cpp
+++ b/src/volumedriver/Volume.cpp
@@ -2974,12 +2974,6 @@ Volume::getCurrentTLogPath_() const
     return snapshotManagement_->getTLogsPath();
 }
 
-const SnapshotManagement&
-Volume::getSnapshotManagement() const
-{
-    return *snapshotManagement_;
-}
-
 void
 Volume::halt()
 {
@@ -3021,10 +3015,18 @@ Volume::is_halted() const
     return halted_;
 }
 
-fs::path
-Volume::saveSnapshotToTempFile()
+SnapshotManagement&
+Volume::getSnapshotManagement()
 {
-    return snapshotManagement_->saveSnapshotToTempFile();
+    ASSERT(snapshotManagement_);
+    return *snapshotManagement_;
+}
+
+const SnapshotManagement&
+Volume::getSnapshotManagement() const
+{
+    ASSERT(snapshotManagement_);
+    return *snapshotManagement_;
 }
 
 void

--- a/src/volumedriver/Volume.cpp
+++ b/src/volumedriver/Volume.cpp
@@ -1452,16 +1452,15 @@ Volume::restoreSnapshot(const SnapshotName& name)
         // 1) update metadata store
         {
             NSIDMap nsid;
-            const SnapshotPersistor& sp(snapshotManagement_->getSnapshotPersistor());
-            const yt::UUID cork(sp.getSnapshotCork(name));
+            const yt::UUID cork(snapshotManagement_->getSnapshotCork(name));
 
             BackendRestartAccumulator acc(nsid,
                                           boost::none,
                                           cork);
 
-            sp.vold(acc,
-                    nsidmap_.get(0)->clone(),
-                    name);
+            snapshotManagement_->vold(acc,
+                                      nsidmap_.get(0)->clone(),
+                                      name);
 
             metaDataStore_->clear_all_keys();
             metaDataStore_->processCloneTLogs(acc.clone_tlogs(),

--- a/src/volumedriver/Volume.h
+++ b/src/volumedriver/Volume.h
@@ -275,8 +275,11 @@ public:
     SCOWrittenToBackendCallback(uint64_t file_size,
                                 boost::chrono::microseconds write_time) override final;
 
-    virtual fs::path
-    saveSnapshotToTempFile() override final;
+    virtual SnapshotManagement&
+    getSnapshotManagement() override final;
+
+    virtual const SnapshotManagement&
+    getSnapshotManagement() const override final;
 
     virtual void
     tlogWrittenToBackendCallback(const TLogId& tid,
@@ -350,9 +353,6 @@ public:
     void
     cloneFromParentSnapshot(const youtils::UUID& parent_snap_uuid,
                             const CloneTLogs& clone_tlogs);
-
-    const SnapshotManagement&
-    getSnapshotManagement() const;
 
     uint64_t
     getSnapshotBackendSize(const SnapshotName&);

--- a/src/volumedriver/VolumeDriverParameters.cpp
+++ b/src/volumedriver/VolumeDriverParameters.cpp
@@ -203,6 +203,13 @@ DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(metadata_cache_capacity,
                                       ShowDocumentation::T,
                                       8192);
 
+DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(metadata_mds_slave_max_tlogs_behind,
+                                      volmanager_component_name,
+                                      "metadata_mds_slave_max_tlogs_behind",
+                                      "max number of TLogs a slave is allowed to run behind to still permit a failover to it",
+                                      ShowDocumentation::T,
+                                      std::numeric_limits<uint32_t>::max());
+
 DEFINE_INITIALIZED_PARAM_WITH_DEFAULT(debug_metadata_path,
                                       volmanager_component_name,
                                       "no_python_name",

--- a/src/volumedriver/VolumeDriverParameters.h
+++ b/src/volumedriver/VolumeDriverParameters.h
@@ -70,6 +70,8 @@ DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(max_volume_size,
                                                   std::atomic<uint64_t>);
 DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(allow_inconsistent_partial_reads,
                                                   std::atomic<bool>);
+DECLARE_RESETTABLE_INITIALIZED_PARAM_WITH_DEFAULT(metadata_mds_slave_max_tlogs_behind,
+                                                  uint32_t);
 
 DECLARE_INITIALIZED_PARAM_WITH_DEFAULT(number_of_scos_in_tlog,
                                        uint32_t);

--- a/src/volumedriver/VolumeFactory.cpp
+++ b/src/volumedriver/VolumeFactory.cpp
@@ -136,11 +136,18 @@ make_metadata_store(const VolumeConfig& config,
             const be::Namespace nspace(config.ns_);
             be::BackendInterfacePtr bi(vm.createBackendInterface(nspace));
             const fs::path home(vm.getMetaDataPath(nspace));
+
+            auto fun([]() -> boost::optional<uint32_t>
+                     {
+                         return VolManager::get()->mds_slave_max_tlogs_behind();
+                     });
+
             return std::unique_ptr<MetaDataStoreInterface>(new MDSMetaDataStore(mcfg,
                                                                                 std::move(bi),
                                                                                 home,
                                                                                 owner_tag,
-                                                                                num_pages_cached));
+                                                                                num_pages_cached,
+                                                                                std::move(fun)));
         }
     }
 

--- a/src/volumedriver/VolumeInterface.h
+++ b/src/volumedriver/VolumeInterface.h
@@ -35,11 +35,12 @@
 namespace volumedriver
 {
 
+class DataStoreNG;
+class FailOverCacheClientInterface;
+class MetaDataBackendConfig;
+class SnapshotManagement;
 class Volume;
 class VolumeConfig;
-class FailOverCacheClientInterface;
-class DataStoreNG;
-class MetaDataBackendConfig;
 
 VD_BOOLEAN_ENUM(AppendCheckSum);
 
@@ -91,8 +92,11 @@ public:
     virtual boost::optional<SCOCacheNonDisposableFactor>
     getSCOCacheMaxNonDisposableFactor() const = 0;
 
-    virtual fs::path
-    saveSnapshotToTempFile() = 0;
+    virtual SnapshotManagement&
+    getSnapshotManagement() = 0;
+
+    virtual const SnapshotManagement&
+    getSnapshotManagement() const = 0;
 
     virtual DataStoreNG*
     getDataStore() = 0;

--- a/src/volumedriver/WriteOnlyVolume.cpp
+++ b/src/volumedriver/WriteOnlyVolume.cpp
@@ -1019,12 +1019,6 @@ WriteOnlyVolume::getCurrentTLogPath() const
     return snapshotManagement_->getTLogsPath();
 }
 
-const SnapshotManagement&
-WriteOnlyVolume::getSnapshotManagement() const
-{
-    return *snapshotManagement_;
-}
-
 void
 WriteOnlyVolume::halt()
 {
@@ -1066,10 +1060,18 @@ WriteOnlyVolume::is_halted() const
     return halted_;
 }
 
-fs::path
-WriteOnlyVolume::saveSnapshotToTempFile()
+SnapshotManagement&
+WriteOnlyVolume::getSnapshotManagement()
 {
-    return snapshotManagement_->saveSnapshotToTempFile();
+    ASSERT(snapshotManagement_);
+    return *snapshotManagement_;
+}
+
+const SnapshotManagement&
+WriteOnlyVolume::getSnapshotManagement() const
+{
+    ASSERT(snapshotManagement_);
+    return *snapshotManagement_;
 }
 
 void

--- a/src/volumedriver/WriteOnlyVolume.h
+++ b/src/volumedriver/WriteOnlyVolume.h
@@ -225,8 +225,11 @@ public:
     tlogWrittenToBackendCallback(const TLogId& tid,
                                  const SCO sconame) override final;
 
-    virtual fs::path
-    saveSnapshotToTempFile() override final;
+    virtual SnapshotManagement&
+    getSnapshotManagement() override final;
+
+    virtual const SnapshotManagement&
+    getSnapshotManagement() const override final;
 
     backend::Namespace
     getNamespace() const override final;
@@ -253,9 +256,6 @@ public:
 
     void
     restoreSnapshot(const SnapshotName&);
-
-    const SnapshotManagement&
-    getSnapshotManagement() const;
 
     uint64_t
     getSnapshotBackendSize(const SnapshotName&);

--- a/src/volumedriver/test/MetaDataBackendConfigTest.cpp
+++ b/src/volumedriver/test/MetaDataBackendConfigTest.cpp
@@ -47,6 +47,8 @@ protected:
 
         const std::string addr("127.0.0.1");
         const uint16_t port = 12345;
+        const uint32_t max_tlogs_behind = 123;
+        const unsigned mds_timeout_secs = 10;
 
         {
             OArchive oa(ss);
@@ -66,7 +68,9 @@ protected:
             oa << mdb;
 
             mdb.reset(new vd::MDSMetaDataBackendConfig(nodes,
-                                                       vd::ApplyRelocationsToSlaves::F));
+                                                       vd::ApplyRelocationsToSlaves::F,
+                                                       mds_timeout_secs,
+                                                       max_tlogs_behind));
             oa << mdb;
         }
 
@@ -106,6 +110,8 @@ protected:
                       mdscfg->node_configs()[0].port());
             ASSERT_EQ(vd::ApplyRelocationsToSlaves::T,
                       mdscfg->apply_relocations_to_slaves());
+            ASSERT_EQ(boost::none,
+                      mdscfg->max_tlogs_behind());
             mdb.reset();
         }
 
@@ -124,6 +130,13 @@ protected:
                       mdscfg->node_configs()[0].port());
             ASSERT_EQ(vd::ApplyRelocationsToSlaves::F,
                       mdscfg->apply_relocations_to_slaves());
+            ASSERT_EQ(std::chrono::seconds(mds_timeout_secs),
+                      mdscfg->timeout());
+            ASSERT_NE(boost::none,
+                      mdscfg->max_tlogs_behind());
+            ASSERT_EQ(max_tlogs_behind,
+                      *mdscfg->max_tlogs_behind());
+
             mdb.reset();
         }
     }

--- a/src/volumedriver/test/SimpleBackupRestoreTest.cpp
+++ b/src/volumedriver/test/SimpleBackupRestoreTest.cpp
@@ -313,8 +313,8 @@ TEST_P(SimpleBackupRestoreTest, rollback_to_previous_snap_if_snapshot_didnt_make
         SCOPED_DESTROY_WRITE_ONLY_VOLUME_UNBLOCK_BACKEND_FOR_BACKEND_RESTART(wov, 3);
         wov->createSnapshot(SnapshotName("snap2"));
 
-        const SnapshotPersistor& sp =
-            wov->getSnapshotManagement().getSnapshotPersistor();
+        const SnapshotPersistor sp =
+            wov->getSnapshotManagement().cloneSnapshotPersistor();
         SnapshotManagement::writeSnapshotPersistor(sp,
                                                    cm_->newBackendInterface(nspace));
     }
@@ -379,8 +379,8 @@ TEST_P(SimpleBackupRestoreTest,
         writeToVolume(*wov, Lba(0), size, pattern3);
         wov->scheduleBackendSync();
 
-        const SnapshotPersistor& sp =
-            wov->getSnapshotManagement().getSnapshotPersistor();
+        const SnapshotPersistor sp =
+            wov->getSnapshotManagement().cloneSnapshotPersistor();
         SnapshotManagement::writeSnapshotPersistor(sp,
                                                    cm_->newBackendInterface(nspace));
     }

--- a/src/volumedriver/test/SimpleVolumeTest.cpp
+++ b/src/volumedriver/test/SimpleVolumeTest.cpp
@@ -84,8 +84,8 @@ public:
             p(yt::FileUtils::create_temp_file_in_temp_dir("spanhosts.mlx"));
         ALWAYS_CLEANUP_FILE(p);
 
-        sm.getSnapshotPersistor().saveToFile(p,
-                                             SyncAndRename::T);
+        sm.cloneSnapshotPersistor().saveToFile(p,
+                                               SyncAndRename::T);
         v->getBackendInterface()->clone()->write(p,
                                                  snapshotFilename(),
                                                  OverwriteObject::T);

--- a/src/volumedriver/test/SnapshotManagementTest.cpp
+++ b/src/volumedriver/test/SnapshotManagementTest.cpp
@@ -131,7 +131,7 @@ TEST_P(SnapshotManagementTest, getTLogsBetweenSnapshots)
     vol_->deleteSnapshot(third);
 
     OrderedTLogIds out;
-    const SnapshotPersistor& pers = getSnapshotManagement(*vol_)->getSnapshotPersistor();
+    const SnapshotPersistor pers = getSnapshotManagement(*vol_)->cloneSnapshotPersistor();
     ASSERT_THROW(pers.getTLogsBetweenSnapshots(thirdn,
                                                fourthn,
                                                out,
@@ -263,18 +263,18 @@ TEST_P(SnapshotManagementTest, backendSizeBetweenSnapshots)
     }
 
     SnapshotManagement* c = getSnapshotManagement(*vol_);
-
+    const SnapshotPersistor sp(c->cloneSnapshotPersistor());
     ASSERT_EQ(10U *4096U,
-              c->getSnapshotPersistor().getBackendSize(SnapshotName("9"),
-                                                       boost::none));
+              sp.getBackendSize(SnapshotName("9"),
+                                boost::none));
 
     for(size_t j = 0; j < 9; j++)
     {
         for (size_t i = 0; i < j; ++i)
         {
             ASSERT_EQ((j-i) * 4096U,
-                      c->getSnapshotPersistor().getBackendSize(boost::lexical_cast<SnapshotName>(j),
-                                                               boost::lexical_cast<SnapshotName>(i)));
+                      sp.getBackendSize(boost::lexical_cast<SnapshotName>(j),
+                                        boost::lexical_cast<SnapshotName>(i)));
         }
     }
 }
@@ -355,9 +355,10 @@ TEST_P(SnapshotManagementTest, test2)
 
     ASSERT_TRUE(tlognames.size() > 0);
 
+    const SnapshotPersistor sp(c->cloneSnapshotPersistor());
     for (const std::string& tlogname : tlognames)
     {
-        EXPECT_TRUE(c->getSnapshotPersistor().isTLogWrittenToBackend(boost::lexical_cast<TLogId>(tlogname)));
+        EXPECT_TRUE(sp.isTLogWrittenToBackend(boost::lexical_cast<TLogId>(tlogname)));
     }
 
     OrderedTLogIds writtentobackend;


### PR DESCRIPTION
Addresses #339: it allows to configure a threshold on how far (in terms of the number of TLogs) an MDS slave table can be behind while still considering promoting it to the MASTER role.
For this a new `max_tlogs_behind` member (and ctor param, exposed in Python API) is added to the `MDSMetaDataBackendConfig` / the following new configurables are introduced:
* `volume_manager/metadata_mds_slave_max_tlogs_behind`: provides default for volumes whose `MDSMetaDataBackendConfig::max_tlogs_behind` is `boost::none`
* `filesystem/fs_metadata_backend_mds_slave_max_tlogs_behind`: provides default value for volumes created via the filesystem interface
.

If a threshold is configured (either for individual volumes or globally), the slave's uptodateness is checked before considering a promotion to the MASTER role.

CC @saelbrec , @kvanhijf : the default values provided by volumedriver maintain the current behaviour, i.e. no limit on (and hence no checking of) how far a slave is behind.