### PR TITLE
Python API: Python translation for NodeNotReachableException

### DIFF
--- a/src/filesystem-python-client/StorageRouterClient.cpp
+++ b/src/filesystem-python-client/StorageRouterClient.cpp
@@ -145,6 +145,7 @@ createExceptionClass(const char* name, PyObject* baseTypeObj = PyExc_Exception)
 }
 
 DEFINE_EXCEPTION_TRANSLATOR(MaxRedirectsExceededException);
+DEFINE_EXCEPTION_TRANSLATOR(NodeNotReachableException);
 DEFINE_EXCEPTION_TRANSLATOR(ClusterNotReachableException);
 DEFINE_EXCEPTION_TRANSLATOR(ObjectNotFoundException);
 DEFINE_EXCEPTION_TRANSLATOR(InvalidOperationException);
@@ -316,6 +317,7 @@ BOOST_PYTHON_MODULE(storagerouterclient)
 
     REGISTER_EXCEPTION_TRANSLATOR(MaxRedirectsExceededException);
     REGISTER_EXCEPTION_TRANSLATOR(ClusterNotReachableException);
+    REGISTER_EXCEPTION_TRANSLATOR(NodeNotReachableException);
     REGISTER_EXCEPTION_TRANSLATOR(ObjectNotFoundException);
     REGISTER_EXCEPTION_TRANSLATOR(InvalidOperationException);
     REGISTER_EXCEPTION_TRANSLATOR(SnapshotNotFoundException);


### PR DESCRIPTION
Addresses https://github.com/openvstorage/volumedriver/issues/349

Before:
```
In [9]: client.list_volumes("node_1")
Out[9]: []

In [10]: !fusermount -u /tmp/RemoteTest/remote/mnt

In [11]: client.list_volumes("node_1")
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-11-1396f3ceb850> in <module>()
----> 1 client.list_volumes("node_1")

RuntimeError: failed to send XMLRPC request volumesList
```

After:
```
In [4]: client.list_volumes("node_1")
Out[4]: []

In [5]: !fusermount -u /tmp/RemoteTest/remote/mnt

In [6]: client.list_volumes("node_1")
---------------------------------------------------------------------------
NodeNotReachableException                 Traceback (most recent call last)
<ipython-input-6-1396f3ceb850> in <module>()
----> 1 client.list_volumes("node_1")

NodeNotReachableException: failed to send XMLRPC request volumesList
```

CC @kvanhijf , @JeffreyDevloo : is that sufficient for the fwk's purposes (keeping in mind that `ClusterNotReachableException` could also be raised in other cases)?