### PR TITLE
Feature/fine grained scrub work

### DIFF
--- a/src/filesystem-python-client/LockedClient.cpp
+++ b/src/filesystem-python-client/LockedClient.cpp
@@ -47,18 +47,23 @@ LockedClient::registerize()
              &vfs::LockedPythonClient::exit)
         .def("get_scrubbing_workunits",
              &LockedPythonClient::get_scrubbing_work,
-             (bpy::args("req_timeout_secs") = PythonClient::MaybeSeconds()),
+             (bpy::args("start_snapshot_id") = boost::optional<std::string>(),
+              bpy::args("end_snapshot_id") = boost::optional<std::string>(),
+              bpy::args("req_timeout_secs") = PythonClient::MaybeSeconds()),
              "get a list of scrubbing work units -- opaque strings\n"
+             "@param start_snapshot_id: optional string, start snapshot (*exclusive* if specified: (start, end])\n"
+             "@param end_snapshot_id: optional string, end snapshot (*inclusive* if specified: (start, end])\n"
              "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: list of strings\n"
-             "@raises \n"
+             "@raises\n"
+             "      SnapshotNotFoundException (if an invalid start/end snapshot was specified)\n"
              "      ObjectNotFoundException\n"
              "      InvalidOperationException (on template)\n")
         .def("apply_scrubbing_result",
              &vfs::LockedPythonClient::apply_scrubbing_result,
              (bpy::args("scrubbing_work_result"),
               bpy::args("req_timeout_secs") = PythonClient::MaybeSeconds()),
-             "Apply a scrubbing result on the volume it's meant for\n"
+             "Apply a scrubbing result on the volume it's meant for.\n"
              "@param scrubbing work result an opaque tuple returned by the scrubber\n"
              "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"

--- a/src/filesystem-python-client/LockedClient.cpp
+++ b/src/filesystem-python-client/LockedClient.cpp
@@ -45,18 +45,22 @@ LockedClient::registerize()
              &vfs::LockedPythonClient::enter)
         .def("__exit__",
              &vfs::LockedPythonClient::exit)
-                .def("get_scrubbing_workunits",
+        .def("get_scrubbing_workunits",
              &LockedPythonClient::get_scrubbing_work,
+             (bpy::args("req_timeout_secs") = PythonClient::MaybeSeconds()),
              "get a list of scrubbing work units -- opaque strings\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@returns: list of strings\n"
              "@raises \n"
              "      ObjectNotFoundException\n"
              "      InvalidOperationException (on template)\n")
         .def("apply_scrubbing_result",
              &vfs::LockedPythonClient::apply_scrubbing_result,
-             (bpy::args("scrubbing_work_result")),
+             (bpy::args("scrubbing_work_result"),
+              bpy::args("req_timeout_secs") = PythonClient::MaybeSeconds()),
              "Apply a scrubbing result on the volume it's meant for\n"
              "@param scrubbing work result an opaque tuple returned by the scrubber\n"
+             "@param req_timeout_secs: optional timeout in seconds for this request\n"
              "@raises \n"
              "      ObjectNotFoundException\n"
              "      SnapshotNotFoundException\n"

--- a/src/filesystem/LockedPythonClient.cpp
+++ b/src/filesystem/LockedPythonClient.cpp
@@ -185,7 +185,9 @@ LockedPythonClient::info()
 }
 
 std::vector<std::string>
-LockedPythonClient::get_scrubbing_work(const PythonClient::MaybeSeconds& timeout)
+LockedPythonClient::get_scrubbing_work(const boost::optional<std::string>& start_snap,
+                                       const boost::optional<std::string>& end_snap,
+                                       const PythonClient::MaybeSeconds& timeout)
 {
     LOG_INFO(volume_id_ << ": getting scrub work");
 
@@ -193,6 +195,8 @@ LockedPythonClient::get_scrubbing_work(const PythonClient::MaybeSeconds& timeout
     THROW_UNLESS(locked_section_);
 
     return PythonClient::get_scrubbing_work(volume_id_,
+                                            start_snap,
+                                            end_snap,
                                             timeout);
 }
 

--- a/src/filesystem/LockedPythonClient.cpp
+++ b/src/filesystem/LockedPythonClient.cpp
@@ -185,18 +185,20 @@ LockedPythonClient::info()
 }
 
 std::vector<std::string>
-LockedPythonClient::get_scrubbing_work()
+LockedPythonClient::get_scrubbing_work(const PythonClient::MaybeSeconds& timeout)
 {
     LOG_INFO(volume_id_ << ": getting scrub work");
 
     THROW_UNLESS(promise_);
     THROW_UNLESS(locked_section_);
 
-    return PythonClient::get_scrubbing_work(volume_id_);
+    return PythonClient::get_scrubbing_work(volume_id_,
+                                            timeout);
 }
 
 void
-LockedPythonClient::apply_scrubbing_result(const std::string& scrub_res)
+LockedPythonClient::apply_scrubbing_result(const std::string& scrub_res,
+                                           const PythonClient::MaybeSeconds& timeout)
 {
     LOG_INFO(volume_id_ << ": applying scrub result");
 
@@ -204,7 +206,8 @@ LockedPythonClient::apply_scrubbing_result(const std::string& scrub_res)
     THROW_UNLESS(locked_section_);
 
     return PythonClient::apply_scrubbing_result(volume_id_,
-                                                scrub_res);
+                                                scrub_res,
+                                                timeout);
 }
 
 std::string

--- a/src/filesystem/LockedPythonClient.h
+++ b/src/filesystem/LockedPythonClient.h
@@ -48,7 +48,7 @@ public:
     create(const std::string& cluster_id,
            const std::vector<ClusterContact>&,
            const std::string& volume_id,
-           const boost::optional<boost::chrono::seconds>& = boost::none,
+           const PythonClient::MaybeSeconds& = boost::none,
            const unsigned update_interval_secs = 3,
            const unsigned grace_period_secs = 5);
 
@@ -68,10 +68,11 @@ public:
          boost::python::object& /* traceback */);
 
     std::vector<std::string>
-    get_scrubbing_work();
+    get_scrubbing_work(const PythonClient::MaybeSeconds& = boost::none);
 
     void
-    apply_scrubbing_result(const std::string& res);
+    apply_scrubbing_result(const std::string& res,
+                           const PythonClient::MaybeSeconds& = boost::none);
 
     std::string
     scrub(const std::string& scrub_work,

--- a/src/filesystem/LockedPythonClient.h
+++ b/src/filesystem/LockedPythonClient.h
@@ -68,7 +68,9 @@ public:
          boost::python::object& /* traceback */);
 
     std::vector<std::string>
-    get_scrubbing_work(const PythonClient::MaybeSeconds& = boost::none);
+    get_scrubbing_work(const boost::optional<std::string>& start_snap = boost::none,
+                       const boost::optional<std::string>& end_snap = boost::none,
+                       const PythonClient::MaybeSeconds& = boost::none);
 
     void
     apply_scrubbing_result(const std::string& res,

--- a/src/filesystem/PythonClient.cpp
+++ b/src/filesystem/PythonClient.cpp
@@ -498,10 +498,22 @@ PythonClient::list_volumes_by_path(const MaybeSeconds& timeout)
 
 std::vector<std::string>
 PythonClient::get_scrubbing_work(const std::string& volume_id,
+                                 const boost::optional<std::string>& start_snap,
+                                 const boost::optional<std::string>& end_snap,
                                  const MaybeSeconds& timeout)
 {
     XmlRpc::XmlRpcValue req;
     req[XMLRPCKeys::volume_id] = volume_id;
+
+    if (start_snap)
+    {
+        req[XMLRPCKeys::start_snapshot] = *start_snap;
+    }
+
+    if (end_snap)
+    {
+        req[XMLRPCKeys::end_snapshot] = *end_snap;
+    }
 
     return extract_vec(call(GetScrubbingWork::method_name(),
                             req,

--- a/src/filesystem/PythonClient.h
+++ b/src/filesystem/PythonClient.h
@@ -219,6 +219,8 @@ public:
 
     std::vector<std::string>
     get_scrubbing_work(const std::string& volume_id,
+                       const boost::optional<std::string>& start_snap = boost::none,
+                       const boost::optional<std::string>& end_snap = boost::none,
                        const MaybeSeconds& = boost::none);
 
     void

--- a/src/volumedriver/Snapshot.cpp
+++ b/src/volumedriver/Snapshot.cpp
@@ -400,7 +400,7 @@ Snapshots::getSnapshotsTill(SnapshotNum num,
         }
     }
     LOG_ERROR("Snapshot with id " << num << " does not exist");
-    throw fungi::IOException("Snapshot does not exist");
+    throw SnapshotNotFoundException("Snapshot does not exist");
 }
 
 void
@@ -421,7 +421,7 @@ Snapshots::getSnapshotsAfter(SnapshotNum num,
     }
 
     LOG_ERROR("Snapshot with id " << num << " does not exist");
-    throw fungi::IOException("Snapshot does not exist");
+    throw SnapshotNotFoundException("Snapshot does not exist");
 }
 
 void
@@ -483,7 +483,7 @@ Snapshots::getTLogsTillSnapshot(const SnapshotNum num,
         }
     }
     LOG_ERROR("Snapshot with id " << num << " does not exist");
-    throw fungi::IOException("Snapshot does not exist");
+    throw SnapshotNotFoundException("Snapshot does not exist");
 }
 
 void
@@ -503,7 +503,7 @@ Snapshots::getTLogsAfterSnapshot(const SnapshotNum num,
         }
     }
     LOG_ERROR("Snapshot with id " << num << " does not exist");
-    throw fungi::IOException("Snapshot does not exist");
+    throw SnapshotNotFoundException("Snapshot does not exist");
 }
 
 void
@@ -532,7 +532,7 @@ Snapshots::getTLogsBetweenSnapshots(const SnapshotNum start,
             if(not start_seen)
             {
                 LOG_ERROR("Snapshot with id " << start << " does not exist");
-                throw fungi::IOException("Snapshot does not exist");
+                throw SnapshotNotFoundException("Snapshot does not exist");
             }
 
             i->getOrderedTLogIds(out);
@@ -542,7 +542,7 @@ Snapshots::getTLogsBetweenSnapshots(const SnapshotNum start,
             if(not start_seen)
             {
                 LOG_ERROR("Snapshot with id " << start << " does not exist");
-                throw fungi::IOException("Snapshot does not exist");
+                throw SnapshotNotFoundException("Snapshot does not exist");
             }
 
             if(include_last == IncludingEndSnapshot::T)
@@ -558,7 +558,7 @@ Snapshots::getTLogsBetweenSnapshots(const SnapshotNum start,
     }
 
     LOG_ERROR("Snapshot with id " << end_snap << " does not exist");
-    throw fungi::IOException("Snapshot does not exist");
+    throw SnapshotNotFoundException("Snapshot does not exist");
 }
 
 bool
@@ -706,8 +706,8 @@ Snapshots::getSnapshotScrubbingWork(const boost::optional<SnapshotName>& start_s
         if (start_snap)
         {
             LOG_ERROR("Requested start snapshot " << *start_snap << " does not exist");
-            throw fungi::IOException("Requested start snapshot does not exist",
-                                     (*start_snap).c_str());
+            throw SnapshotNotFoundException("Requested start snapshot does not exist",
+                                            (*start_snap).c_str());
         }
     }
 
@@ -716,8 +716,8 @@ Snapshots::getSnapshotScrubbingWork(const boost::optional<SnapshotName>& start_s
         if (end_snap)
         {
             LOG_ERROR("Requested end snapshot " << *end_snap << " does not exist");
-            throw fungi::IOException("Requested end snapshot does not exist",
-                                     (*end_snap).c_str());
+            throw SnapshotNotFoundException("Requested end snapshot does not exist",
+                                            (*end_snap).c_str());
         }
     }
 


### PR DESCRIPTION
Addresses #143 and #389 while at it.

@JeffreyDevloo : the Python API looks like this (backward compatible due to the defaults) 
```
In [2]: src.LockedClient.get_scrubbing_workunits?
Docstring:
get_scrubbing_workunits( (LockedClient)arg1 [, (object)start_snapshot_id=None [, (object)end_snapshot_id=None [, (object)req_timeout_secs=None]]]) -> object :
    get a list of scrubbing work units -- opaque strings
    @param start_snapshot_id: optional string, start snapshot (*exclusive* if specified: (start, end])
    @param end_snapshot_id: optional string, end snapshot (*inclusive* if specified: (start, end])
    @param req_timeout_secs: optional timeout in seconds for this request
    @returns: list of strings
    @raises
          SnapshotNotFoundException (if an invalid start/end snapshot was specified)
          ObjectNotFoundException
          InvalidOperationException (on template)
   
```